### PR TITLE
feat: homepage optimization + e2e against vercel previews

### DIFF
--- a/.github/workflows/e2e-preview.yml
+++ b/.github/workflows/e2e-preview.yml
@@ -1,0 +1,45 @@
+name: E2E (Vercel Preview)
+
+on:
+  deployment_status:
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  e2e:
+    name: Playwright
+    if: github.event.deployment_status.state == 'success' && github.event.deployment.environment != 'Production'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.deployment.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests against preview
+        run: npx playwright test --project=chromium
+        env:
+          CI: true
+          PLAYWRIGHT_BASE_URL: ${{ github.event.deployment_status.target_url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,40 +62,9 @@ jobs:
       - name: Run typecheck
         run: npm run typecheck
 
-  e2e:
-    name: Playwright
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
-      - name: Run E2E tests
-        run: npx playwright test --project=chromium
-        env:
-          CI: true
-
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 7
-
   notify:
     name: Notify Vercel
-    needs: [lint, unit, typecheck, e2e]
+    needs: [lint, unit, typecheck]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/__tests__/components/Loader.test.tsx
+++ b/__tests__/components/Loader.test.tsx
@@ -1,0 +1,78 @@
+import { render, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Loader from '@/components/Loader'
+
+describe('Loader', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0)
+      return 0
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('renders initially with the loading overlay visible', () => {
+    const { container } = render(<Loader />)
+    const overlay = container.firstChild as HTMLElement
+    expect(overlay).toHaveClass('opacity-100')
+    expect(overlay).not.toHaveClass('opacity-0')
+  })
+
+  it('types out "Please wait..." character by character', () => {
+    const { getByText, queryByText } = render(<Loader />)
+
+    // Initially, text is empty
+    expect(queryByText('Please wait...')).not.toBeInTheDocument()
+
+    // Fast-forward 500ms -> should have typed "Pleas"
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(getByText(/Pleas/)).toBeInTheDocument()
+
+    // Fast-forward past the total typing time (14 chars * 100ms = 1400ms)
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(getByText(/Please wait\.\.\./)).toBeInTheDocument()
+  })
+
+  it('toggles cursor from solid to blinking after typing completes', () => {
+    const { container } = render(<Loader />)
+    const cursor = container.querySelector('span')
+    
+    // Initially solid (no animate-blink class)
+    expect(cursor).not.toHaveClass('animate-blink')
+
+    // Fast forward past typing completion (1400ms+)
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    // Now it should blink
+    expect(cursor).toHaveClass('animate-blink')
+  })
+
+  it('fades out completely after 2600ms', () => {
+    const { container } = render(<Loader />)
+    const overlay = container.firstChild as HTMLElement
+
+    // Before timeout
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(overlay).toHaveClass('opacity-100')
+
+    // After timeout
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+    expect(overlay).toHaveClass('opacity-0')
+    expect(overlay).toHaveClass('pointer-events-none')
+  })
+})

--- a/__tests__/components/Loader.test.tsx
+++ b/__tests__/components/Loader.test.tsx
@@ -19,27 +19,28 @@ describe('Loader', () => {
   it('renders initially with the loading overlay visible', () => {
     const { container } = render(<Loader />)
     const overlay = container.firstChild as HTMLElement
-    expect(overlay).toHaveClass('opacity-100')
-    expect(overlay).not.toHaveClass('opacity-0')
+    // The component uses 'loading' class initially and slides up when done
+    expect(overlay).toHaveClass('loading')
+    expect(overlay).not.toHaveClass('-translate-y-full')
   })
 
-  it('types out "Please wait..." character by character', () => {
+  it('types out "LOADING..." character by character', () => {
     const { getByText, queryByText } = render(<Loader />)
 
     // Initially, text is empty
-    expect(queryByText('Please wait...')).not.toBeInTheDocument()
+    expect(queryByText('LOADING...')).not.toBeInTheDocument()
 
-    // Fast-forward 500ms -> should have typed "Pleas"
+    // Fast-forward 250ms (5 chars at 50ms each) -> should have typed "LOADI"
     act(() => {
-      vi.advanceTimersByTime(500)
+      vi.advanceTimersByTime(250)
     })
-    expect(getByText(/Pleas/)).toBeInTheDocument()
+    expect(getByText(/LOADI/)).toBeInTheDocument()
 
-    // Fast-forward past the total typing time (14 chars * 100ms = 1400ms)
+    // Fast-forward past the total typing time (10 chars * 50ms = 500ms)
     act(() => {
-      vi.advanceTimersByTime(1000)
+      vi.advanceTimersByTime(300)
     })
-    expect(getByText(/Please wait\.\.\./)).toBeInTheDocument()
+    expect(getByText(/LOADING\.\.\./)).toBeInTheDocument()
   })
 
   it('toggles cursor from solid to blinking after typing completes', () => {
@@ -49,30 +50,30 @@ describe('Loader', () => {
     // Initially solid (no animate-blink class)
     expect(cursor).not.toHaveClass('animate-blink')
 
-    // Fast forward past typing completion (1400ms+)
+    // Fast forward past typing completion (500ms+)
     act(() => {
-      vi.advanceTimersByTime(1500)
+      vi.advanceTimersByTime(600)
     })
 
     // Now it should blink
     expect(cursor).toHaveClass('animate-blink')
   })
 
-  it('fades out completely after 2600ms', () => {
+  it('slides out completely after 2750ms', () => {
     const { container } = render(<Loader />)
     const overlay = container.firstChild as HTMLElement
 
-    // Before timeout
+    // Before timeout (e.g. 2500ms)
     act(() => {
-      vi.advanceTimersByTime(2000)
+      vi.advanceTimersByTime(2500)
     })
-    expect(overlay).toHaveClass('opacity-100')
+    expect(overlay).toHaveClass('loading')
 
-    // After timeout
+    // After timeout (2750ms total)
     act(() => {
-      vi.advanceTimersByTime(700)
+      vi.advanceTimersByTime(300)
     })
-    expect(overlay).toHaveClass('opacity-0')
+    expect(overlay).toHaveClass('-translate-y-full')
     expect(overlay).toHaveClass('pointer-events-none')
   })
 })

--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -4,6 +4,7 @@ export default function Loader() {
   const [loading, setLoading] = useState(true);
   const [progress, setProgress] = useState(0);
   const [text, setText] = useState('');
+  const [isTyping, setIsTyping] = useState(true);
 
   useEffect(() => {
     const fullText = 'Please wait...';
@@ -11,7 +12,10 @@ export default function Loader() {
     const typeInterval = setInterval(() => {
       setText(fullText.substring(0, i + 1));
       i++;
-      if (i >= fullText.length) clearInterval(typeInterval);
+      if (i >= fullText.length) {
+        clearInterval(typeInterval);
+        setIsTyping(false);
+      }
     }, 100);
 
     requestAnimationFrame(() => {
@@ -37,7 +41,7 @@ export default function Loader() {
       <div className="w-64 space-y-4">
         <div className="font-mono text-xl text-[#FFCC00]">
           {text}
-          <span className="animate-pulse">█</span>
+          <span className={isTyping ? '' : 'animate-pulse'}>█</span>
         </div>
         <div className="h-1 w-full overflow-hidden rounded-full bg-zinc-900 shadow-[0_0_10px_#FFCC00]">
           <div

--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+export default function Loader() {
+  const [loading, setLoading] = useState(true);
+  const [progress, setProgress] = useState(0);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    const fullText = 'Please wait...';
+    let i = 0;
+    const typeInterval = setInterval(() => {
+      setText(fullText.substring(0, i + 1));
+      i++;
+      if (i >= fullText.length) clearInterval(typeInterval);
+    }, 100);
+
+    requestAnimationFrame(() => {
+      setTimeout(() => setProgress(100), 100);
+    });
+
+    const timeout = setTimeout(() => {
+      setLoading(false);
+    }, 2600);
+
+    return () => {
+      clearInterval(typeInterval);
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex flex-col items-center justify-center bg-black transition-opacity duration-1000 ease-in-out ${
+        loading ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      }`}
+    >
+      <div className="w-64 space-y-4">
+        <div className="font-mono text-xl text-[#FFCC00]">
+          {text}
+          <span className="animate-pulse">█</span>
+        </div>
+        <div className="h-1 w-full overflow-hidden rounded-full bg-zinc-900 shadow-[0_0_10px_#FFCC00]">
+          <div
+            className="h-full bg-[#FFCC00] shadow-[0_0_10px_#FFCC00] transition-all duration-[2500ms] ease-out"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -41,7 +41,7 @@ export default function Loader() {
       <div className="w-64 space-y-4">
         <div className="font-mono text-xl text-[#FFCC00]">
           {text}
-          <span className={isTyping ? '' : 'animate-pulse'}>█</span>
+          <span className={isTyping ? '' : 'animate-blink'}>█</span>
         </div>
         <div className="h-1 w-full overflow-hidden rounded-full bg-zinc-900 shadow-[0_0_10px_#FFCC00]">
           <div

--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -7,7 +7,7 @@ export default function Loader() {
   const [isTyping, setIsTyping] = useState(true);
 
   useEffect(() => {
-    const fullText = 'Please wait...';
+    const fullText = 'LOADING...';
     let i = 0;
     const typeInterval = setInterval(() => {
       setText(fullText.substring(0, i + 1));
@@ -16,7 +16,7 @@ export default function Loader() {
         clearInterval(typeInterval);
         setIsTyping(false);
       }
-    }, 100);
+    }, 50);
 
     requestAnimationFrame(() => {
       setTimeout(() => setProgress(100), 100);
@@ -24,7 +24,7 @@ export default function Loader() {
 
     const timeout = setTimeout(() => {
       setLoading(false);
-    }, 2600);
+    }, 2750);
 
     return () => {
       clearInterval(typeInterval);
@@ -34,8 +34,8 @@ export default function Loader() {
 
   return (
     <div
-      className={`fixed inset-0 z-50 flex flex-col items-center justify-center bg-black transition-opacity duration-1000 ease-in-out ${
-        loading ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      className={`fixed inset-0 z-50 flex flex-col items-center justify-center bg-black opacity-80 transition-transform duration-200 ease-in-out ${
+        loading ? 'loading' : '-translate-y-full pointer-events-none'
       }`}
     >
       <div className="w-64 space-y-4">

--- a/components/ScrollContainer.tsx
+++ b/components/ScrollContainer.tsx
@@ -5,6 +5,7 @@ import { gsap } from 'gsap'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
 import dynamic from 'next/dynamic'
 import HUDOverlay from '@/components/overlay/HUDOverlay'
+import Loader from '@/components/Loader'
 import styles from '@/app/page.module.sass'
 
 // WorldCanvas is browser-only (WebGL) — skip SSR
@@ -63,6 +64,7 @@ export default function ScrollContainer() {
       >
         <WorldCanvas scrollProgress={scrollProgress} />
         <HUDOverlay scrollProgress={scrollProgress} />
+        <Loader />
       </div>
     </div>
   )

--- a/components/canvas/CameraRig.tsx
+++ b/components/canvas/CameraRig.tsx
@@ -27,7 +27,7 @@ const KEYFRAMES = [
   { t: 0.52, pos: [0, 3, -28] as const, lookAt: [0, -5, -55] as const }, // After UFO — subtle tilt, planet arc appears
   { t: 0.68, pos: [0, 3, -38] as const, lookAt: [0, -5, -62] as const }, // HOLD — craft + satellite (planet stays in frame)
   { t: 0.82, pos: [0, 2, -48] as const, lookAt: [0, 0, -72] as const }, // Level — galaxy incoming
-  { t: 1.0, pos: [0, 1, -56] as const, lookAt: [0, 0, -80] as const }, // Galaxy center-frame
+  { t: 1.0, pos: [0, 1, -73] as const, lookAt: [0, 0, -80] as const }, // Galaxy center-frame
 ];
 
 const KF_POS = KEYFRAMES.map((k) => new THREE.Vector3(...k.pos));

--- a/components/canvas/CameraRig.tsx
+++ b/components/canvas/CameraRig.tsx
@@ -27,7 +27,7 @@ const KEYFRAMES = [
   { t: 0.52, pos: [0, 3, -28] as const, lookAt: [0, -5, -55] as const }, // After UFO — subtle tilt, planet arc appears
   { t: 0.68, pos: [0, 3, -38] as const, lookAt: [0, -5, -62] as const }, // HOLD — craft + satellite (planet stays in frame)
   { t: 0.82, pos: [0, 2, -48] as const, lookAt: [0, 0, -72] as const }, // Level — galaxy incoming
-  { t: 1.0, pos: [0, 1, -73] as const, lookAt: [0, 0, -80] as const }, // Galaxy center-frame
+  { t: 1.0, pos: [0, 1, -72] as const, lookAt: [0, 0, -80] as const }, // Galaxy center-frame
 ];
 
 const KF_POS = KEYFRAMES.map((k) => new THREE.Vector3(...k.pos));

--- a/components/canvas/WorldCanvas.tsx
+++ b/components/canvas/WorldCanvas.tsx
@@ -215,7 +215,7 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
             intensity={1.5}
             mipmapBlur
             radius={0.85}
-            levels={9}
+            levels={5}
           />
           <Vignette eskil={false} offset={0.3} darkness={0.55} />
         </EffectComposer>

--- a/components/canvas/WorldCanvas.tsx
+++ b/components/canvas/WorldCanvas.tsx
@@ -118,7 +118,7 @@ function ParticleSystem({ scrollProgress }: ParticleSystemProps) {
     mat.opacity = (1 - disperse) * 0.75;
 
     // ── Color/Bloom: over-bright when dense, dimming as it spreads ───
-    const glowIntensity = 0.2 + (1 - disperse) * 2;
+    const glowIntensity = 0.02 + (1 - disperse) * 2;
     mat.color.copy(BASE_COLOR).multiplyScalar(glowIntensity);
 
     // ── Rotation: spin while formed; stop once exploded ────────

--- a/components/canvas/objects/Galaxy.tsx
+++ b/components/canvas/objects/Galaxy.tsx
@@ -457,11 +457,11 @@ export default function Galaxy({ scrollProgress }: GalaxyProps) {
 
       {/* Galactic core — glowing sun (lighter tint) */}
       <mesh>
-        <sphereGeometry args={[2, 16, 16]} />
+        <sphereGeometry args={[2.2, 16, 16]} />
         <meshStandardMaterial
           color="#fffde0"
           emissive="#ffe895"
-          emissiveIntensity={1.1}
+          emissiveIntensity={2}
           toneMapped={true}
         />
       </mesh>

--- a/components/canvas/objects/Planet.tsx
+++ b/components/canvas/objects/Planet.tsx
@@ -130,7 +130,7 @@ const NOISE_GLSL = `
     float v = 0.0;
     float a = 0.5;
     vec3 shift = vec3(100.0);
-    for (int i = 0; i < 6; ++i) {
+    for (int i = 0; i < 4; ++i) {
       v += a * snoise(x);
       x = x * 2.0 + shift;
       a *= 0.5;
@@ -274,7 +274,7 @@ export default function Planet({ scrollProgress }: PlanetProps) {
         Zero vertex displacement. Beautiful, mathematically generated swirling cloud bands.
       */}
       <mesh ref={meshRef}>
-        <sphereGeometry args={[20, 128, 128]} />
+        <sphereGeometry args={[20, 64, 64]} />
         <meshStandardMaterial
           ref={planetMatRef}
           roughness={0.6} // Gas giants are relatively smooth/matte

--- a/components/canvas/objects/Spaceship.tsx
+++ b/components/canvas/objects/Spaceship.tsx
@@ -265,30 +265,30 @@ export default function Spaceship({ scrollProgress }: SpaceshipProps) {
 
       <mesh position={[0, 0, -1.8]} rotation={[-Math.PI / 2, 0, 0]}>
         <coneGeometry args={[0.4, 2.8, 16]} />
-        <meshPhysicalMaterial color="#ffffff" metalness={0.9} roughness={0.1} clearcoat={1.0} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial color="#ffffff" metalness={0.9} roughness={0.1} onBeforeCompile={customGrungeShader} />
       </mesh>
 
       <mesh position={[0, 0, 0.3]} rotation={[-Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.4, 0.5, 1.8, 16]} />
-        <meshPhysicalMaterial color="#ffffff" metalness={0.9} roughness={0.1} clearcoat={1.0} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial color="#ffffff" metalness={0.9} roughness={0.1} onBeforeCompile={customGrungeShader} />
       </mesh>
 
       <mesh position={[-1.6, -0.05, 0.4]} rotation={[0, 0.4, 0]}>
         <boxGeometry args={[2.5, 0.08, 1.5]} />
-        <meshPhysicalMaterial color="#f0f0f0" metalness={0.8} roughness={0.15} clearcoat={1.0} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial color="#f0f0f0" metalness={0.8} roughness={0.15} onBeforeCompile={customGrungeShader} />
       </mesh>
       <mesh position={[1.6, -0.05, 0.4]} rotation={[0, -0.4, 0]}>
         <boxGeometry args={[2.5, 0.08, 1.5]} />
-        <meshPhysicalMaterial color="#f0f0f0" metalness={0.8} roughness={0.15} clearcoat={1.0} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial color="#f0f0f0" metalness={0.8} roughness={0.15} onBeforeCompile={customGrungeShader} />
       </mesh>
 
       <mesh position={[-2.7, 0.2, 0.8]} rotation={[0, 0, 0.2]}>
         <boxGeometry args={[0.06, 0.6, 1.2]} />
-        <meshPhysicalMaterial color="#ff3333" metalness={0.6} roughness={0.2} clearcoat={0.8} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial color="#ff3333" metalness={0.6} roughness={0.2} onBeforeCompile={customGrungeShader} />
       </mesh>
       <mesh position={[2.7, 0.2, 0.8]} rotation={[0, 0, -0.2]}>
         <boxGeometry args={[0.06, 0.6, 1.2]} />
-        <meshPhysicalMaterial color="#ff3333" metalness={0.6} roughness={0.2} clearcoat={0.8} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial color="#ff3333" metalness={0.6} roughness={0.2} onBeforeCompile={customGrungeShader} />
       </mesh>
 
       <mesh position={[0, 0.25, -0.5]} scale={[0.6, 0.4, 1.4]}>
@@ -298,20 +298,20 @@ export default function Spaceship({ scrollProgress }: SpaceshipProps) {
 
       <mesh position={[-0.65, -0.05, 0.8]} rotation={[Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.22, 0.28, 1.4, 12]} />
-        <meshPhysicalMaterial color="#e0e0e0" metalness={0.95} roughness={0.1} clearcoat={1.0} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial color="#e0e0e0" metalness={0.95} roughness={0.1} onBeforeCompile={customGrungeShader} />
       </mesh>
       <mesh position={[0.65, -0.05, 0.8]} rotation={[Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.22, 0.28, 1.4, 12]} />
-        <meshPhysicalMaterial color="#e0e0e0" metalness={0.95} roughness={0.1} clearcoat={1.0} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial color="#e0e0e0" metalness={0.95} roughness={0.1} onBeforeCompile={customGrungeShader} />
       </mesh>
 
       <mesh position={[-0.65, -0.05, 1.5]} rotation={[Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.26, 0.22, 0.2, 12]} />
-        <meshPhysicalMaterial color="#111" metalness={0.9} roughness={0.9} />
+        <meshStandardMaterial color="#111" metalness={0.9} roughness={0.9} />
       </mesh>
       <mesh position={[0.65, -0.05, 1.5]} rotation={[Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.26, 0.22, 0.2, 12]} />
-        <meshPhysicalMaterial color="#111" metalness={0.9} roughness={0.9} />
+        <meshStandardMaterial color="#111" metalness={0.9} roughness={0.9} />
       </mesh>
 
       <mesh position={[-0.65, -0.05, 1.51]} rotation={[Math.PI / 2, 0, 0]}>
@@ -325,11 +325,11 @@ export default function Spaceship({ scrollProgress }: SpaceshipProps) {
 
       <mesh position={[-2.2, -0.05, -0.4]} rotation={[Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.03, 0.04, 1.2, 8]} />
-        <meshPhysicalMaterial color="#222" metalness={0.8} roughness={0.6} />
+        <meshStandardMaterial color="#222" metalness={0.8} roughness={0.6} />
       </mesh>
       <mesh position={[2.2, -0.05, -0.4]} rotation={[Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.03, 0.04, 1.2, 8]} />
-        <meshPhysicalMaterial color="#222" metalness={0.8} roughness={0.6} />
+        <meshStandardMaterial color="#222" metalness={0.8} roughness={0.6} />
       </mesh>
 
       <mesh position={[-2.75, -0.05, -0.2]}>
@@ -343,11 +343,11 @@ export default function Spaceship({ scrollProgress }: SpaceshipProps) {
 
       <mesh position={[-0.3, 0.2, 0.2]}>
         <boxGeometry args={[0.1, 0.1, 1.0]} />
-        <meshPhysicalMaterial color="#111" metalness={0.9} roughness={0.8} />
+        <meshStandardMaterial color="#111" metalness={0.9} roughness={0.8} />
       </mesh>
       <mesh position={[0.3, 0.2, 0.2]}>
         <boxGeometry args={[0.1, 0.1, 1.0]} />
-        <meshPhysicalMaterial color="#111" metalness={0.9} roughness={0.8} />
+        <meshStandardMaterial color="#111" metalness={0.9} roughness={0.8} />
       </mesh>
     </group>
   );

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -53,11 +53,11 @@
   font-family: var(--font-outfit), sans-serif
   font-size: clamp(3.5rem, 5vw, 4rem)
   font-weight: 700
-  line-height: 1.15
+  line-height: 1
   color: #f0f0ff
   margin: 0
-  text-shadow: #000000 0px 0 10px;
-  letter-spacing: -0.02em
+  text-shadow: #2B2B2B 1px 0px 3px;
+  letter-spacing: -0.04em
   
 
 .byline
@@ -72,7 +72,7 @@
   font-family: var(--font-outfit), sans-serif
   font-size: clamp(1.5rem, 2vw, 1.5rem)
   font-weight: 400
-  line-height: 1.7
+  line-height: 1.15
   color: #FFCC00
   margin: 0
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const externalBaseURL = process.env.PLAYWRIGHT_BASE_URL
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+
 export default defineConfig({
   timeout: 120000,
   testDir: './e2e',
@@ -9,8 +12,11 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'list',
   use: {
-    baseURL: 'http://127.0.0.1:3000',
+    baseURL: externalBaseURL ?? 'http://127.0.0.1:3000',
     trace: 'on-first-retry',
+    extraHTTPHeaders: bypassSecret
+      ? { 'x-vercel-protection-bypass': bypassSecret }
+      : undefined,
   },
   projects: [
     {
@@ -22,10 +28,12 @@ export default defineConfig({
       use: { ...devices['Desktop Firefox'] },
     },
   ],
-  webServer: {
-    command: 'NEXT_TELEMETRY_DISABLED=1 npm run dev -- -H 127.0.0.1 -p 3000 --turbo',
-    url: 'http://127.0.0.1:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000,
-  },
+  webServer: externalBaseURL
+    ? undefined
+    : {
+        command: 'NEXT_TELEMETRY_DISABLED=1 npm run dev -- -H 127.0.0.1 -p 3000 --turbo',
+        url: 'http://127.0.0.1:3000',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120000,
+      },
 })


### PR DESCRIPTION
## Summary
- Loading overlay, canvas perf tweaks, and visual polish across the homepage scene (loader, galaxy glow, merkaba, spaceship, planet, overlay text).
- Unit tests for the Loader component.
- CI: e2e now runs against the Vercel preview deployment via a new `deployment_status`-triggered workflow. Playwright config accepts `PLAYWRIGHT_BASE_URL` and forwards a Vercel protection bypass header when provided.

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm test` passes (Loader unit tests)
- [ ] `npm run typecheck` passes
- [ ] Vercel preview builds successfully
- [ ] After merge to master, open a follow-up PR and confirm the `E2E (Vercel Preview) / Playwright` check runs against the preview URL
- [ ] Manually smoke-test the homepage scene in the preview deployment