### PR TITLE
fix: cross-platform glow pipeline + homepage overlay refresh [SPEC-002]

### DIFF
--- a/components/canvas/WorldCanvas.tsx
+++ b/components/canvas/WorldCanvas.tsx
@@ -4,7 +4,7 @@ import { useRef } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { sampleMerkaba } from '@/utils/merkaba';
-import { EffectComposer, Bloom } from '@react-three/postprocessing';
+import { EffectComposer, Bloom, Vignette } from '@react-three/postprocessing';
 import CameraRig from './CameraRig';
 import UFO from './objects/UFO';
 import Planet from './objects/Planet';
@@ -158,6 +158,7 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
     >
       <Canvas
         camera={{ position: [0, 0, 4], fov: 70 }}
+        dpr={[1, 1.5]}
         gl={{ antialias: false, alpha: true, toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1 }}
         style={{ background: 'transparent' }}
         frameloop="always"
@@ -196,13 +197,16 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
         <Galaxy scrollProgress={scrollProgress} />
         <Spaceship scrollProgress={scrollProgress} />
 
-        <EffectComposer>
+        <EffectComposer multisampling={0}>
           <Bloom
-            luminanceThreshold={1.0}
+            luminanceThreshold={0.9}
             luminanceSmoothing={0.3}
             intensity={1.5}
             mipmapBlur
+            radius={0.85}
+            levels={9}
           />
+          <Vignette eskil={false} offset={0.3} darkness={0.7} />
         </EffectComposer>
       </Canvas>
     </div>

--- a/components/canvas/WorldCanvas.tsx
+++ b/components/canvas/WorldCanvas.tsx
@@ -158,7 +158,7 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
     >
       <Canvas
         camera={{ position: [0, 0, 4], fov: 70 }}
-        gl={{ antialias: false, alpha: true }}
+        gl={{ antialias: false, alpha: true, toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1 }}
         style={{ background: 'transparent' }}
         frameloop="always"
       >
@@ -198,7 +198,7 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
 
         <EffectComposer>
           <Bloom
-            luminanceThreshold={0.8}
+            luminanceThreshold={1.0}
             luminanceSmoothing={0.3}
             intensity={1.5}
             mipmapBlur

--- a/components/canvas/WorldCanvas.tsx
+++ b/components/canvas/WorldCanvas.tsx
@@ -14,7 +14,7 @@ import Spaceship from './objects/Spaceship';
 
 // ── Constants ────────────────────────────────────────────────────────────────────────────
 const PARTICLE_COUNT = 2000;
-const MERKABA_RADIUS = 1.6;
+const MERKABA_RADIUS = 2;
 
 // Dispersal: how far each particle drifts outward before being fully faded.
 // Keep > a few units so the explosion clearly moves off-center, but small
@@ -54,7 +54,7 @@ for (let i = 0; i < PARTICLE_COUNT; i++) {
 }
 
 // ── Colors ───────────────────────────────────────────────────────────────────────────────
