### PR TITLE
feat: on-page technical SEO audit and sitewide meta rewrite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,24 @@ on:
     branches: [master]
 
 jobs:
+  lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
   unit:
     name: Vitest
     runs-on: ubuntu-latest

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -43,7 +43,7 @@ const MOCK_POSTS = [
 
 beforeEach(() => {
   vi.clearAllMocks()
-  vi.mocked(getAllBlogPosts).mockReturnValue(MOCK_POSTS as any)
+  vi.mocked(getAllBlogPosts).mockReturnValue(MOCK_POSTS as never)
 })
 
 describe('GET /api/search', () => {

--- a/__tests__/articles/category-page.test.tsx
+++ b/__tests__/articles/category-page.test.tsx
@@ -72,7 +72,7 @@ beforeEach(() => {
 
 describe('CategoryPage', () => {
   it('calls notFound when no posts match the category', async () => {
-    vi.mocked(getPaginatedBlogPostsByCategory).mockReturnValue(EMPTY_RESULT as any)
+    vi.mocked(getPaginatedBlogPostsByCategory).mockReturnValue(EMPTY_RESULT as never)
     await CategoryPage({
       params: Promise.resolve({ category: 'nonexistent' }),
       searchParams: Promise.resolve({}),
@@ -81,7 +81,7 @@ describe('CategoryPage', () => {
   })
 
   it('does not call notFound when posts exist', async () => {
-    vi.mocked(getPaginatedBlogPostsByCategory).mockReturnValue(ONE_POST_RESULT as any)
+    vi.mocked(getPaginatedBlogPostsByCategory).mockReturnValue(ONE_POST_RESULT as never)
     await CategoryPage({
       params: Promise.resolve({ category: 'backend' }),
       searchParams: Promise.resolve({}),
@@ -90,7 +90,7 @@ describe('CategoryPage', () => {
   })
 
   it('decodes URL-encoded category and passes to utils', async () => {
-    vi.mocked(getPaginatedBlogPostsByCategory).mockReturnValue(ONE_POST_RESULT as any)
+    vi.mocked(getPaginatedBlogPostsByCategory).mockReturnValue(ONE_POST_RESULT as never)
     await CategoryPage({
       params: Promise.resolve({ category: 'web%20development' }),
       searchParams: Promise.resolve({}),
@@ -99,7 +99,7 @@ describe('CategoryPage', () => {
   })
 
   it('uses page number from searchParams', async () => {
-    vi.mocked(getPaginatedBlogPostsByCategory).mockReturnValue(ONE_POST_RESULT as any)
+    vi.mocked(getPaginatedBlogPostsByCategory).mockReturnValue(ONE_POST_RESULT as never)
     await CategoryPage({
       params: Promise.resolve({ category: 'backend' }),
       searchParams: Promise.resolve({ page: '3' }),
@@ -108,7 +108,7 @@ describe('CategoryPage', () => {
   })
 
   it('excludes the active category from the sidebar list', async () => {
-    vi.mocked(getPaginatedBlogPostsByCategory).mockReturnValue(ONE_POST_RESULT as any)
+    vi.mocked(getPaginatedBlogPostsByCategory).mockReturnValue(ONE_POST_RESULT as never)
     const jsx = await CategoryPage({
       params: Promise.resolve({ category: 'backend' }),
       searchParams: Promise.resolve({}),

--- a/__tests__/articles/page.test.tsx
+++ b/__tests__/articles/page.test.tsx
@@ -36,7 +36,7 @@ const MOCK_RESULT = {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  vi.mocked(getPaginatedBlogPosts).mockReturnValue(MOCK_RESULT as any)
+  vi.mocked(getPaginatedBlogPosts).mockReturnValue(MOCK_RESULT as never)
   vi.mocked(getAllTags).mockReturnValue(['react', 'typescript'])
   vi.mocked(getAllCategories).mockReturnValue(['backend'])
 })

--- a/__tests__/articles/search-page.test.tsx
+++ b/__tests__/articles/search-page.test.tsx
@@ -53,7 +53,7 @@ function mockFetch(posts: typeof MOCK_POSTS) {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as any)
+  vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as never)
 })
 
 describe('SearchPage — empty state', () => {
@@ -68,7 +68,7 @@ describe('SearchPage — empty state', () => {
 
 describe('SearchPage — with query', () => {
   beforeEach(() => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('q=react') as any)
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('q=react') as never)
   })
 
   it('renders search results when API returns matches', async () => {
@@ -100,7 +100,7 @@ describe('SearchPage — with query', () => {
 
 describe('SearchPage — custom search event', () => {
   it('re-fetches when search-query-updated event fires', async () => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as any)
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as never)
     mockFetch([])
     render(<SearchPage />)
 
@@ -120,7 +120,7 @@ describe('SearchPage — custom search event', () => {
 
 describe('SearchPage — pagination', () => {
   it('renders pagination when results exceed 5 items', async () => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('q=test') as any)
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('q=test') as never)
     const manyPosts = Array.from({ length: 6 }, (_, i) => ({
       slug: `post-${i}`,
       title: `Post ${i}`,
@@ -137,7 +137,7 @@ describe('SearchPage — pagination', () => {
   })
 
   it('does not render pagination when results fit on one page', async () => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('q=test') as any)
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('q=test') as never)
     mockFetch(MOCK_POSTS)
     render(<SearchPage />)
     await waitFor(() => {

--- a/__tests__/articles/tag-page.test.tsx
+++ b/__tests__/articles/tag-page.test.tsx
@@ -73,12 +73,12 @@ beforeEach(() => {
   vi.mocked(getPaginatedBlogPosts).mockReturnValue({
     posts: ONE_POST_RESULT.posts,
     pagination: ONE_POST_RESULT.pagination,
-  } as any)
+  } as never)
 })
 
 describe('TagPage', () => {
   it('calls notFound when no posts match the tag', async () => {
-    vi.mocked(getPaginatedBlogPostsByTag).mockReturnValue(EMPTY_RESULT as any)
+    vi.mocked(getPaginatedBlogPostsByTag).mockReturnValue(EMPTY_RESULT as never)
     await TagPage({
       params: Promise.resolve({ tag: 'nonexistent' }),
       searchParams: Promise.resolve({}),
@@ -87,7 +87,7 @@ describe('TagPage', () => {
   })
 
   it('does not call notFound when posts exist', async () => {
-    vi.mocked(getPaginatedBlogPostsByTag).mockReturnValue(ONE_POST_RESULT as any)
+    vi.mocked(getPaginatedBlogPostsByTag).mockReturnValue(ONE_POST_RESULT as never)
     await TagPage({
       params: Promise.resolve({ tag: 'typescript' }),
       searchParams: Promise.resolve({}),
@@ -96,7 +96,7 @@ describe('TagPage', () => {
   })
 
   it('decodes URL-encoded tag and passes capitalized value to utils', async () => {
-    vi.mocked(getPaginatedBlogPostsByTag).mockReturnValue(ONE_POST_RESULT as any)
+    vi.mocked(getPaginatedBlogPostsByTag).mockReturnValue(ONE_POST_RESULT as never)
     await TagPage({
       params: Promise.resolve({ tag: 'web%20development' }),
       searchParams: Promise.resolve({}),
@@ -105,7 +105,7 @@ describe('TagPage', () => {
   })
 
   it('uses page number from searchParams', async () => {
-    vi.mocked(getPaginatedBlogPostsByTag).mockReturnValue(ONE_POST_RESULT as any)
+    vi.mocked(getPaginatedBlogPostsByTag).mockReturnValue(ONE_POST_RESULT as never)
     await TagPage({
       params: Promise.resolve({ tag: 'typescript' }),
       searchParams: Promise.resolve({ page: '2' }),
@@ -114,7 +114,7 @@ describe('TagPage', () => {
   })
 
   it('excludes the active tag from the sidebar tag list', async () => {
-    vi.mocked(getPaginatedBlogPostsByTag).mockReturnValue(ONE_POST_RESULT as any)
+    vi.mocked(getPaginatedBlogPostsByTag).mockReturnValue(ONE_POST_RESULT as never)
     const jsx = await TagPage({
       params: Promise.resolve({ tag: 'typescript' }),
       searchParams: Promise.resolve({}),

--- a/__tests__/articles/utils.test.ts
+++ b/__tests__/articles/utils.test.ts
@@ -60,7 +60,7 @@ beforeEach(() => {
     if (filePath.endsWith('post-c.mdx')) return FIXTURE_C
     return ''
   })
-  vi.mocked(fs.readdirSync).mockReturnValue(['post-a.mdx', 'post-b.mdx', 'post-c.mdx'] as any)
+  vi.mocked(fs.readdirSync).mockReturnValue(['post-a.mdx', 'post-b.mdx', 'post-c.mdx'] as never)
 })
 
 describe('capitalizeWords', () => {

--- a/__tests__/hooks/usePagination.test.tsx
+++ b/__tests__/hooks/usePagination.test.tsx
@@ -14,9 +14,9 @@ import { usePagination } from '@/hooks/usePagination'
 
 beforeEach(() => {
   vi.clearAllMocks()
-  vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as any)
+  vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as never)
   vi.mocked(usePathname).mockReturnValue('/articles')
-  vi.mocked(useRouter).mockReturnValue({ push: mockPush } as any)
+  vi.mocked(useRouter).mockReturnValue({ push: mockPush } as never)
 })
 
 describe('usePagination', () => {
@@ -26,7 +26,7 @@ describe('usePagination', () => {
   })
 
   it('reads initial page from ?page search param', () => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=3') as any)
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=3') as never)
     const { result } = renderHook(() => usePagination(5))
     expect(result.current.currentPage).toBe(3)
   })
@@ -37,19 +37,19 @@ describe('usePagination', () => {
   })
 
   it('isFirstPage is false on page 2+', () => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=2') as any)
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=2') as never)
     const { result } = renderHook(() => usePagination(5))
     expect(result.current.isFirstPage).toBe(false)
   })
 
   it('isLastPage is true on the last page', () => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=5') as any)
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=5') as never)
     const { result } = renderHook(() => usePagination(5))
     expect(result.current.isLastPage).toBe(true)
   })
 
   it('hasNextPage is false on the last page', () => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=5') as any)
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=5') as never)
     const { result } = renderHook(() => usePagination(5))
     expect(result.current.hasNextPage).toBe(false)
   })
@@ -65,7 +65,7 @@ describe('usePagination', () => {
   })
 
   it('hasPrevPage is true on page 2+', () => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=2') as any)
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=2') as never)
     const { result } = renderHook(() => usePagination(5))
     expect(result.current.hasPrevPage).toBe(true)
   })
@@ -79,7 +79,7 @@ describe('usePagination', () => {
   })
 
   it('changePage removes ?page param when navigating to page 1', () => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=3') as any)
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('page=3') as never)
     const { result } = renderHook(() => usePagination(5))
     act(() => {
       result.current.changePage(1)

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -30,19 +30,16 @@ export async function generateMetadata({ params }) {
     image,
   } = post.metadata;
 
-  // Use simpler title format for articles to prioritize article title and avoid truncation
-  const title = `${postTitle} | Anthony Coffey`;
-
-  // Use the original postTitle for generating the OG image if no specific image is provided
   const ogImage = image
     ? image
     : `${baseUrl}/og?title=${encodeURIComponent(postTitle)}`;
 
   return {
-    title, // Use the modified title
+    title: postTitle,
     description,
+    alternates: { canonical: `/articles/${post.slug}` },
     openGraph: {
-      title, // Use the modified title
+      title: postTitle,
       description,
       type: 'article',
       publishedTime,
@@ -55,7 +52,7 @@ export async function generateMetadata({ params }) {
     },
     twitter: {
       card: 'summary_large_image',
-      title,
+      title: postTitle,
       description,
       images: [ogImage],
     },
@@ -86,14 +83,54 @@ export default async function Blog({ params }) {
             description: post.metadata.summary,
             image: post.metadata.image
               ? `${baseUrl}${post.metadata.image}`
-              : `/og?title=${encodeURIComponent(post.metadata.title)}`,
+              : `${baseUrl}/og?title=${encodeURIComponent(post.metadata.title)}`,
             url: `${baseUrl}/articles/${post.slug}`,
             author: {
               '@type': 'Person',
               name: 'Anthony Coffey',
+              url: baseUrl,
+            },
+            publisher: {
+              '@type': 'Person',
+              name: 'Anthony Coffey',
+              url: baseUrl,
+            },
+            mainEntityOfPage: {
+              '@type': 'WebPage',
+              '@id': `${baseUrl}/articles/${post.slug}`,
             },
             keywords: post.metadata.tags ? post.metadata.tags.join(', ') : '',
             articleSection: post.metadata.category || '',
+          }),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BreadcrumbList',
+            itemListElement: [
+              {
+                '@type': 'ListItem',
+                position: 1,
+                name: 'Home',
+                item: baseUrl,
+              },
+              {
+                '@type': 'ListItem',
+                position: 2,
+                name: 'Articles',
+                item: `${baseUrl}/articles`,
+              },
+              {
+                '@type': 'ListItem',
+                position: 3,
+                name: post.metadata.title,
+                item: `${baseUrl}/articles/${post.slug}`,
+              },
+            ],
           }),
         }}
       />

--- a/app/articles/categories/page.tsx
+++ b/app/articles/categories/page.tsx
@@ -1,10 +1,14 @@
 import { getAllCategories } from '@/app/articles/utils';
 import Link from 'next/link';
 
-export function generateMetadata() {
+import type { Metadata } from 'next';
+
+export function generateMetadata(): Metadata {
   return {
-    title: 'All Article Categories | Anthony Coffey - Solutions Architect, AI/ML',
-    description: 'Browse articles by category on topics like software engineering, AI/ML, cloud computing, and web development from Anthony Coffey.',
+    title: 'All Article Categories',
+    description:
+      'Browse articles by category — software engineering, AI/ML, cloud computing, and web development from Anthony Coffey.',
+    alternates: { canonical: '/articles/categories' },
   };
 }
 

--- a/app/articles/categories/page.tsx
+++ b/app/articles/categories/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from 'next';
 
 export function generateMetadata(): Metadata {
   return {
-    title: 'Software Engineering Article Categories',
+    title: 'Articles Categories',
     description:
       'Browse articles by category — software engineering, AI/ML, cloud computing, and web development from Anthony Coffey.',
     alternates: { canonical: '/articles/categories' },

--- a/app/articles/categories/page.tsx
+++ b/app/articles/categories/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from 'next';
 
 export function generateMetadata(): Metadata {
   return {
-    title: 'All Article Categories',
+    title: 'Software Engineering Article Categories',
     description:
       'Browse articles by category — software engineering, AI/ML, cloud computing, and web development from Anthony Coffey.',
     alternates: { canonical: '/articles/categories' },

--- a/app/articles/category/[category]/page.tsx
+++ b/app/articles/category/[category]/page.tsx
@@ -35,8 +35,9 @@ export async function generateMetadata({ params }) {
   const decodedCategory = capitalizeWords(decodeURIComponent(category));
 
   return {
-    title: `Articles in Category: ${decodedCategory} | Anthony Coffey - Solutions Architect, AI/ML`,
-    description: `Explore software development articles by Anthony Coffey, Solutions Architect & AI/ML Specialist, categorized under "${decodedCategory}". Find insights on relevant topics.`,
+    title: `${decodedCategory} Articles`,
+    description: `Articles categorized under ${decodedCategory} — software engineering insights and deep dives by Anthony Coffey.`,
+    alternates: { canonical: `/articles/category/${encodeURIComponent(category)}` },
   };
 }
 

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -17,12 +17,12 @@ import SearchBox from '@/components/SearchBox';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Software Engineering & AI Articles',
+  title: { absolute: 'Articles by Anthony Coffey' },
   description:
-    'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey — Austin-based software engineer and AI consultant.',
+    'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey — Austin-based AI consultant and software engineer.',
   alternates: { canonical: '/articles' },
   openGraph: {
-    title: 'Software Engineering & AI Articles',
+    title: 'Articles by Anthony Coffey',
     description:
       'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey.',
     url: '/articles',

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -17,12 +17,12 @@ import SearchBox from '@/components/SearchBox';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Articles',
+  title: 'Software Engineering & AI Articles',
   description:
-    'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey — Solutions Architect based in Austin, TX.',
+    'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey — Austin-based software engineer and AI consultant.',
   alternates: { canonical: '/articles' },
   openGraph: {
-    title: 'Articles',
+    title: 'Software Engineering & AI Articles',
     description:
       'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey.',
     url: '/articles',

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -14,11 +14,20 @@ import {
 import Link from 'next/link';
 import SearchBox from '@/components/SearchBox';
 
-export const metadata = {
-  title:
-    'Articles | Anthony Coffey - Solutions Architect, AI/ML',
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Articles',
   description:
-    'Explore articles by Anthony Coffey, Solutions Architect & AI/ML Specialist, on software engineering, AI/ML integration, cloud architecture, web development best practices, and project management strategies.',
+    'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey — Solutions Architect based in Austin, TX.',
+  alternates: { canonical: '/articles' },
+  openGraph: {
+    title: 'Articles',
+    description:
+      'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey.',
+    url: '/articles',
+    type: 'website',
+  },
 };
 
 export default async function ArticlesPage({ searchParams }) {

--- a/app/articles/search/layout.tsx
+++ b/app/articles/search/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Search Articles',
+  title: 'Search Software Engineering Articles',
   description:
     'Search articles by Anthony Coffey on software engineering, AI/ML, cloud architecture, and web development.',
   alternates: { canonical: '/articles/search' },

--- a/app/articles/search/layout.tsx
+++ b/app/articles/search/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Search Articles',
+  description:
+    'Search articles by Anthony Coffey on software engineering, AI/ML, cloud architecture, and web development.',
+  alternates: { canonical: '/articles/search' },
+  robots: { index: false, follow: true },
+};
+
+export default function SearchLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/articles/search/layout.tsx
+++ b/app/articles/search/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Search Software Engineering Articles',
+  title: 'Search Articles',
   description:
     'Search articles by Anthony Coffey on software engineering, AI/ML, cloud architecture, and web development.',
   alternates: { canonical: '/articles/search' },

--- a/app/articles/tag/[tag]/page.tsx
+++ b/app/articles/tag/[tag]/page.tsx
@@ -31,8 +31,9 @@ export async function generateMetadata({ params }) {
   const decodedTag = capitalizeWords(decodeURIComponent(tag));
 
   return {
-    title: `Articles Tagged: ${decodedTag} | Anthony Coffey - Solutions Architect, AI/ML`,
-    description: `Find software development articles by Anthony Coffey, Solutions Architect & AI/ML Specialist, tagged with "${decodedTag}". Explore specific technologies and concepts.`,
+    title: `${decodedTag} Articles`,
+    description: `Articles tagged ${decodedTag} — technical write-ups and deep dives by Anthony Coffey.`,
+    alternates: { canonical: `/articles/tag/${encodeURIComponent(tag)}` },
   };
 }
 

--- a/app/articles/tags/page.tsx
+++ b/app/articles/tags/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from 'next';
 
 export function generateMetadata(): Metadata {
   return {
-    title: 'All Article Tags',
+    title: 'Software Engineering Article Tags',
     description:
       'Browse articles by tag — React, Next.js, AWS, AI/ML, Git, and other technologies covered by Anthony Coffey.',
     alternates: { canonical: '/articles/tags' },

--- a/app/articles/tags/page.tsx
+++ b/app/articles/tags/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from 'next';
 
 export function generateMetadata(): Metadata {
   return {
-    title: 'Software Engineering Article Tags',
+    title: 'Articles Tags',
     description:
       'Browse articles by tag — React, Next.js, AWS, AI/ML, Git, and other technologies covered by Anthony Coffey.',
     alternates: { canonical: '/articles/tags' },

--- a/app/articles/tags/page.tsx
+++ b/app/articles/tags/page.tsx
@@ -1,10 +1,14 @@
 import { getAllTags } from '@/app/articles/utils';
 import Link from 'next/link';
 
-export function generateMetadata() {
+import type { Metadata } from 'next';
+
+export function generateMetadata(): Metadata {
   return {
-    title: 'All Article Tags | Anthony Coffey - Solutions Architect, AI/ML',
-    description: 'Explore articles by tag on specific technologies and concepts like React, Next.js, AWS, AI/ML, Git, and more from Anthony Coffey.',
+    title: 'All Article Tags',
+    description:
+      'Browse articles by tag — React, Next.js, AWS, AI/ML, Git, and other technologies covered by Anthony Coffey.',
+    alternates: { canonical: '/articles/tags' },
   };
 }
 

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Software Engineering Case Studies',
+  title: 'Case Studies',
   description:
     'Software engineering case studies by Anthony Coffey — geospatial tech, fleet optimization, and real-world problem solving.',
   alternates: { canonical: '/case-studies' },

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Case Studies',
+  title: 'Software Engineering Case Studies',
   description:
     'Software engineering case studies by Anthony Coffey — geospatial tech, fleet optimization, and real-world problem solving.',
   alternates: { canonical: '/case-studies' },

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -5,10 +5,14 @@ import {
 } from '@heroicons/react/20/solid';
 import Link from 'next/link';
 
-export const metadata = {
-  title: 'Case Studies | Anthony Coffey - Solutions Architect, AI/ML',
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Case Studies',
   description:
-    'Explore detailed software development case studies by Anthony Coffey, Solutions Architect & AI/ML Specialist, showcasing problem-solving approaches and results in areas like geospatial tech, optimization, and more.',
+    'Software engineering case studies by Anthony Coffey — geospatial tech, fleet optimization, and real-world problem solving.',
+  alternates: { canonical: '/case-studies' },
+  robots: { index: false, follow: true },
 };
 
 const CaseStudyCard = ({ icon, title, description, pdfPath, tags }) => {

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -12,9 +12,9 @@ import { EnvelopeOpenIcon } from '@heroicons/react/24/solid';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Contact',
+  title: 'Hire an Austin Software Engineer',
   description:
-    'Get in touch with Anthony Coffey for software engineering, AI/ML, or consulting work. Send a message or book a free 30-minute consultation.',
+    'Get in touch with Anthony Coffey, an Austin software engineer and AI consultant, for web, mobile, or AI/ML work. Book a free 30-minute consultation.',
   alternates: { canonical: '/contact' },
 };
 

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -9,10 +9,13 @@ import {
 } from '@heroicons/react/24/outline';
 import { EnvelopeOpenIcon } from '@heroicons/react/24/solid';
 
-export const metadata = {
-  title: 'Contact | Anthony Coffey - Solutions Architect, AI/ML',
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Contact',
   description:
-    'Get in touch with Anthony Coffey, Solutions Architect & AI/ML Specialist, for software development, AI/ML integration, or consulting services. Send a message or schedule a free consultation.',
+    'Get in touch with Anthony Coffey for software engineering, AI/ML, or consulting work. Send a message or book a free 30-minute consultation.',
+  alternates: { canonical: '/contact' },
 };
 
 export default async function ContactPage() {

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -12,9 +12,9 @@ import { EnvelopeOpenIcon } from '@heroicons/react/24/solid';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Hire an Austin Software Engineer',
+  title: 'Contact',
   description:
-    'Get in touch with Anthony Coffey, an Austin software engineer and AI consultant, for web, mobile, or AI/ML work. Book a free 30-minute consultation.',
+    'Get in touch with Anthony Coffey, an AI consultant and software engineer in Austin, TX, for web, mobile, or AI/ML work. Book a free 30-minute consultation.',
   alternates: { canonical: '/contact' },
 };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,26 +1,124 @@
-'use client';
-
+import type { Metadata, Viewport } from 'next';
 import '../styles/global.sass';
-import { usePathname } from 'next/navigation';
 import { outfit, GeistMono } from '../lib/fonts';
-import Navbar from '../components/Navbar';
-import { LandingPageHeader } from '../components/LandingPageHeader';
-import GoogleAnalyticsClient from '../components/GoogleAnalyticsClient';
-import Footer from '../components/Footer';
-import ConsentManager from '../components/ConsentManager';
-import { ThemeProvider } from '../components/ThemeProvider';
+import LayoutShell from '../components/LayoutShell';
+import JsonLd from '../components/JsonLd';
+import { baseUrl } from './sitemap';
 
-const cx = (...classes: (string | undefined | false)[]) => classes.filter(Boolean).join(' ');
+const cx = (...classes: (string | undefined | false)[]) =>
+  classes.filter(Boolean).join(' ');
+
+const SITE_NAME = 'Anthony Coffey';
+const SITE_DESCRIPTION =
+  'Anthony Coffey — musician, director, and software engineer in Austin, TX. Creativity is at the core of everything I build, design, and ship.';
+
+export const metadata: Metadata = {
+  metadataBase: new URL(baseUrl),
+  title: {
+    default: `${SITE_NAME} — Musician, Engineer, Maker in Austin`,
+    template: `%s | ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
+  applicationName: SITE_NAME,
+  authors: [{ name: SITE_NAME, url: baseUrl }],
+  creator: SITE_NAME,
+  publisher: SITE_NAME,
+  manifest: '/site.webmanifest',
+  icons: {
+    icon: [
+      { url: '/favicon.ico', sizes: 'any' },
+      { url: '/favicon-16x16.png', sizes: '16x16', type: 'image/png' },
+      { url: '/favicon-32x32.png', sizes: '32x32', type: 'image/png' },
+    ],
+    apple: '/apple-touch-icon.png',
+  },
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: baseUrl,
+    siteName: SITE_NAME,
+    title: `${SITE_NAME} — Musician, Engineer, Maker in Austin`,
+    description: SITE_DESCRIPTION,
+    images: [
+      {
+        url: '/og-image.jpg',
+        width: 1200,
+        height: 630,
+        alt: SITE_NAME,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${SITE_NAME} — Musician, Engineer, Maker in Austin`,
+    description: SITE_DESCRIPTION,
+    images: ['/og-image.jpg'],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
+  },
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: '#000000' },
+  ],
+};
+
+const personSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: SITE_NAME,
+  url: baseUrl,
+  image: `${baseUrl}/headshot.png`,
+  jobTitle: 'Software Engineer & Solutions Architect',
+  description: SITE_DESCRIPTION,
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Austin',
+    addressRegion: 'TX',
+    addressCountry: 'US',
+  },
+  sameAs: [
+    'https://github.com/anthonycoffey',
+    'https://linkedin.com/in/coffeyanthony',
+    'https://linktr.ee/coffeycodes',
+  ],
+};
+
+const websiteSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: SITE_NAME,
+  url: baseUrl,
+  description: SITE_DESCRIPTION,
+  inLanguage: 'en-US',
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: `${baseUrl}/articles/search?q={search_term_string}`,
+    },
+    'query-input': 'required name=search_term_string',
+  },
+};
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const isLandingPage = pathname === '/lp' || pathname?.startsWith('/lp/');
-  const isHomePage = pathname === '/';
-
   return (
     <html
       lang="en"
@@ -29,20 +127,9 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="antialiased bg-bg text-c-text font-outfit">
-        <ThemeProvider
-          attribute="data-theme"
-          defaultTheme="light"
-          storageKey="theme"
-        >
-          <ConsentManager />
-          <GoogleAnalyticsClient />
-
-          {isLandingPage ? <LandingPageHeader /> : <Navbar />}
-
-          <main>{children}</main>
-
-          {!isLandingPage && !isHomePage && <Footer />}
-        </ThemeProvider>
+        <JsonLd data={personSchema} />
+        <JsonLd data={websiteSchema} />
+        <LayoutShell>{children}</LayoutShell>
       </body>
     </html>
   );

--- a/app/lp/practical-ai/page.tsx
+++ b/app/lp/practical-ai/page.tsx
@@ -3,6 +3,8 @@ import ContactForm from '@/components/ContactForm'; // Assuming ContactForm path
 import { Metadata } from 'next';
 import Image from 'next/image';
 import SocialIcons from '@/components/SocialIcons';
+import JsonLd from '@/components/JsonLd';
+import { baseUrl } from '@/app/sitemap';
 import {
   LightBulbIcon,
   ArrowsPointingOutIcon,
@@ -12,15 +14,42 @@ import {
 } from '@heroicons/react/24/outline'; // Import necessary icons
 
 export const metadata: Metadata = {
-  title:
-    'Practical AI Solutions for Business Growth | Anthony Coffey - Solutions Architect, AI/ML',
+  title: 'Practical AI Solutions for Business Growth',
   description:
-    'Move beyond AI hype with Anthony Coffey, Solutions Architect & AI/ML Specialist. Get production-ready, scalable AI/ML solutions integrated with your business for tangible results.',
+    'Move past AI hype. Production-ready, scalable AI/ML solutions integrated with your business for tangible, measurable results.',
+  alternates: { canonical: '/lp/practical-ai' },
+  openGraph: {
+    title: 'Practical AI Solutions for Business Growth',
+    description:
+      'Production-ready, scalable AI/ML solutions integrated with your business for measurable ROI.',
+    url: '/lp/practical-ai',
+    type: 'website',
+  },
 };
 
 export default function PracticalAiLandingPage() {
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: baseUrl },
+      { '@type': 'ListItem', position: 2, name: 'Practical AI', item: `${baseUrl}/lp/practical-ai` },
+    ],
+  };
+  const service = {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: 'Practical AI Solutions for Business Growth',
+    provider: { '@type': 'Person', name: 'Anthony Coffey', url: baseUrl },
+    areaServed: 'US',
+    description:
+      'Production-ready, scalable AI/ML solutions integrated with your business for tangible, measurable results.',
+    url: `${baseUrl}/lp/practical-ai`,
+  };
   return (
     <div className="container max-w-6xl mx-auto px-4 py-16">
+      <JsonLd data={breadcrumb} />
+      <JsonLd data={service} />
       <section className="text-center mb-12">
         <h1 className="text-4xl font-bold mb-4 text-c-heading">
           Cut Through the AI Hype. Get AI Solutions That Actually Work.

--- a/app/lp/smb-web-marketing/page.tsx
+++ b/app/lp/smb-web-marketing/page.tsx
@@ -3,6 +3,8 @@ import ContactForm from '@/components/ContactForm'; // Assuming ContactForm path
 import { Metadata } from 'next';
 import Image from 'next/image';
 import SocialIcons from '@/components/SocialIcons';
+import JsonLd from '@/components/JsonLd';
+import { baseUrl } from '@/app/sitemap';
 import {
   CodeBracketSquareIcon,
   ChartPieIcon,
@@ -12,15 +14,42 @@ import {
 } from '@heroicons/react/24/outline'; // Import necessary icons
 
 export const metadata: Metadata = {
-  title:
-    'Integrated Web Presence & Marketing Tech for SMBs | Anthony Coffey - Solutions Architect, AI/ML',
+  title: 'Web & Marketing Tech for Small Businesses',
   description:
-    'Expert web development (WordPress, JavaScript) combined with essential marketing tech setup (Analytics, GTM) for SMBs by Anthony Coffey, Solutions Architect & AI/ML Specialist.',
+    'Professional websites (WordPress & JavaScript) wired up with Google Analytics and Tag Manager, so your SMB can track and grow with confidence.',
+  alternates: { canonical: '/lp/smb-web-marketing' },
+  openGraph: {
+    title: 'Web & Marketing Tech for Small Businesses',
+    description:
+      'Professional websites integrated with Google Analytics and Tag Manager — built for SMB growth.',
+    url: '/lp/smb-web-marketing',
+    type: 'website',
+  },
 };
 
 export default function SmbWebMarketingLandingPage() {
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: baseUrl },
+      { '@type': 'ListItem', position: 2, name: 'SMB Web & Marketing', item: `${baseUrl}/lp/smb-web-marketing` },
+    ],
+  };
+  const service = {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: 'Web Development & Marketing Tech for Small Businesses',
+    provider: { '@type': 'Person', name: 'Anthony Coffey', url: baseUrl },
+    areaServed: 'US',
+    description:
+      'Professional websites (WordPress & JavaScript) integrated with Google Analytics and Tag Manager for SMB growth.',
+    url: `${baseUrl}/lp/smb-web-marketing`,
+  };
   return (
     <div className="container max-w-6xl mx-auto px-4 py-16">
+      <JsonLd data={breadcrumb} />
+      <JsonLd data={service} />
       <section className="text-center mb-12">
         <h1 className="text-4xl font-bold mb-4 text-c-heading">
           Stop Worrying About Your Website. Start Growing Your Business.

--- a/app/lp/sme-web-mobile/page.tsx
+++ b/app/lp/sme-web-mobile/page.tsx
@@ -3,6 +3,8 @@ import ContactForm from '@/components/ContactForm'; // Assuming ContactForm path
 import { Metadata } from 'next';
 import Image from 'next/image';
 import SocialIcons from '@/components/SocialIcons';
+import JsonLd from '@/components/JsonLd';
+import { baseUrl } from '@/app/sitemap';
 import {
   ClockIcon,
   ArrowsPointingOutIcon,
@@ -12,15 +14,42 @@ import {
 } from '@heroicons/react/24/outline'; // Import necessary icons
 
 export const metadata: Metadata = {
-  title:
-    'Custom Web & Mobile Apps for Established SMEs | Anthony Coffey - Solutions Architect, AI/ML',
+  title: 'Custom Web & Mobile Apps for SMEs',
   description:
-    'Reliable, scalable web and mobile applications built with senior-level expertise by Anthony Coffey, Solutions Architect & AI/ML Specialist, for established SMEs seeking long-term growth.',
+    'Reliable, scalable web and mobile apps built with senior-level expertise. Fractional CTO partnership for established SMEs focused on long-term growth.',
+  alternates: { canonical: '/lp/sme-web-mobile' },
+  openGraph: {
+    title: 'Custom Web & Mobile Apps for SMEs',
+    description:
+      'Reliable, scalable web and mobile apps with senior-level, Fractional-CTO-style partnership.',
+    url: '/lp/sme-web-mobile',
+    type: 'website',
+  },
 };
 
 export default function SmeWebMobileLandingPage() {
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: baseUrl },
+      { '@type': 'ListItem', position: 2, name: 'Custom Web & Mobile Apps', item: `${baseUrl}/lp/sme-web-mobile` },
+    ],
+  };
+  const service = {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: 'Custom Web & Mobile Application Development',
+    provider: { '@type': 'Person', name: 'Anthony Coffey', url: baseUrl },
+    areaServed: 'US',
+    description:
+      'Reliable, scalable web and mobile apps with Fractional CTO partnership for established SMEs.',
+    url: `${baseUrl}/lp/sme-web-mobile`,
+  };
   return (
     <div className="container max-w-6xl mx-auto px-4 py-16">
+      <JsonLd data={breadcrumb} />
+      <JsonLd data={service} />
       <section className="text-center mb-12">
         <h1 className="text-4xl font-bold mb-4 text-c-heading">
           Stop Fighting Unreliable Tech. Get Custom Apps That Fuel Growth.

--- a/app/lp/sme-web-mobile/page.tsx
+++ b/app/lp/sme-web-mobile/page.tsx
@@ -14,12 +14,12 @@ import {
 } from '@heroicons/react/24/outline'; // Import necessary icons
 
 export const metadata: Metadata = {
-  title: 'Custom Web & Mobile Apps for SMEs',
+  title: 'Custom Web & Mobile Apps for Growing SMEs',
   description:
     'Reliable, scalable web and mobile apps built with senior-level expertise. Fractional CTO partnership for established SMEs focused on long-term growth.',
   alternates: { canonical: '/lp/sme-web-mobile' },
   openGraph: {
-    title: 'Custom Web & Mobile Apps for SMEs',
+    title: 'Custom Web & Mobile Apps for Growing SMEs',
     description:
       'Reliable, scalable web and mobile apps with senior-level, Fractional-CTO-style partnership.',
     url: '/lp/sme-web-mobile',

--- a/app/lp/strategic-partners/page.tsx
+++ b/app/lp/strategic-partners/page.tsx
@@ -3,6 +3,8 @@ import ContactForm from '@/components/ContactForm'; // Assuming ContactForm path
 import { Metadata } from 'next';
 import Image from 'next/image';
 import SocialIcons from '@/components/SocialIcons';
+import JsonLd from '@/components/JsonLd';
+import { baseUrl } from '@/app/sitemap';
 import {
   BuildingLibraryIcon,
   ServerStackIcon,
@@ -12,15 +14,42 @@ import {
 } from '@heroicons/react/24/outline'; // Import necessary icons
 
 export const metadata: Metadata = {
-  title:
-    'Senior-Level Expertise for Strategic Partners | Anthony Coffey - Solutions Architect, AI/ML',
+  title: 'Fractional CTO & Tech Partner for Agencies',
   description:
-    'Augment your team with specialized expertise from Anthony Coffey, Solutions Architect & AI/ML Specialist, in software architecture, DevOps, and practical AI/ML integration. Fractional CTO & Specialist Lead services.',
+    'Senior-level expertise in architecture, DevOps, and AI integration. Fractional CTO and Specialist Lead services for agencies, startups, and tech teams.',
+  alternates: { canonical: '/lp/strategic-partners' },
+  openGraph: {
+    title: 'Fractional CTO & Tech Partner for Agencies',
+    description:
+      'Augment your team with senior architecture, DevOps, and AI expertise — Fractional CTO and Specialist Lead services.',
+    url: '/lp/strategic-partners',
+    type: 'website',
+  },
 };
 
 export default function StrategicPartnersLandingPage() {
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: baseUrl },
+      { '@type': 'ListItem', position: 2, name: 'Strategic Partners', item: `${baseUrl}/lp/strategic-partners` },
+    ],
+  };
+  const service = {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: 'Fractional CTO & Specialist Lead Services',
+    provider: { '@type': 'Person', name: 'Anthony Coffey', url: baseUrl },
+    areaServed: 'US',
+    description:
+      'Senior-level expertise in software architecture, DevOps, and practical AI/ML integration for agencies, startups, and tech teams.',
+    url: `${baseUrl}/lp/strategic-partners`,
+  };
   return (
     <div className="container max-w-6xl mx-auto px-4 py-16">
+      <JsonLd data={breadcrumb} />
+      <JsonLd data={service} />
       <section className="text-center mb-12">
         <h1 className="text-4xl font-bold mb-4 text-c-heading">
           Need Senior Expertise? Augment Your Team with a Strategic Tech

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,28 @@
+import type { Metadata } from 'next'
 import ScrollContainer from '@/components/ScrollContainer'
 
-export const metadata = {
-  title: 'Anthony Coffey — Artist. Engineer. Austin.',
+export const metadata: Metadata = {
+  title: {
+    absolute: 'Anthony Coffey — Musician, Engineer, Maker in Austin',
+  },
   description:
-    'Art is the point. Everything else is the medium. Anthony Coffey — musician, director, software engineer, problem solver. Based in Austin, TX.',
+    'Anthony Coffey is a musician, director, and software engineer in Austin, TX. Creativity is at the core of everything I build, design, and ship.',
+  alternates: { canonical: '/' },
+  openGraph: {
+    title: 'Anthony Coffey — Musician, Engineer, Maker in Austin',
+    description:
+      'Anthony Coffey is a musician, director, and software engineer in Austin, TX. Creativity is at the core of everything I build, design, and ship.',
+    url: '/',
+    type: 'website',
+    images: ['/og-image.jpg'],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Anthony Coffey — Musician, Engineer, Maker in Austin',
+    description:
+      'Anthony Coffey is a musician, director, and software engineer in Austin, TX. Creativity is at the core of everything I build, design, and ship.',
+    images: ['/og-image.jpg'],
+  },
 }
 
 export default function Page() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next'
 import ScrollContainer from '@/components/ScrollContainer'
 
-const HOME_TITLE = 'Anthony Coffey — Austin Software Engineer & AI Consultant'
+const HOME_TITLE = 'Anthony Coffey — AI Consultant & Software Engineer, Austin TX'
 const HOME_DESCRIPTION =
-  'Austin-based software engineer and AI consultant building web apps, mobile apps, and practical AI solutions. Creativity at the core of everything I ship.'
+  'Anthony Coffey is an AI consultant and software engineer in Austin, TX, building web apps, mobile apps, and practical AI solutions with creativity at the core.'
 
 export const metadata: Metadata = {
   title: { absolute: HOME_TITLE },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,26 +1,25 @@
 import type { Metadata } from 'next'
 import ScrollContainer from '@/components/ScrollContainer'
 
+const HOME_TITLE = 'Anthony Coffey — Austin Software Engineer & AI Consultant'
+const HOME_DESCRIPTION =
+  'Austin-based software engineer and AI consultant building web apps, mobile apps, and practical AI solutions. Creativity at the core of everything I ship.'
+
 export const metadata: Metadata = {
-  title: {
-    absolute: 'Anthony Coffey — Musician, Engineer, Maker in Austin',
-  },
-  description:
-    'Anthony Coffey is a musician, director, and software engineer in Austin, TX. Creativity is at the core of everything I build, design, and ship.',
+  title: { absolute: HOME_TITLE },
+  description: HOME_DESCRIPTION,
   alternates: { canonical: '/' },
   openGraph: {
-    title: 'Anthony Coffey — Musician, Engineer, Maker in Austin',
-    description:
-      'Anthony Coffey is a musician, director, and software engineer in Austin, TX. Creativity is at the core of everything I build, design, and ship.',
+    title: HOME_TITLE,
+    description: HOME_DESCRIPTION,
     url: '/',
     type: 'website',
     images: ['/og-image.jpg'],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Anthony Coffey — Musician, Engineer, Maker in Austin',
-    description:
-      'Anthony Coffey is a musician, director, and software engineer in Austin, TX. Creativity is at the core of everything I build, design, and ship.',
+    title: HOME_TITLE,
+    description: HOME_DESCRIPTION,
     images: ['/og-image.jpg'],
   },
 }

--- a/app/portfolio/layout.tsx
+++ b/app/portfolio/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Software Engineering & AI Portfolio',
+  title: 'Portfolio',
   description:
     'Selected software projects by Anthony Coffey — web apps, mobile apps, AI/ML integrations, and custom development work from an Austin software engineer.',
   alternates: { canonical: '/portfolio' },

--- a/app/portfolio/layout.tsx
+++ b/app/portfolio/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Portfolio | Anthony Coffey - Solutions Architect, AI/ML',
-  description: 'Explore a selection of software development projects by Anthony Coffey, Solutions Architect & AI/ML Specialist, showcasing expertise in web applications, AI/ML integration, and more.',
+  title: 'Portfolio',
+  description:
+    'Selected software projects by Anthony Coffey — web applications, AI/ML integrations, and custom development work.',
+  alternates: { canonical: '/portfolio' },
 };
 
 export default function PortfolioLayout({ // Renamed function for clarity

--- a/app/portfolio/layout.tsx
+++ b/app/portfolio/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Portfolio',
+  title: 'Software Engineering & AI Portfolio',
   description:
-    'Selected software projects by Anthony Coffey — web applications, AI/ML integrations, and custom development work.',
+    'Selected software projects by Anthony Coffey — web apps, mobile apps, AI/ML integrations, and custom development work from an Austin software engineer.',
   alternates: { canonical: '/portfolio' },
 };
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,19 +1,57 @@
-import { getAllBlogPosts } from '@/app/articles/utils';
+import { getAllBlogPosts, getAllCategories, getAllTags } from '@/app/articles/utils';
 
 export const baseUrl = 'https://coffey.codes';
 
-export default async function sitemap() {
-  const articles = getAllBlogPosts().map((post) => ({
+type SitemapEntry = {
+  url: string;
+  lastModified: string;
+  changeFrequency?:
+    | 'always'
+    | 'hourly'
+    | 'daily'
+    | 'weekly'
+    | 'monthly'
+    | 'yearly'
+    | 'never';
+  priority?: number;
+};
+
+export default async function sitemap(): Promise<SitemapEntry[]> {
+  const today = new Date().toISOString().split('T')[0];
+
+  const articles: SitemapEntry[] = getAllBlogPosts().map((post) => ({
     url: `${baseUrl}/articles/${post.slug}`,
     lastModified: post.metadata.publishedAt,
+    changeFrequency: 'monthly',
+    priority: 0.7,
   }));
 
-  const routes = ['/', '/contact', '/articles', '/case-studies'].map(
-    (route) => ({
-      url: `${baseUrl}${route}`,
-      lastModified: new Date().toISOString().split('T')[0],
-    }),
-  );
+  const categories: SitemapEntry[] = getAllCategories().map((category) => ({
+    url: `${baseUrl}/articles/category/${encodeURIComponent(category.toLowerCase())}`,
+    lastModified: today,
+    changeFrequency: 'weekly',
+    priority: 0.5,
+  }));
 
-  return [...routes, ...articles];
+  const tags: SitemapEntry[] = getAllTags().map((tag) => ({
+    url: `${baseUrl}/articles/tag/${encodeURIComponent(tag.toLowerCase())}`,
+    lastModified: today,
+    changeFrequency: 'weekly',
+    priority: 0.4,
+  }));
+
+  const staticRoutes: SitemapEntry[] = [
+    { url: `${baseUrl}/`, lastModified: today, changeFrequency: 'weekly', priority: 1.0 },
+    { url: `${baseUrl}/articles`, lastModified: today, changeFrequency: 'weekly', priority: 0.9 },
+    { url: `${baseUrl}/articles/categories`, lastModified: today, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${baseUrl}/articles/tags`, lastModified: today, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${baseUrl}/portfolio`, lastModified: today, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${baseUrl}/contact`, lastModified: today, changeFrequency: 'yearly', priority: 0.7 },
+    { url: `${baseUrl}/lp/practical-ai`, lastModified: today, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${baseUrl}/lp/smb-web-marketing`, lastModified: today, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${baseUrl}/lp/sme-web-mobile`, lastModified: today, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${baseUrl}/lp/strategic-partners`, lastModified: today, changeFrequency: 'monthly', priority: 0.8 },
+  ];
+
+  return [...staticRoutes, ...articles, ...categories, ...tags];
 }

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -67,7 +67,7 @@ export default function ContactForm() {
                     `An error occurred: ${response.statusText} (${response.status})`,
                 );
               }
-            } catch (error) {
+            } catch {
               setApiError(
                 'An error occurred while sending your message, please try again.',
               );

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,8 @@
+export default function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/components/LayoutShell.tsx
+++ b/components/LayoutShell.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Navbar from './Navbar';
+import { LandingPageHeader } from './LandingPageHeader';
+import GoogleAnalyticsClient from './GoogleAnalyticsClient';
+import Footer from './Footer';
+import ConsentManager from './ConsentManager';
+import { ThemeProvider } from './ThemeProvider';
+
+export default function LayoutShell({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const isLandingPage = pathname === '/lp' || pathname?.startsWith('/lp/');
+  const isHomePage = pathname === '/';
+
+  return (
+    <ThemeProvider
+      attribute="data-theme"
+      defaultTheme="light"
+      storageKey="theme"
+    >
+      <ConsentManager />
+      <GoogleAnalyticsClient />
+
+      {isLandingPage ? <LandingPageHeader /> : <Navbar />}
+
+      <main>{children}</main>
+
+      {!isLandingPage && !isHomePage && <Footer />}
+    </ThemeProvider>
+  );
+}

--- a/components/canvas/objects/Planet.tsx
+++ b/components/canvas/objects/Planet.tsx
@@ -195,7 +195,7 @@ export default function Planet({ scrollProgress }: PlanetProps) {
     }
   })
 
-  const handleBeforeCompile = (shader: any) => {
+  const handleBeforeCompile = (shader: THREE.WebGLProgramParametersWithUniforms) => {
     if (planetMatRef.current) {
       planetMatRef.current.userData.shader = shader
     }

--- a/components/overlay/IntroOverlay.tsx
+++ b/components/overlay/IntroOverlay.tsx
@@ -10,11 +10,11 @@ interface IntroOverlayProps {
 export default function IntroOverlay({ visible }: IntroOverlayProps) {
   return (
     <div className={`${styles.introPanel} ${visible ? styles.visible : ''}`}>
-      <p className={styles.leadLine}>
+      <h1 className={styles.leadLine}>
         👨‍🚀
         <br />
         Who Am I?
-      </p>
+      </h1>
       <p className={styles.byline}>Anthony Coffey - Austin, Texas</p>
 
       <div className={styles.socialLinks}>

--- a/e2e/articles.spec.ts
+++ b/e2e/articles.spec.ts
@@ -10,8 +10,6 @@ test.describe('Articles index', () => {
   })
 
   test('renders at least one article card', async ({ page }) => {
-    const articles = page.locator('[data-testid="blog-post"], article, .article-card, h2 a[href^="/articles/"]').first()
-    // Fall back to any link pointing at an article slug
     const articleLink = page.locator('a[href^="/articles/"]').first()
     await expect(articleLink).toBeVisible()
   })

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 
 // Must match the SCROLL_MULTIPLIER constant in ScrollContainer.tsx
 const SCROLL_MULTIPLIER = 6
@@ -12,18 +12,17 @@ const totalScroll = (vh: number) => (SCROLL_MULTIPLIER - 1) * vh
 // present on the panel container.  The class appears in the compiled attribute as a
 // substring (e.g. "__visible"), so a /visible/ regex match is reliable.
 const panels = {
-  intro: (page: any) => page.locator('[class*="introPanel"]').first(),
-  final: (page: any) => page.locator('[class*="introPanel"]').last(),
-  about: (page: any) => page.locator('[class*="hudPanel"]').first(),
-  craft: (page: any) => page.locator('[class*="hudPanel"]').last(),
+  intro: (page: Page) => page.locator('[class*="introPanel"]').first(),
+  final: (page: Page) => page.locator('[class*="introPanel"]').last(),
+  about: (page: Page) => page.locator('[class*="hudPanel"]').first(),
+  craft: (page: Page) => page.locator('[class*="hudPanel"]').last(),
 }
 
 const isShowing  = /visible/
-const isHidden   = expect.not
 
 // Brings the page to front (prevents Chrome from throttling RAF in parallel workers)
 // then scrolls and waits for GSAP + React to process the new position.
-async function scrollTo(page: any, fraction: number) {
+async function scrollTo(page: Page, fraction: number) {
   await page.bringToFront()
   const vh = page.viewportSize()!.height
   const y = fraction * totalScroll(vh)


### PR DESCRIPTION
## Summary

Full on-page technical SEO overhaul plus lint + CI hygiene. No spec file — one-off audit.

**Infrastructure**
- Root layout converted to a Server Component so it can export metadata; pathname-dependent logic moved into a new `LayoutShell` client child
- Global `metadataBase`, `title.template`, default OpenGraph/Twitter, icons, manifest, robots, and `viewport` exports
- Reusable `JsonLd` component; site-wide `Person` + `WebSite` (with `SearchAction`) schema emitted in the body
- Sitemap expanded from 4 routes to full coverage: `/portfolio`, all 4 `/lp/*`, `/articles/categories`, `/articles/tags`, per-category + per-tag pages, with `changeFrequency` and `priority`
- `/articles/search` and `/case-studies` (redirects to `/`) marked `robots: noindex`

**Titles + descriptions (rewritten sitewide)**
- Home: `Anthony Coffey — AI Consultant & Software Engineer, Austin TX` — leads with the two highest-intent keyword phrases, includes city + state
- Articles: `Articles by Anthony Coffey` (absolute, avoids double brand)
- Index pages (Portfolio, Case Studies, Contact, Articles Categories, Articles Tags, Search): simple `<Page> | Anthony Coffey` via root template
- Landing pages: keyword-rich value props for each ICP (Practical AI, SMB web/marketing, SME web+mobile, strategic partners)
- Every page now has `alternates.canonical`
- Homepage `<p>` overlay lead promoted to semantic `<h1>`

**Structured data**
- `BreadcrumbList` + enriched `BlogPosting` (publisher, mainEntityOfPage) on articles
- `BreadcrumbList` + `Service` schema on each landing page

**Tooling**
- Fixed all 33 pre-existing ESLint errors (test mock casts, Planet shader type, unused vars, Playwright typing)
- New `ESLint` job in `.github/workflows/test.yml` runs on every PR to master — lint failures now block merges

## Commits

Atomic, dependency-ordered:
1. `chore: fix existing lint errors`
2. `ci: enforce eslint on pull requests`
3. `feat: add global SEO metadata and structured data to root layout`
4. `feat: rewrite homepage meta and promote overlay lead to h1`
5. `feat: rewrite article and content page meta with canonicals`
6. `feat: rewrite landing page meta and add service/breadcrumb schema`
7. `feat: expand sitemap with portfolio, landing pages, and taxonomies`
8. `feat: optimize page titles for software engineering search terms`
9. `feat: simplify index page titles and lead home with AI consultant keyword`

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run build` — all 163 pages generate cleanly
- [x] `npm test` — 170/170 unit tests pass
- [ ] `npm run dev` — spot-check `/`, `/articles`, `/articles/[slug]`, `/portfolio`, `/contact`, `/lp/practical-ai`; confirm 3D scroll still works and no hydration mismatch
- [ ] View-source each route: unique `<title>`, 140–160 char description, `<link rel=canonical>`, OG + Twitter tags present
- [ ] Paste rendered HTML from `/`, `/articles/[slug]`, and one `/lp/*` into https://validator.schema.org/ — all schemas validate
- [ ] `curl /robots.txt` and `/sitemap.xml` — new routes present, noindex pages absent from sitemap
- [ ] Lighthouse SEO score = 100 on `/`, `/articles`, `/articles/[slug]`, `/contact`, `/lp/practical-ai`