### PR TITLE
fix: final overlay link unclickable due to ghost social links

### DIFF
--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -17,9 +17,12 @@
   opacity: 0
   transform: translateY(16px)
 
+  pointer-events: none
+
   &.visible
     opacity: 1
     transform: translateY(0)
+    pointer-events: auto
 
 // ── Intro overlay — centered ──────────────────────────────────────────────
 .introPanel
@@ -86,7 +89,6 @@
 .socialLinks
   display: flex
   gap: 1rem
-  pointer-events: auto // CRITICAL: re-enables interaction inside the overlay
 
 .iconLink
   color: rgba(240, 240, 255, 0.35)

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -134,10 +134,13 @@ test.describe('Homepage', () => {
     await expect(panels.shine(page)).toContainText('Want to know more?')
   })
 
-  test('shine overlay contact link points to /contact', async ({ page }) => {
+  test('shine overlay contact link points to /contact and is clickable', async ({ page }) => {
     await scrollTo(page, 0.91)
     await expect(panels.shine(page)).toHaveClass(isShowing)
     const link = panels.shine(page).locator('a[href="/contact"]')
     await expect(link).toHaveAttribute('href', '/contact')
+    // Playwright's click action automatically checks for actionability and intercepting elements.
+    // Setting trial: true verifies the link can be cleanly clicked without getting blocked by invisible overlays.
+    await link.click({ trial: true })
   })
 })


### PR DESCRIPTION
Resolves an issue where invisible social links were capturing click events from the final overlay by properly managing pointer-events via the wrapper panel.