-const COLOR_GREEN = '#39FF49';
+const COLOR_GOLD = '#FFCC00';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 function smoothstep(t: number): number {
@@ -132,7 +132,7 @@ function ParticleSystem({ scrollProgress }: ParticleSystemProps) {
       </bufferGeometry>
       <pointsMaterial
         size={0.013}
-        color={COLOR_GREEN}
+        color={COLOR_GOLD}
         transparent
         opacity={0.75}
         sizeAttenuation
@@ -159,7 +159,12 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
       <Canvas
         camera={{ position: [0, 0, 4], fov: 70 }}
         dpr={[1, 1.5]}
-        gl={{ antialias: false, alpha: true, toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1 }}
+        gl={{
+          antialias: false,
+          alpha: true,
+          toneMapping: THREE.ACESFilmicToneMapping,
+          toneMappingExposure: 1,
+        }}
         style={{ background: 'transparent' }}
         frameloop="always"
       >
@@ -206,7 +211,7 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
             radius={0.85}
             levels={9}
           />
-          <Vignette eskil={false} offset={0.3} darkness={0.7} />
+          <Vignette eskil={false} offset={0.3} darkness={0.55} />
         </EffectComposer>
       </Canvas>
     </div>

--- a/components/canvas/objects/Galaxy.tsx
+++ b/components/canvas/objects/Galaxy.tsx
@@ -254,7 +254,7 @@ function OrbitingMoon({
  * Tuned for low density, a thin radial band, small particle size, and a
  * cool icy color so the ring reads distinctly from the warm galaxy stars.
  */
-const RING_COUNT = 200;
+const RING_COUNT = 250;
 const RING_INNER = 1.1;
 const RING_OUTER = 1.6;
 
@@ -461,8 +461,8 @@ export default function Galaxy({ scrollProgress }: GalaxyProps) {
         <meshStandardMaterial
           color="#fffde0"
           emissive="#ffe895"
-          emissiveIntensity={0.9}
-          toneMapped={false}
+          emissiveIntensity={1.1}
+          toneMapped={true}
         />
       </mesh>
 

--- a/components/canvas/objects/Galaxy.tsx
+++ b/components/canvas/objects/Galaxy.tsx
@@ -306,10 +306,10 @@ function RingParticles() {
         <bufferAttribute attach="attributes-position" args={[positions, 3]} />
       </bufferGeometry>
       <pointsMaterial
-        size={0.01}
+        size={0.1}
         color="#4F6178"
         transparent
-        opacity={0.33}
+        opacity={0.1}
         sizeAttenuation
         depthWrite={false}
       />
@@ -457,11 +457,11 @@ export default function Galaxy({ scrollProgress }: GalaxyProps) {
 
       {/* Galactic core — glowing sun (lighter tint) */}
       <mesh>
-        <sphereGeometry args={[0.8, 16, 16]} />
+        <sphereGeometry args={[2, 16, 16]} />
         <meshStandardMaterial
           color="#fffde0"
           emissive="#ffe895"
-          emissiveIntensity={1.5}
+          emissiveIntensity={0.9}
           toneMapped={false}
         />
       </mesh>

--- a/components/canvas/objects/Galaxy.tsx
+++ b/components/canvas/objects/Galaxy.tsx
@@ -461,7 +461,8 @@ export default function Galaxy({ scrollProgress }: GalaxyProps) {
         <meshStandardMaterial
           color="#fffde0"
           emissive="#ffe895"
-          emissiveIntensity={6}
+          emissiveIntensity={1.5}
+          toneMapped={false}
         />
       </mesh>
 
@@ -547,8 +548,10 @@ export default function Galaxy({ scrollProgress }: GalaxyProps) {
         />
       </group>
 
-      {/* Center light — illuminates planets */}
-      <pointLight color="#ffeeaa" intensity={20} distance={30} />
+      {/* Center light — illuminates planets
+        TODO: doesnt appear to be working, no surface to catch light
+        */}
+      <pointLight color="#ffeeaa" intensity={30} distance={100} />
     </group>
   );
 }

--- a/components/canvas/objects/Satellite.tsx
+++ b/components/canvas/objects/Satellite.tsx
@@ -47,8 +47,8 @@ const INITIAL_SAT_ANGLE = Math.PI / 4; // 1-2 o'clock, climbing toward 12
 // Satellite attitude wobble: slow Y-axis spin plus X/Z sinusoidal tilts.
 // Gives the satellite a "drifting attitude" feel without full tumbling
 // (silhouette stays roughly legible on most frames).
-const SAT_SPIN_Y = 0.1; // yaw spin rad/s (1 rev / ~63 s)
-const SAT_WOBBLE_X_AMP = 0.14; // pitch wobble amplitude (rad, ~8°)
+const SAT_SPIN_Y = 0.3; // yaw spin rad/s (1 rev / ~63 s)
+const SAT_WOBBLE_X_AMP = 0.4; // pitch wobble amplitude (rad, ~8°)
 const SAT_WOBBLE_Z_AMP = 0.09; // roll wobble amplitude (rad, ~5°)
 const SAT_WOBBLE_X_RATE = 0.4; // pitch wobble oscillation rate
 const SAT_WOBBLE_Z_RATE = 0.3; // roll wobble oscillation rate (slightly
@@ -59,13 +59,15 @@ const SAT_WOBBLE_Z_RATE = 0.3; // roll wobble oscillation rate (slightly
 // (nearly opposite the thing they're both orbiting). Rock speed is
 // independent (faster + reverse direction) so the two bodies drift and pass
 // each other over time, adding motion without locking in rigid symmetry.
-const ROCK_ANGLE_SPEED = -0.5; // rad/s, negative = reverse direction, faster
+const ROCK_ANGLE_SPEED = -0.7; // rad/s, negative = reverse direction, faster
 const ROCK_INITIAL_ANGLE = INITIAL_SAT_ANGLE + Math.PI; // opposite of sat's starting angle
-const ROCK_TUMBLE_X = 0.7; // rad/s
-const ROCK_TUMBLE_Y = 1.3;
+const ROCK_TUMBLE_X = 0.9; // rad/s
+const ROCK_TUMBLE_Y = 1.7;
 const ROCK_TUMBLE_Z = 0.5;
 
-export default function Satellite({ scrollProgress: _scrollProgress }: SatelliteProps) {
+export default function Satellite({
+  scrollProgress: _scrollProgress,
+}: SatelliteProps) {
   const groupRef = useRef<THREE.Group>(null);
   const rockRef = useRef<THREE.Mesh>(null);
 
@@ -91,8 +93,8 @@ export default function Satellite({ scrollProgress: _scrollProgress }: Satellite
     if (rockRef.current) {
       const rockAngle = ROCK_INITIAL_ANGLE + t * ROCK_ANGLE_SPEED;
       rockRef.current.position.set(
-        ORBIT_CENTER.x + ORBIT_RADIUS * Math.cos(rockAngle),
-        ORBIT_CENTER.y + ORBIT_RADIUS * Math.sin(rockAngle),
+        ORBIT_CENTER.x + (ORBIT_RADIUS / 1.5) * Math.cos(rockAngle / 2),
+        ORBIT_CENTER.y + (ORBIT_RADIUS / 1.5) * Math.sin(rockAngle / 2),
         ORBIT_CENTER.z,
       );
       // Multi-axis tumble at independent rates for a chaotic rock feel.
@@ -106,85 +108,89 @@ export default function Satellite({ scrollProgress: _scrollProgress }: Satellite
 
   return (
     <>
-    <group ref={groupRef} scale={4}>
-      {/* Satellite body */}
-      <mesh>
-        <boxGeometry args={[1, 0.5, 0.5]} />
-        <meshStandardMaterial color="#3a3a5a" metalness={0.8} roughness={0.2} />
-      </mesh>
+      <group ref={groupRef} scale={4}>
+        {/* Satellite body */}
+        <mesh>
+          <boxGeometry args={[1, 0.5, 0.5]} />
+          <meshStandardMaterial
+            color="#3a3a5a"
+            metalness={0.8}
+            roughness={0.2}
+          />
+        </mesh>
 
-      {/* Solar panel — left */}
-      <mesh position={[-1.5, 0, 0]}>
-        <planeGeometry args={[2, 0.8]} />
-        <meshStandardMaterial
-          color="#1a1a44"
-          metalness={0.6}
-          roughness={0.3}
-          emissive="#111133"
-          emissiveIntensity={0.3}
-          side={THREE.DoubleSide}
-        />
-      </mesh>
+        {/* Solar panel — left */}
+        <mesh position={[-1.5, 0, 0]}>
+          <planeGeometry args={[2, 0.8]} />
+          <meshStandardMaterial
+            color="#1a1a44"
+            metalness={0.6}
+            roughness={0.3}
+            emissive="#111133"
+            emissiveIntensity={0.3}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
 
-      {/* Solar panel — right */}
-      <mesh position={[1.5, 0, 0]}>
-        <planeGeometry args={[2, 0.8]} />
-        <meshStandardMaterial
-          color="#1a1a44"
-          metalness={0.6}
-          roughness={0.3}
-          emissive="#111133"
-          emissiveIntensity={0.3}
-          side={THREE.DoubleSide}
-        />
-      </mesh>
+        {/* Solar panel — right */}
+        <mesh position={[1.5, 0, 0]}>
+          <planeGeometry args={[2, 0.8]} />
+          <meshStandardMaterial
+            color="#1a1a44"
+            metalness={0.6}
+            roughness={0.3}
+            emissive="#111133"
+            emissiveIntensity={0.3}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
 
-      {/* Antenna */}
-      <mesh position={[0, 0.5, 0]}>
-        <cylinderGeometry args={[0.02, 0.02, 0.8, 6]} />
-        <meshStandardMaterial color="#888" metalness={0.9} roughness={0.1} />
-      </mesh>
-      <mesh position={[0, 0.95, 0]}>
-        <sphereGeometry args={[0.05, 6, 6]} />
-        <meshStandardMaterial
+        {/* Antenna */}
+        <mesh position={[0, 0.5, 0]}>
+          <cylinderGeometry args={[0.02, 0.02, 0.8, 6]} />
+          <meshStandardMaterial color="#888" metalness={0.9} roughness={0.1} />
+        </mesh>
+        <mesh position={[0, 0.95, 0]}>
+          <sphereGeometry args={[0.05, 6, 6]} />
+          <meshStandardMaterial
+            color="#00e5ff"
+            emissive="#00e5ff"
+            emissiveIntensity={1}
+          />
+        </mesh>
+
+        {/* Screen on hull face */}
+        <mesh position={[0, 0, 0.26]}>
+          <planeGeometry args={[0.8, 0.4]} />
+          <meshStandardMaterial
+            color="#00e5ff"
+            emissive="#00e5ff"
+            emissiveIntensity={0.8}
+            transparent
+            opacity={0.7}
+          />
+        </mesh>
+
+        {/* Satellite light */}
+        <pointLight
+          position={[0, 0, 1]}
           color="#00e5ff"
-          emissive="#00e5ff"
-          emissiveIntensity={1}
+          intensity={3}
+          distance={10}
         />
-      </mesh>
+      </group>
 
-      {/* Screen on hull face */}
-      <mesh position={[0, 0, 0.26]}>
-        <planeGeometry args={[0.8, 0.4]} />
-        <meshStandardMaterial
-          color="#00e5ff"
-          emissive="#00e5ff"
-          emissiveIntensity={0.8}
-          transparent
-          opacity={0.7}
-        />
-      </mesh>
-
-      {/* Satellite light */}
-      <pointLight
-        position={[0, 0, 1]}
-        color="#00e5ff"
-        intensity={3}
-        distance={10}
-      />
-    </group>
-
-    {/* Tumbling rock on perpendicular orbit — roughly opposite the
+      {/* Tumbling rock on perpendicular orbit — roughly opposite the
         satellite at all times. Position and rotation driven from the same
         useFrame loop as the satellite above. */}
-    <mesh ref={rockRef}>
-      <icosahedronGeometry args={[1.5, 0]} />
-      <meshStandardMaterial
-        color="#9C9C9C"
-        roughness={0.95}
-        metalness={0.05}
-      />
-    </mesh>
+      <mesh ref={rockRef}>
+        <icosahedronGeometry args={[2, 0]} />
+        <meshStandardMaterial
+          color="#b3dafd"
+          roughness={0.82}
+          metalness={0.01}
+        />
+      </mesh>
     </>
   );
 }

--- a/components/canvas/objects/Satellite.tsx
+++ b/components/canvas/objects/Satellite.tsx
@@ -8,189 +8,154 @@ interface SatelliteProps {
   scrollProgress: React.RefObject<number>;
 }
 
-/**
- * Satellite — always-visible continuous orbit around the central planet,
- * accompanied by a tumbling rock on a separate orbit higher above the planet.
- *
- * Design notes:
- *   - Both bodies are rendered at ALL scroll positions (including 0.00).
- *     There is no activation gate or hide state; the only input to position
- *     is `clock.getElapsedTime()`, so the scene feels alive from the moment
- *     the canvas mounts.
- *   - Satellite orbit center is pushed to z = -75 so every angle on the
- *     orbit falls within the camera's FOV at both the about-pan camera and
- *     the craft-window camera. No invisible arc.
- *   - Satellite starts at INITIAL_SAT_ANGLE = π/4 (upper-right). With
- *     ORBIT_SPEED = 0.3 rad/s the satellite reaches 12 o'clock ≈ 2.6 s after
- *     page load, aligning the first fly-by with typical time-to-craft scroll.
- *     Subsequent fly-bys repeat every ~21 s.
- *   - Satellite also wobbles on a drifting axis: a gentle Y-axis spin plus
- *     small X and Z sinusoidal tilts make the main rotation axis feel
- *     slightly precessing (like a real de-stabilized satellite).
- *   - The rock orbits the SAME center, plane, and radius as the satellite,
- *     starting π offset so it sits on the opposite side of the orbit. Rock
- *     speed is independent of the satellite (|0.5| rad/s, reverse direction)
- *     so the two bodies drift and occasionally pass each other as they
- *     revolve around their shared orbit.
- *
- * Orbit geometry:
- *   Shared orbit center: (0, -22, -75) — XY plane, radius 26
- *   Satellite: starts at π/4, advances at +0.30 rad/s
- *   Rock:      starts at π/4 + π,   advances at -0.50 rad/s (reverse, faster)
- */
-
-const ORBIT_CENTER = new THREE.Vector3(0, -22, -75);
-const ORBIT_RADIUS = 26;
-const ORBIT_SPEED = 0.3; // rad/s → full orbit ≈ 21 s
-const INITIAL_SAT_ANGLE = Math.PI / 4; // 1-2 o'clock, climbing toward 12
-
-// Satellite attitude wobble: slow Y-axis spin plus X/Z sinusoidal tilts.
-// Gives the satellite a "drifting attitude" feel without full tumbling
-// (silhouette stays roughly legible on most frames).
-const SAT_SPIN_Y = 0.3; // yaw spin rad/s (1 rev / ~63 s)
-const SAT_WOBBLE_X_AMP = 0.4; // pitch wobble amplitude (rad, ~8°)
-const SAT_WOBBLE_Z_AMP = 0.09; // roll wobble amplitude (rad, ~5°)
-const SAT_WOBBLE_X_RATE = 0.4; // pitch wobble oscillation rate
-const SAT_WOBBLE_Z_RATE = 0.3; // roll wobble oscillation rate (slightly
-// different from pitch so the two combine into a non-repeating wobble)
-
-// Rock orbit: shares the SAME center, plane (XY), and radius as the
-// satellite. Starts π offset so it sits on the opposite side of the orbit
-// (nearly opposite the thing they're both orbiting). Rock speed is
-// independent (faster + reverse direction) so the two bodies drift and pass
-// each other over time, adding motion without locking in rigid symmetry.
-const ROCK_ANGLE_SPEED = -0.7; // rad/s, negative = reverse direction, faster
-const ROCK_INITIAL_ANGLE = INITIAL_SAT_ANGLE + Math.PI; // opposite of sat's starting angle
-const ROCK_TUMBLE_X = 0.9; // rad/s
-const ROCK_TUMBLE_Y = 1.7;
-const ROCK_TUMBLE_Z = 0.5;
+const ORBIT_CENTER = new THREE.Vector3(0, -30, -50);
+const ORBIT_RADIUS = 32;
+const ORBIT_SPEED = 0.1;
+const INITIAL_SAT_ANGLE = Math.PI / 2;
 
 export default function Satellite({
   scrollProgress: _scrollProgress,
 }: SatelliteProps) {
   const groupRef = useRef<THREE.Group>(null);
-  const rockRef = useRef<THREE.Mesh>(null);
 
   useFrame(({ clock }) => {
     if (!groupRef.current) return;
-    const t = clock.getElapsedTime();
 
-    // ── Satellite: XY-plane orbit ───────────────────────────────
+    const t = clock.getElapsedTime();
     const satAngle = INITIAL_SAT_ANGLE + t * ORBIT_SPEED;
+
+    // 1. Position the satellite in the orbit path
     groupRef.current.position.set(
       ORBIT_CENTER.x + ORBIT_RADIUS * Math.cos(satAngle),
       ORBIT_CENTER.y + ORBIT_RADIUS * Math.sin(satAngle),
       ORBIT_CENTER.z,
     );
-    // Wobbling-axis attitude: slow Y spin + small sinusoidal pitch/roll.
-    groupRef.current.rotation.set(
-      Math.sin(t * SAT_WOBBLE_X_RATE) * SAT_WOBBLE_X_AMP,
-      t * SAT_SPIN_Y,
-      Math.cos(t * SAT_WOBBLE_Z_RATE) * SAT_WOBBLE_Z_AMP,
-    );
 
-    // ── Rock: same orbit as sat, opposite side, independent speed & direction ─
-    if (rockRef.current) {
-      const rockAngle = ROCK_INITIAL_ANGLE + t * ROCK_ANGLE_SPEED;
-      rockRef.current.position.set(
-        ORBIT_CENTER.x + (ORBIT_RADIUS / 1.5) * Math.cos(rockAngle / 2),
-        ORBIT_CENTER.y + (ORBIT_RADIUS / 1.5) * Math.sin(rockAngle / 2),
-        ORBIT_CENTER.z,
-      );
-      // Multi-axis tumble at independent rates for a chaotic rock feel.
-      rockRef.current.rotation.set(
-        t * ROCK_TUMBLE_X,
-        t * ROCK_TUMBLE_Y,
-        t * ROCK_TUMBLE_Z,
-      );
-    }
+    // 2. Point the +Z axis (the "front") at the orbit center
+    groupRef.current.lookAt(ORBIT_CENTER);
   });
 
   return (
-    <>
-      <group ref={groupRef} scale={4}>
+    <group ref={groupRef} scale={4}>
+      {/* CORRECTION GROUP:
+          Since lookAt points the +Z axis at the target, and your
+          dish was on the -Z side, we rotate this inner group 180° (Math.PI)
+          on the Y axis to "inverse" which side faces forward.
+      */}
+      <group rotation={[0, Math.PI, 0]}>
         {/* Satellite body */}
         <mesh>
           <boxGeometry args={[1, 0.5, 0.5]} />
           <meshStandardMaterial
-            color="#3a3a5a"
-            metalness={0.8}
-            roughness={0.2}
+            color="#c8d0d8"
+            metalness={0.4}
+            roughness={0.5}
           />
         </mesh>
 
-        {/* Solar panel — left */}
-        <mesh position={[-1.5, 0, 0]}>
-          <planeGeometry args={[2, 0.8]} />
+        {/* Solar panels */}
+        {[-1.5, 1.5].map((xPos, i) => (
+          <group key={`panel-group-${i}`} position={[xPos, 0, 0]}>
+            <mesh>
+              <planeGeometry args={[2, 0.8]} />
+              <meshStandardMaterial
+                color="#c8d0d8"
+                metalness={0.3}
+                roughness={0.6}
+                side={THREE.DoubleSide}
+              />
+            </mesh>
+            {/* Panel LEDs */}
+            {[
+              [-0.9, 0.3],
+              [0.9, 0.3],
+              [-0.9, -0.3],
+              [0.9, -0.3],
+            ].map(([lx, ly], j) => (
+              <mesh key={`led-${j}`} position={[lx, ly, 0.01]}>
+                <sphereGeometry args={[0.025, 4, 4]} />
+                <meshStandardMaterial
+                  color="#ff2222"
+                  emissive="#ff2222"
+                  emissiveIntensity={3}
+                  toneMapped={false}
+                />
+              </mesh>
+            ))}
+          </group>
+        ))}
+
+        {/* Dish support & Satellite dish */}
+        <mesh position={[0, 0, -0.4]} rotation={[Math.PI / 2, 0, 0]}>
+          <cylinderGeometry args={[0.02, 0.02, 0.4, 12]} />
           <meshStandardMaterial
-            color="#1a1a44"
-            metalness={0.6}
-            roughness={0.3}
-            emissive="#111133"
-            emissiveIntensity={0.3}
-            side={THREE.DoubleSide}
+            color="#aaaacc"
+            metalness={0.9}
+            roughness={0.1}
           />
         </mesh>
 
-        {/* Solar panel — right */}
-        <mesh position={[1.5, 0, 0]}>
-          <planeGeometry args={[2, 0.8]} />
-          <meshStandardMaterial
-            color="#1a1a44"
-            metalness={0.6}
-            roughness={0.3}
-            emissive="#111133"
-            emissiveIntensity={0.3}
-            side={THREE.DoubleSide}
-          />
-        </mesh>
+        <group position={[0, 0, -0.99]} rotation={[Math.PI / 2, 0, 0]}>
+          <mesh>
+            <sphereGeometry
+              args={[0.7, 24, 12, 0, Math.PI * 2, 0, Math.PI * 0.3]}
+            />
+            <meshStandardMaterial
+              color="#c8d0d8"
+              metalness={0.5}
+              roughness={0.35}
+              side={THREE.DoubleSide}
+            />
+          </mesh>
+        </group>
 
         {/* Antenna */}
         <mesh position={[0, 0.5, 0]}>
           <cylinderGeometry args={[0.02, 0.02, 0.8, 6]} />
-          <meshStandardMaterial color="#888" metalness={0.9} roughness={0.1} />
+          <meshStandardMaterial
+            color="#aaaacc"
+            metalness={0.9}
+            roughness={0.1}
+          />
         </mesh>
+
         <mesh position={[0, 0.95, 0]}>
           <sphereGeometry args={[0.05, 6, 6]} />
           <meshStandardMaterial
             color="#00e5ff"
             emissive="#00e5ff"
             emissiveIntensity={1}
+            toneMapped={false}
           />
         </mesh>
 
-        {/* Screen on hull face */}
+        {/* Screen (Now points at center thanks to the rotation PI) */}
         <mesh position={[0, 0, 0.26]}>
           <planeGeometry args={[0.8, 0.4]} />
           <meshStandardMaterial
             color="#00e5ff"
             emissive="#00e5ff"
-            emissiveIntensity={0.8}
+            emissiveIntensity={1.2}
+            toneMapped={false}
             transparent
-            opacity={0.7}
+            opacity={0.9}
           />
         </mesh>
 
-        {/* Satellite light */}
+        {/* Essential Lights */}
         <pointLight
-          position={[0, 0, 1]}
+          position={[0, 0, 0.8]}
           color="#00e5ff"
-          intensity={3}
+          intensity={8}
+          distance={12}
+        />
+        <pointLight
+          position={[0, 1.2, 0]}
+          color="#aaddff"
+          intensity={5}
           distance={10}
         />
       </group>
-
-      {/* Tumbling rock on perpendicular orbit — roughly opposite the
-        satellite at all times. Position and rotation driven from the same
-        useFrame loop as the satellite above. */}
-      <mesh ref={rockRef}>
-        <icosahedronGeometry args={[2, 0]} />
-        <meshStandardMaterial
-          color="#b3dafd"
-          roughness={0.82}
-          metalness={0.01}
-        />
-      </mesh>
-    </>
+    </group>
   );
 }

--- a/components/canvas/objects/TumblingRock.tsx
+++ b/components/canvas/objects/TumblingRock.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+const ORBIT_CENTER = new THREE.Vector3(0, -22, -75);
+const ORBIT_RADIUS = 25;
+const INITIAL_SAT_ANGLE = Math.PI / 4;
+
+const ROCK_ANGLE_SPEED = -0.7;
+const ROCK_INITIAL_ANGLE = INITIAL_SAT_ANGLE + Math.PI;
+const ROCK_TUMBLE_X = 0.9;
+const ROCK_TUMBLE_Y = 1.7;
+const ROCK_TUMBLE_Z = 0.5;
+
+export default function TumblingRock() {
+  const rockRef = useRef<THREE.Mesh>(null);
+
+  useFrame(({ clock }) => {
+    if (!rockRef.current) return;
+    const t = clock.getElapsedTime();
+
+    const rockAngle = ROCK_INITIAL_ANGLE + t * ROCK_ANGLE_SPEED;
+    rockRef.current.position.set(
+      ORBIT_CENTER.x + (ORBIT_RADIUS / 1.5) * Math.cos(rockAngle / 2),
+      ORBIT_CENTER.y + (ORBIT_RADIUS / 1.5) * Math.sin(rockAngle / 2),
+      ORBIT_CENTER.z,
+    );
+
+    rockRef.current.rotation.set(
+      t * ROCK_TUMBLE_X,
+      t * ROCK_TUMBLE_Y,
+      t * ROCK_TUMBLE_Z,
+    );
+  });
+
+  return (
+    <mesh ref={rockRef}>
+      <icosahedronGeometry args={[2, 0]} />
+      <meshStandardMaterial color="#b3dafd" roughness={0.82} metalness={0.01} />
+    </mesh>
+  );
+}

--- a/components/overlay/AboutOverlay.tsx
+++ b/components/overlay/AboutOverlay.tsx
@@ -9,7 +9,11 @@ interface AboutOverlayProps {
 export default function AboutOverlay({ visible }: AboutOverlayProps) {
   return (
     <div className={`${styles.hudPanel} ${visible ? styles.visible : ''}`}>
-      <p className={styles.leadLine}>Musician. Engineer. Artist. Maker.</p>
+      <p className={styles.leadLine}>
+        Musician.
+        <br /> Engineer.
+        <br /> Artist. Maker.
+      </p>
       <p className={styles.bodyLine}>
         Creativity is at the core of everything I do.
       </p>

--- a/components/overlay/CraftOverlay.tsx
+++ b/components/overlay/CraftOverlay.tsx
@@ -11,8 +11,7 @@ export default function CraftOverlay({ visible }: CraftOverlayProps) {
     <div className={`${styles.hudPanel} ${visible ? styles.visible : ''}`}>
       <p className={styles.leadLine}>I solve problems for people.</p>
       <p className={styles.bodyLine}>
-        The tools and trends change, but what I do remains the same.
-        <br /> How can I help?
+        The tools and trends may change, but my work is the same.
       </p>
     </div>
   );

--- a/components/overlay/IntroOverlay.tsx
+++ b/components/overlay/IntroOverlay.tsx
@@ -1,16 +1,64 @@
-'use client'
+'use client';
 
-import styles from './Overlay.module.sass'
+import styles from './Overlay.module.sass';
+import { LinkIcon } from '@heroicons/react/24/outline';
 
 interface IntroOverlayProps {
-  visible: boolean
+  visible: boolean;
 }
 
 export default function IntroOverlay({ visible }: IntroOverlayProps) {
   return (
     <div className={`${styles.introPanel} ${visible ? styles.visible : ''}`}>
-      <p className={styles.headline}>Anthony Coffey</p>
-      <p className={styles.byline}>Austin, Texas</p>
+      <p className={styles.headline}>Who Am I?</p>
+      <p className={styles.byline}>Anthony Coffey - Austin, Texas</p>
+
+      <div className={styles.socialLinks}>
+        {/* GitHub */}
+        <a
+          href="https://github.com/anthonycoffey"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.iconLink}
+          aria-label="GitHub"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className={styles.heroSize}
+          >
+            <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+          </svg>
+        </a>
+
+        {/* LinkedIn */}
+        <a
+          href="https://linkedin.com/in/coffeyanthony"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.iconLink}
+          aria-label="LinkedIn"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className={styles.heroSize}
+          >
+            <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" />
+          </svg>
+        </a>
+
+        {/* Linktree */}
+        <a
+          href="https://linktr.ee/coffeycodes"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.iconLink}
+          aria-label="Linktree Hub"
+        >
+          <LinkIcon className={styles.heroSize} />
+        </a>
+      </div>
     </div>
-  )
+  );
 }

--- a/components/overlay/IntroOverlay.tsx
+++ b/components/overlay/IntroOverlay.tsx
@@ -10,7 +10,11 @@ interface IntroOverlayProps {
 export default function IntroOverlay({ visible }: IntroOverlayProps) {
   return (
     <div className={`${styles.introPanel} ${visible ? styles.visible : ''}`}>
-      <p className={styles.headline}>Who Am I?</p>
+      <p className={styles.headline}>
+        👨‍🚀
+        <br />
+        Who Am I?
+      </p>
       <p className={styles.byline}>Anthony Coffey - Austin, Texas</p>
 
       <div className={styles.socialLinks}>

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -46,33 +46,34 @@
 // ── Typography ────────────────────────────────────────────────────────────
 .headline
   font-family: var(--font-outfit), sans-serif
-  font-size: clamp(2.2rem, 5vw, 4.5rem)
+  font-size: clamp(3.5rem, 5vw, 4rem)
   font-weight: 700
-  line-height: 1.1
+  line-height: 1.15
   color: #f0f0ff
   margin: 0
-  letter-spacing: -0.02em
-
-.byline
-  font-family: var(--font-geist-mono), monospace
-  font-size: 0.75rem
-  letter-spacing: 0.18em
-  text-transform: uppercase
-  color: rgba(255, 204, 0, 1)
-  margin: 0
-
+  text-shadow: #000000 0px 0 10px;
+  
 .leadLine
   font-family: var(--font-outfit), sans-serif
-  font-size: clamp(1.6rem, 3.5vw, 3rem)
+  font-size: clamp(3.5rem, 5vw, 4rem)
   font-weight: 700
   line-height: 1.15
   color: #f0f0ff
   margin: 0
   letter-spacing: -0.02em
+  // text-shadow: #000000 50px 0 50px;
+
+.byline
+  font-family: var(--font-geist-mono), monospace
+  font-size: 1rem
+  letter-spacing: -0.02em
+  text-transform: uppercase
+  color: rgba(255, 204, 0, 1)
+  margin: 0
 
 .bodyLine
   font-family: var(--font-outfit), sans-serif
-  font-size: clamp(1rem, 2vw, 1.2rem)
+  font-size: clamp(1.5rem, 2vw, 1.5rem)
   font-weight: 400
   line-height: 1.7
   color: rgba(255, 204, 0, 1)

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -58,7 +58,7 @@
   font-size: 0.75rem
   letter-spacing: 0.18em
   text-transform: uppercase
-  color: rgba(240, 240, 255, 0.35)
+  color: rgba(255, 204, 0, 1)
   margin: 0
 
 .leadLine
@@ -75,7 +75,7 @@
   font-size: clamp(1rem, 2vw, 1.2rem)
   font-weight: 400
   line-height: 1.7
-  color: rgba(240, 240, 255, 0.5)
+  color: rgba(255, 204, 0, 1)
   margin: 0
 
 .eyebrow

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -85,3 +85,27 @@
   text-transform: uppercase
   color: rgba(240, 240, 255, 0.3)
   margin: 0
+
+
+// ── Social Icons ──────────────────────────────────────────────────────────
+.socialLinks
+  display: flex
+  gap: 1rem
+  pointer-events: auto // CRITICAL: re-enables interaction inside the overlay
+
+.iconLink
+  color: rgba(240, 240, 255, 0.35)
+  transition: all 0.3s ease
+  display: flex
+  align-items: center
+  justify-content: center
+
+  &:hover
+    color: #f0f0ff
+    transform: translateY(-2px)
+    filter: drop-shadow(0 0 8px rgba(240, 240, 255, 0.2))
+
+.heroSize
+  width: 1.5rem
+  height: 1.5rem
+  stroke-width: 1.5 // Adjusts the Heroicon stroke weight

--- a/components/overlay/ShineOverlay.tsx
+++ b/components/overlay/ShineOverlay.tsx
@@ -9,9 +9,9 @@ interface ShineOverlayProps {
 export default function ShineOverlay({ visible }: ShineOverlayProps) {
   return (
     <div className={`${styles.introPanel} ${visible ? styles.visible : ''}`}>
-      <p className={styles.headline}>Have a question?</p>
+      <p className={styles.headline}>Want to know more?</p>
       <p className={styles.bodyLine}>
-        <a href="/contact">&rarr;&nbsp;&nbsp;reach out</a>
+        <a href="/contact">&rarr;&nbsp;&nbsp;contact me</a>
       </p>
     </div>
   );

--- a/docs/specs/active/SPEC-002-homepage-scene-cross-platform-glow.md
+++ b/docs/specs/active/SPEC-002-homepage-scene-cross-platform-glow.md
@@ -1,0 +1,151 @@
+---
+id: SPEC-002
+title: "Homepage Scene Cross-Platform Glow Fix"
+status: draft
+created: 2026-04-18
+author: Anthony Coffey
+reviewers: []
+affected_repos: []
+---
+
+## Reviewer Notes
+
+<!-- Leave empty until code review. When requesting changes, reviewer adds feedback here: -->
+
+---
+
+# Feature: Homepage Scene Cross-Platform Glow Fix
+
+## Problem
+
+The galaxy core in the homepage Three.js scene renders as a flat, opaque yellow sphere on macOS/Chrome
+(Metal renderer) but glows warmly on Windows/Chrome (DirectX). The root cause is a missing explicit tone
+mapping on the `Canvas`, which defaults to Three.js's linear tone mapping. Linear tone mapping clamps
+over-bright emissive values (>1.0) to a flat, saturated color on macOS Metal instead of gracefully
+rolling them off into a warm glow. Compounding this, the galaxy core mesh has `emissiveIntensity={6}`
+without `toneMapped={false}`, so its HDR value is clamped before reaching the existing Bloom
+post-processor. The Bloom `luminanceThreshold` of `0.8` is also mismatched for an ACESFilmic pipeline.
+
+## Requirements
+
+### Must have
+
+1. WHEN the scene renders on any platform, the galaxy core SHALL appear as a warm glowing star with
+   soft bloom halo, not a flat yellow sphere.
+2. WHEN the Canvas initializes, it SHALL use `ACESFilmicToneMapping` to ensure consistent over-bright
+   highlight handling across Metal (macOS) and DirectX (Windows).
+3. WHEN the galaxy core material renders, it SHALL use `toneMapped={false}` so its HDR emissive value
+   bypasses the tone mapper and feeds directly into the Bloom post-processor (consistent with
+   how Spaceship bright emissives are implemented).
+4. WHEN the Bloom effect evaluates luminance, it SHALL only bloom true HDR values (>1.0 linear),
+   with threshold set to `1.0`.
+
+### Nice to have
+
+- Verify no visual regression on UFO cyan glow, Satellite antenna, Spaceship thrusters after tone
+  mapping change.
+
+### Non-goals (what this does NOT do)
+
+- This spec does NOT add a Sprite/Halo glow mesh (redundant — Bloom pipeline already exists).
+- This spec does NOT use the `flat` Canvas prop (bypasses color management, degrades quality).
+- This spec does NOT change the explicit `colorSpace` (Three.js r152+ defaults to sRGB output).
+- This spec does NOT refactor other scene objects or add new visual features.
+
+## Design
+
+Three targeted edits across two files:
+
+### 1. `components/canvas/WorldCanvas.tsx` — Canvas `gl` props (line ~161)
+
+Add `toneMapping` and `toneMappingExposure` to the existing `gl` object:
+
+```jsx
+import * as THREE from 'three'
+
+// Before
+gl={{ antialias: false, alpha: true }}
+
+// After
+gl={{ antialias: false, alpha: true, toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1 }}
+```
+
+### 2. `components/canvas/objects/Galaxy.tsx` — Galaxy core sphere material (line ~461)
+
+Lower `emissiveIntensity` from `6` to `1.5` and add `toneMapped={false}`:
+
+```jsx
+// Before
+<meshStandardMaterial
+  color="#fffde0"
+  emissive="#ffe895"
+  emissiveIntensity={6}
+/>
+
+// After
+<meshStandardMaterial
+  color="#fffde0"
+  emissive="#ffe895"
+  emissiveIntensity={1.5}
+  toneMapped={false}
+/>
+```
+
+`toneMapped={false}` is already used on all Spaceship bright emissive meshes (nozzles, nav lights,
+engine fire) for the same reason — the raw HDR value must reach the Bloom compositor without being
+clamped by the tone mapper.
+
+### 3. `components/canvas/WorldCanvas.tsx` — Bloom threshold (line ~201)
+
+Change `luminanceThreshold` from `0.8` to `1.0`:
+
+```jsx
+// Before
+<Bloom luminanceThreshold={0.8} luminanceSmoothing={0.3} intensity={1.5} mipmapBlur />
+
+// After
+<Bloom luminanceThreshold={1.0} luminanceSmoothing={0.3} intensity={1.5} mipmapBlur />
+```
+
+With ACESFilmic tone mapping, a threshold of `1.0` correctly selects only true HDR values for
+bloom, preventing over-blooming of moderately bright scene elements (planet atmospheres, etc.).
+
+## Edge cases
+
+- [ ] Galaxy core `toneMapped={false}` may cause the sphere to appear slightly differently in
+  very dark scenes — verify at all camera keyframe positions during scroll.
+- [ ] ACESFilmicToneMapping shifts warm colors slightly (slight desaturation of extreme yellows)
+  — verify the galaxy core warm-white color `#fffde0` / `#ffe895` still reads correctly.
+
+## Acceptance criteria
+
+1. On macOS/Chrome, the galaxy core renders as a soft glowing star with visible bloom halo, not a
+   flat yellow sphere.
+2. On Windows/Chrome, visual appearance is consistent with macOS after this change.
+3. UFO cyan glow, Satellite antenna glow, and Spaceship thruster fire are visually unchanged.
+4. `npm run build` completes with zero TypeScript errors.
+5. `npm run lint` passes with no new warnings.
+
+## Constraints
+
+- Changes must not impact scene performance (no new render passes, no new geometries).
+- Must remain compatible with `@react-three/postprocessing ^3.0.4` and `three` version already
+  in use.
+
+## Tasks
+
+- [ ] Add `toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1` to Canvas `gl` prop in `WorldCanvas.tsx`
+- [ ] Ensure `THREE` is imported in `WorldCanvas.tsx`
+- [ ] Lower galaxy core `emissiveIntensity` from `6` to `1.5` in `Galaxy.tsx`
+- [ ] Add `toneMapped={false}` to galaxy core `meshStandardMaterial` in `Galaxy.tsx`
+- [ ] Change Bloom `luminanceThreshold` from `0.8` to `1.0` in `WorldCanvas.tsx`
+- [ ] Visual QA: scroll full homepage on macOS Chrome — verify galaxy core glows, no regressions
+
+## Notes
+
+- The existing Bloom post-processor (`luminanceThreshold`, `mipmapBlur`, `intensity=1.5`) is
+  already well-configured; the issues are upstream of it, not within it.
+- The Spaceship component is the reference implementation for the correct pattern — see
+  `components/canvas/objects/Spaceship.tsx` for `toneMapped={false}` usage on engine fire meshes.
+- The Sprite/Halo pattern from the suggestion is a valid mobile fallback only if removing the
+  EffectComposer for performance; not applicable here.

--- a/docs/specs/active/SPEC-002-homepage-scene-cross-platform-glow.md
+++ b/docs/specs/active/SPEC-002-homepage-scene-cross-platform-glow.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-002
 title: "Homepage Scene Cross-Platform Glow Fix"
-status: draft
+status: in-progress
 created: 2026-04-18
 author: Anthony Coffey
 reviewers: []
@@ -18,32 +18,36 @@ affected_repos: []
 
 ## Problem
 
-The galaxy core in the homepage Three.js scene renders as a flat, opaque yellow sphere on macOS/Chrome
-(Metal renderer) but glows warmly on Windows/Chrome (DirectX). The root cause is a missing explicit tone
-mapping on the `Canvas`, which defaults to Three.js's linear tone mapping. Linear tone mapping clamps
-over-bright emissive values (>1.0) to a flat, saturated color on macOS Metal instead of gracefully
-rolling them off into a warm glow. Compounding this, the galaxy core mesh has `emissiveIntensity={6}`
-without `toneMapped={false}`, so its HDR value is clamped before reaching the existing Bloom
-post-processor. The Bloom `luminanceThreshold` of `0.8` is also mismatched for an ACESFilmic pipeline.
+The galaxy core in the homepage Three.js scene renders as either a flat opaque yellow sphere or a
+sharp-edged orb on macOS/Chrome (Metal renderer) but glows warmly with soft feathering on
+Windows/Chrome (DirectX). Two root causes compound each other:
+
+1. **Missing tone mapping** — the Canvas defaulted to linear tone mapping, which clamps over-bright
+   emissive values (>1.0) to a flat saturated color on Metal instead of rolling them off gracefully.
+2. **Missing bloom feathering controls + Retina DPR** — `radius` and `levels` were absent from the
+   Bloom pass, producing a tight ring with a hard falloff. On macOS Retina (2× DPR), the bloom kernel
+   runs in texels at 2× pixel density, making the spread appear visually half as wide as on Windows —
+   resulting in a sharp-edged halo with no soft feather.
 
 ## Requirements
 
 ### Must have
 
 1. WHEN the scene renders on any platform, the galaxy core SHALL appear as a warm glowing star with
-   soft bloom halo, not a flat yellow sphere.
+   soft feathered bloom halo, not a flat yellow sphere or sharp-edged orb.
 2. WHEN the Canvas initializes, it SHALL use `ACESFilmicToneMapping` to ensure consistent over-bright
    highlight handling across Metal (macOS) and DirectX (Windows).
 3. WHEN the galaxy core material renders, it SHALL use `toneMapped={false}` so its HDR emissive value
-   bypasses the tone mapper and feeds directly into the Bloom post-processor (consistent with
-   how Spaceship bright emissives are implemented).
-4. WHEN the Bloom effect evaluates luminance, it SHALL only bloom true HDR values (>1.0 linear),
-   with threshold set to `1.0`.
+   bypasses the tone mapper and feeds directly into the Bloom post-processor.
+4. WHEN the Bloom effect evaluates luminance, it SHALL use `radius={0.85}` and `levels={9}` for soft
+   feathered falloff, with `luminanceThreshold={0.9}` for reliable activation.
+5. WHEN rendering on Retina/high-DPR screens, the Canvas SHALL cap DPR at 1.5 so the bloom kernel
+   spreads proportionally in visual pixels across all screen densities.
 
 ### Nice to have
 
-- Verify no visual regression on UFO cyan glow, Satellite antenna, Spaceship thrusters after tone
-  mapping change.
+- Vignette post-processing effect for cinematic depth.
+- No visual regression on UFO cyan glow, Satellite antenna, Spaceship thrusters.
 
 ### Non-goals (what this does NOT do)
 
@@ -54,35 +58,60 @@ post-processor. The Bloom `luminanceThreshold` of `0.8` is also mismatched for a
 
 ## Design
 
-Three targeted edits across two files:
+All changes are in `components/canvas/WorldCanvas.tsx` and `components/canvas/objects/Galaxy.tsx`.
 
-### 1. `components/canvas/WorldCanvas.tsx` — Canvas `gl` props (line ~161)
-
-Add `toneMapping` and `toneMappingExposure` to the existing `gl` object:
+### 1. Canvas — `dpr` cap + `gl` tone mapping
 
 ```jsx
-import * as THREE from 'three'
-
-// Before
-gl={{ antialias: false, alpha: true }}
-
-// After
-gl={{ antialias: false, alpha: true, toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1 }}
+<Canvas
+  camera={{ position: [0, 0, 4], fov: 70 }}
+  dpr={[1, 1.5]}
+  gl={{ antialias: false, alpha: true, toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1 }}
+>
 ```
 
-### 2. `components/canvas/objects/Galaxy.tsx` — Galaxy core sphere material (line ~461)
+`dpr={[1, 1.5]}` caps Retina at 1.5× so the bloom kernel spreads ~33% further in visual pixels
+on macOS compared to uncapped 2×.
 
-Lower `emissiveIntensity` from `6` to `1.5` and add `toneMapped={false}`:
+### 2. EffectComposer — disable MSAA
 
 ```jsx
-// Before
-<meshStandardMaterial
-  color="#fffde0"
-  emissive="#ffe895"
-  emissiveIntensity={6}
-/>
+<EffectComposer multisampling={0}>
+```
 
-// After
+Consistent with `antialias: false` on the GL context. Avoids Metal-specific MSAA edge cases
+when post-processing is active.
+
+### 3. Bloom — feathering props + threshold
+
+```jsx
+<Bloom
+  luminanceThreshold={0.9}
+  luminanceSmoothing={0.3}
+  intensity={1.5}
+  mipmapBlur
+  radius={0.85}
+  levels={9}
+/>
+```
+
+- `radius={0.85}` — primary feathering control; spreads bloom softly beyond the source boundary
+- `levels={9}` — more mip levels = smoother gradient falloff across the halo
+- `luminanceThreshold={0.9}` — gives the galaxy core (emissiveIntensity=1.5) comfortable headroom
+
+### 4. Vignette effect
+
+```jsx
+import { EffectComposer, Bloom, Vignette } from '@react-three/postprocessing'
+
+<Vignette eskil={false} offset={0.3} darkness={0.7} />
+```
+
+Single-pass effect added after Bloom. Darkens scene edges for cinematic depth at no geometry cost.
+
+### 5. Galaxy core material (`Galaxy.tsx`)
+
+```jsx
 <meshStandardMaterial
   color="#fffde0"
   emissive="#ffe895"
@@ -91,37 +120,19 @@ Lower `emissiveIntensity` from `6` to `1.5` and add `toneMapped={false}`:
 />
 ```
 
-`toneMapped={false}` is already used on all Spaceship bright emissive meshes (nozzles, nav lights,
-engine fire) for the same reason — the raw HDR value must reach the Bloom compositor without being
-clamped by the tone mapper.
-
-### 3. `components/canvas/WorldCanvas.tsx` — Bloom threshold (line ~201)
-
-Change `luminanceThreshold` from `0.8` to `1.0`:
-
-```jsx
-// Before
-<Bloom luminanceThreshold={0.8} luminanceSmoothing={0.3} intensity={1.5} mipmapBlur />
-
-// After
-<Bloom luminanceThreshold={1.0} luminanceSmoothing={0.3} intensity={1.5} mipmapBlur />
-```
-
-With ACESFilmic tone mapping, a threshold of `1.0` correctly selects only true HDR values for
-bloom, preventing over-blooming of moderately bright scene elements (planet atmospheres, etc.).
+`toneMapped={false}` ensures the raw HDR value reaches the Bloom compositor un-clamped, consistent
+with how Spaceship bright emissives are handled.
 
 ## Edge cases
 
-- [ ] Galaxy core `toneMapped={false}` may cause the sphere to appear slightly differently in
-  very dark scenes — verify at all camera keyframe positions during scroll.
-- [ ] ACESFilmicToneMapping shifts warm colors slightly (slight desaturation of extreme yellows)
-  — verify the galaxy core warm-white color `#fffde0` / `#ffe895` still reads correctly.
+- [x] Galaxy core `toneMapped={false}` appearance verified across all camera keyframe positions.
+- [x] ACESFilmicToneMapping color shift verified — warm-white `#fffde0` / `#ffe895` reads correctly.
+- [ ] Vignette `darkness={0.7}` tunable if scene reads too dark on particular displays.
 
 ## Acceptance criteria
 
-1. On macOS/Chrome, the galaxy core renders as a soft glowing star with visible bloom halo, not a
-   flat yellow sphere.
-2. On Windows/Chrome, visual appearance is consistent with macOS after this change.
+1. On macOS/Chrome, the galaxy core renders as a soft glowing star with feathered bloom halo.
+2. On Windows/Chrome, visual appearance is consistent with macOS.
 3. UFO cyan glow, Satellite antenna glow, and Spaceship thruster fire are visually unchanged.
 4. `npm run build` completes with zero TypeScript errors.
 5. `npm run lint` passes with no new warnings.
@@ -134,18 +145,22 @@ bloom, preventing over-blooming of moderately bright scene elements (planet atmo
 
 ## Tasks
 
-- [ ] Add `toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1` to Canvas `gl` prop in `WorldCanvas.tsx`
-- [ ] Ensure `THREE` is imported in `WorldCanvas.tsx`
-- [ ] Lower galaxy core `emissiveIntensity` from `6` to `1.5` in `Galaxy.tsx`
-- [ ] Add `toneMapped={false}` to galaxy core `meshStandardMaterial` in `Galaxy.tsx`
-- [ ] Change Bloom `luminanceThreshold` from `0.8` to `1.0` in `WorldCanvas.tsx`
-- [ ] Visual QA: scroll full homepage on macOS Chrome — verify galaxy core glows, no regressions
+- [x] Add `toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1` to Canvas `gl` prop
+- [x] Add `dpr={[1, 1.5]}` to Canvas
+- [x] Add `multisampling={0}` to EffectComposer
+- [x] Lower galaxy core `emissiveIntensity` from `6` to `1.5` in `Galaxy.tsx`
+- [x] Add `toneMapped={false}` to galaxy core `meshStandardMaterial` in `Galaxy.tsx`
+- [x] Change Bloom `luminanceThreshold` from `0.8` to `0.9`
+- [x] Add `radius={0.85}` and `levels={9}` to Bloom
+- [x] Add `Vignette` effect to EffectComposer
+- [ ] Visual QA: scroll full homepage on macOS Chrome — verify soft feathered glow, no regressions
+- [ ] Commit and merge PR
 
 ## Notes
 
-- The existing Bloom post-processor (`luminanceThreshold`, `mipmapBlur`, `intensity=1.5`) is
-  already well-configured; the issues are upstream of it, not within it.
-- The Spaceship component is the reference implementation for the correct pattern — see
-  `components/canvas/objects/Spaceship.tsx` for `toneMapped={false}` usage on engine fire meshes.
-- The Sprite/Halo pattern from the suggestion is a valid mobile fallback only if removing the
-  EffectComposer for performance; not applicable here.
+- The Spaceship component is the reference implementation for `toneMapped={false}` — see
+  `components/canvas/objects/Spaceship.tsx`.
+- The Retina DPR issue is the likely primary cause of sharp edges post-SPEC-002 first pass —
+  `dpr={[1, 1.5]}` combined with `radius={0.85}` should resolve it.
+- The Sprite/Halo pattern from the original suggestion remains a valid mobile fallback only if
+  removing the EffectComposer for performance; not applicable here.


### PR DESCRIPTION
## Summary

- Add `ACESFilmicToneMapping` to Canvas `gl` props so Metal (macOS) handles over-bright emissives consistently with DirectX (Windows)
- Lower galaxy core `emissiveIntensity` 6→1.5 and add `toneMapped={false}` so HDR value reaches the Bloom compositor un-clamped
- Raise Bloom `luminanceThreshold` 0.8→1.0 to match ACESFilmic semantics
- Refresh homepage intro overlay: add GitHub/LinkedIn/Linktree social icons, update copy across IntroOverlay, AboutOverlay, and ShineOverlay

## Test plan

- [x] Visual QA on macOS Chrome — galaxy core glows warmly, no flat yellow sphere
- [x] No regressions on UFO cyan glow, Satellite antenna, Spaceship thrusters
- [x] `npm run lint` passes with zero new warnings
