### PR TITLE
fix: resolve Three.js shader type error in spaceship component

### DIFF
--- a/components/canvas/objects/Spaceship.tsx
+++ b/components/canvas/objects/Spaceship.tsx
@@ -31,7 +31,7 @@ function lerp(a: number, b: number, t: number) {
   return a + (b - a) * t;
 }
 
-const customGrungeShader = (shader: THREE.Shader) => {
+const customGrungeShader = (shader: { vertexShader: string; fragmentShader: string; [key: string]: any }) => {
   shader.vertexShader = `
     varying vec3 vWorldPosition;
     ${shader.vertexShader}

--- a/components/canvas/objects/Spaceship.tsx
+++ b/components/canvas/objects/Spaceship.tsx
@@ -31,7 +31,7 @@ function lerp(a: number, b: number, t: number) {
   return a + (b - a) * t;
 }
 
-const customGrungeShader = (shader: { vertexShader: string; fragmentShader: string; [key: string]: any }) => {
+const customGrungeShader = (shader: { vertexShader: string; fragmentShader: string }) => {
   shader.vertexShader = `
     varying vec3 vWorldPosition;
     ${shader.vertexShader}


### PR DESCRIPTION
Resolves the Next.js build error related to the missing `THREE.Shader` type in the `Spaceship` component.