### PR TITLE
feat: add sci-fi Table of Contents and scroll prompts to HUD overlay

### DIFF
--- a/__tests__/components/Loader.test.tsx
+++ b/__tests__/components/Loader.test.tsx
@@ -59,19 +59,19 @@ describe('Loader', () => {
     expect(cursor).toHaveClass('animate-blink')
   })
 
-  it('slides out completely after 2750ms', () => {
+  it('slides out completely after 2000ms', () => {
     const { container } = render(<Loader />)
     const overlay = container.firstChild as HTMLElement
 
-    // Before timeout (e.g. 2500ms)
+    // Before timeout (e.g. 1500ms)
     act(() => {
-      vi.advanceTimersByTime(2500)
+      vi.advanceTimersByTime(1500)
     })
     expect(overlay).toHaveClass('loading')
 
-    // After timeout (2750ms total)
+    // After timeout (2000ms total)
     act(() => {
-      vi.advanceTimersByTime(300)
+      vi.advanceTimersByTime(500)
     })
     expect(overlay).toHaveClass('-translate-y-full')
     expect(overlay).toHaveClass('pointer-events-none')

--- a/app/articles/posts/production-grade-ci-cd-with-nextjs-vercel-and-github-actions.mdx
+++ b/app/articles/posts/production-grade-ci-cd-with-nextjs-vercel-and-github-actions.mdx
@@ -16,9 +16,15 @@ This guide is the story of how I built a production-grade CI/CD pipeline, the pi
 
 ## The Stack & The Goal
 
-Our stack relies on **Next.js, TypeScript, GitHub Actions, Vercel, Vitest, and Playwright**.
+Our stack relies on:
+- Next.js
+- TypeScript
+- GitHub Actions
+- Vercel
+- Vitest
+- Playwright
 
-The goal was to enforce strict gates. A PR should not be allowed to merge unless **every** check is green. This meant linting, unit tests, strict type-checking, and most importantly, running our Playwright E2E tests against a real deployed environment, rather than a mocked-up `next dev` server on a CI runner.
+The goal was to enforce strict gates. A PR should not be allowed to merge unless every check is green. This meant linting, unit tests, strict type-checking, and most importantly, running our Playwright E2E tests against a real deployed environment, rather than a mocked-up `next dev` server on a CI runner.
 
 ## Step 1: The First Line of Defense (The PR Workflow)
 
@@ -50,17 +56,21 @@ jobs:
 
 Previously, I would build the Next.js app on the GitHub runner, spin it up locally, and run Playwright against that local instance. It was painfully slow, but more importantly, it was fundamentally flawed! It didn't test the actual edge network, serverless functions, or the caching layer that production uses.
 
-Then came the realization: **Vercel is already building a Preview Deployment for every PR.** Why build it twice?
+I thought to myself, "Wait a minute... If Vercel is already building a Preview Deployment for every PR... Why build it twice?" 🤔
 
 So I decided to leverage Vercel's Preview Deployments as the environment for our E2E tests, and this approach provides more confidence that the code is production-ready since our tests run against the actual deployment.
 
 By moving my E2E tests to run against the Vercel Preview, I cut out the build step entirely. This saved ~2–3 minutes per PR _and_ made the test runs more trustworthy because it was hitting a real edge runtime.
 
-To enforce this, I went into GitHub's Branch Protection Rules and required deployments to succeed, specifically checking the **`Preview`** environment.
+To enforce this, I went into GitHub's Branch Protection Rules and required deployments to succeed, specifically checking the `Preview` environment.
 
-<Callout>Only `Preview` worked, and that's a feature, not a bug.</Callout>
+<Callout>
 
-GitHub Branch Protection's "Require deployments to succeed" dropdown lists several Vercel environment names (Production, Preview, etc.). In practice, **`Preview` is the one you want**. The other names never turn green in a PR context because PRs don't trigger production deploys. Selecting only `Preview` aligned perfectly with our strategy to test the artifact Vercel is about to serve.
+Only `Preview` worked, and that's a feature, not a bug. GitHub Branch Protection's "Require deployments to succeed" dropdown lists several Vercel environment names (Production, Preview, etc.). In practice, `Preview` is the one you want. 
+
+The other names never turn green in a PR context because PRs don't trigger production deploys. Selecting only `Preview` aligned perfectly with our strategy to test the artifact Vercel is about to serve.
+
+</Callout>
 
 ## Step 3: The Reverse Handshake (Vercel Deployment Checks)
 
@@ -83,17 +93,22 @@ notify:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-**Gotcha Alert #1:** While GitHub automatically provides `secrets.GITHUB_TOKEN`, the `vercel/repository-dispatch` action does _not_ automatically consume it. You **must** explicitly pass it down via the `with:` block.
 
+<Callout type="danger">
+**Gotcha Alert #1:** While GitHub automatically provides `secrets.GITHUB_TOKEN`, the `vercel/repository-dispatch` action does _not_ automatically consume it. You must explicitly pass it down via the `with:` block.
+</Callout>
+
+<Callout type="danger">
 **Gotcha Alert #2:** The string you provide to `name:` in the `with` block (e.g., `"Vercel - coffey-codes: Test"`) must exactly match what you configure in the Vercel Dashboard (Settings > Build & Development > Deployment Checks). They communicate via this arbitrary string.
+</Callout>
 
 ### The Silent Production Hang (The Lesson I Learned the Hard Way)
 
-This configuration worked beautifully for PRs. PR checks went green, I merged cheerfully, and then... **our production deployment hung on Vercel indefinitely.**
+This configuration worked beautifully for PRs. PR checks went green, I merged and noticed the site never updated and then I checked vercel and found the production deployment hanging indefinitely. Vercel has a button to override and deploy anyway, but I wanted to understand why it was hanging in the first place.
 
-It was waiting for status checks that were never going to arrive.
+The answer was simple really, it was waiting for status checks that were never going to arrive.
 
-_Why?_ Vercel Deployment Checks evaluate the commit that's _being deployed_. When a PR is squash-merged, main gets a **brand-new commit SHA** that has never been through CI. Because our `Test` workflow only triggered on `pull_request`, it didn't fire for the new push to main. No workflow ran, no status was posted, and Vercel waited forever.
+_Why?_ Vercel Deployment Checks evaluate the commit that's _being deployed_. When a PR is squash-merged, main gets a brand-new commit SHA that has never been through CI. Because our `Test` workflow only triggered on `pull_request`, it didn't fire for the new push to main. No workflow ran, no status was posted, and Vercel waited forever.
 
 **The Fix:** I had to add a `repository_dispatch` trigger listening for the `vercel.deployment.ready` event that Vercel emits when _any_ deployment (including production) is created.
 
@@ -140,13 +155,13 @@ jobs:
           ref: ${{ github.event.deployment.sha }}
 ```
 
-_Note that I check out `github.event.deployment.sha` to ensure Playwright tests match the exact code that was deployed, not just the branch head._
+>_Note that I check out `github.event.deployment.sha` to ensure Playwright tests match the exact code that was deployed, not just the branch head._
 
 ### The Vercel Protection Bypass
 
 By default, Vercel Preview deployments are password-gated. If Playwright tries to visit the preview URL, it will just test Vercel's login screen.
 
-To fix this, I created a **Protection Bypass for Automation** token in Vercel (Settings → Deployment Protection), stored it as a GitHub secret (`VERCEL_AUTOMATION_BYPASS_SECRET`), and passed it to Playwright as an environment variable, along with the live target URL.
+To fix this, I created a `Protection Bypass for Automation` token in Vercel (Settings → Deployment Protection), stored it as a GitHub secret (`VERCEL_AUTOMATION_BYPASS_SECRET`), and passed it to Playwright as an environment variable, along with the live target URL.
 
 ```yaml
 - name: Run E2E tests against preview
@@ -179,25 +194,23 @@ export default defineConfig({
 });
 ```
 
-**Gotcha Alert #3:** GitHub only runs `deployment_status` workflows from files that exist on the repository's default branch. The first PR that adds this workflow won't trigger it! You have to merge it to main first, then open a second PR to verify the workflow works.
-
 ## Step 5: Hardening the Rules
 
 With all workflows in place, the final step was locking down the repository via GitHub's Branch Protection Rules.
 
 A PR cannot be merged unless the following are completely green:
 
-1. **Required status checks:**
+1. Required status checks:
    - `Test / ESLint`
    - `Test / Vitest`
    - `Test / TypeScript`
    - `Test / Notify Vercel`
    - `E2E (Vercel Preview) / Playwright`
-2. **Require deployments to succeed:**
+2. Require deployments to succeed:
    - `Preview`
 
 ## Conclusion
 
-Building this pipeline took some trial and error, but it has completely transformed our workflow. We no longer waste CI minutes spinning up redundant dev environments; instead, our E2E tests run against the exact infrastructure our users will experience in production. Most importantly, when we click merge, we have total confidence that the build is linted, typed correctly, and free of the errors that would otherwise break production.
+Building this pipeline took some trial and error, but now we no longer waste CI minutes spinning up redundant dev environments. Now, our E2E tests run against the exact infrastructure our users will experience in production. Most importantly, when I click merge, I have total confidence that the build is linted, typed correctly, and free of the errors that may break production.
 
-By cutting those 2–3 minutes of build time per PR, we’re not just saving time—we’re saving money on GitHub Action minutes. Strict branch protection rules ensure that only high-quality code reaches the finish line, which means less time putting out fires and more time to focus on what matters. If you're using Next.js and Vercel, I highly recommend adopting this approach. It’s straightforward to implement, and the payoff in reliability is huge.
+By cutting those 2–3 minutes of build time per PR, I'm saving time and money on GitHub Action minutes. Strict branch protection rules ensure that only high-quality code reaches the finish line, and that means less time putting out fires and more time to focus on what matters. If you're using Next.js and Vercel without a solid CI/CD pipeline, I highly recommend giving this approach a try. Your future self (and your users) will thank you!

--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -24,7 +24,7 @@ export default function Loader() {
 
     const timeout = setTimeout(() => {
       setLoading(false);
-    }, 2750);
+    }, 2000);
 
     return () => {
       clearInterval(typeInterval);
@@ -34,7 +34,7 @@ export default function Loader() {
 
   return (
     <div
-      className={`fixed inset-0 z-50 flex flex-col items-center justify-center bg-black opacity-80 transition-transform duration-200 ease-in-out ${
+      className={`fixed inset-0 z-50 flex flex-col items-center justify-center bg-black transition-transform duration-200 ease-in-out ${
         loading ? 'loading' : '-translate-y-full pointer-events-none'
       }`}
     >

--- a/components/canvas/objects/Spaceship.tsx
+++ b/components/canvas/objects/Spaceship.tsx
@@ -7,20 +7,20 @@ import * as THREE from 'three';
 const THRUST_PER_ENGINE = 70;
 const ENGINE_COUNT = 2;
 const TOTAL_THRUST = THRUST_PER_ENGINE * ENGINE_COUNT;
-const SPACESHIP_LAYER = 2;
+const SPACESHIP_LAYER = 3;
 
 const ENGINE_OFFSETS = [
-  new THREE.Vector3(-0.65, -0.05, 1.5), 
-  new THREE.Vector3(0.65, -0.05, 1.5), 
+  new THREE.Vector3(-0.65, -0.05, 1.5),
+  new THREE.Vector3(0.65, -0.05, 1.5),
 ];
 
 const PARTICLE_DATA = (() => {
   const arr = new Float32Array(TOTAL_THRUST * 4);
   for (let i = 0; i < TOTAL_THRUST; i++) {
-    arr[i * 4 + 0] = Math.random(); 
-    arr[i * 4 + 1] = 0.5 + Math.random() * 0.8; 
-    arr[i * 4 + 2] = (Math.random() - 0.5) * 0.16; 
-    arr[i * 4 + 3] = (Math.random() - 0.5) * 0.16; 
+    arr[i * 4 + 0] = Math.random();
+    arr[i * 4 + 1] = 0.5 + Math.random() * 0.8;
+    arr[i * 4 + 2] = (Math.random() - 0.5) * 0.16;
+    arr[i * 4 + 3] = (Math.random() - 0.5) * 0.16;
   }
   return arr;
 })();
@@ -31,14 +31,17 @@ function lerp(a: number, b: number, t: number) {
   return a + (b - a) * t;
 }
 
-const customGrungeShader = (shader: { vertexShader: string; fragmentShader: string }) => {
+const customGrungeShader = (shader: {
+  vertexShader: string;
+  fragmentShader: string;
+}) => {
   shader.vertexShader = `
     varying vec3 vWorldPosition;
     ${shader.vertexShader}
   `.replace(
     `#include <worldpos_vertex>`,
     `#include <worldpos_vertex>
-     vWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;`
+     vWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;`,
   );
 
   shader.fragmentShader = `
@@ -100,11 +103,13 @@ const customGrungeShader = (shader: { vertexShader: string; fragmentShader: stri
      float n2 = snoise(vWorldPosition * 35.0);
      float grunge = smoothstep(-0.3, 0.8, n1 * 0.7 + n2 * 0.3);
      diffuseColor.rgb *= mix(0.35, 1.0, grunge);
-    `
+    `,
   );
 };
 
-interface SpaceshipProps { scrollProgress: React.RefObject<number>; }
+interface SpaceshipProps {
+  scrollProgress: React.RefObject<number>;
+}
 export default function Spaceship({ scrollProgress }: SpaceshipProps) {
   const groupRef = useRef<THREE.Group>(null);
   const thrustRef = useRef<THREE.InstancedMesh>(null);
@@ -141,13 +146,15 @@ export default function Spaceship({ scrollProgress }: SpaceshipProps) {
     if (thrustRef.current) {
       dummy.scale.setScalar(0);
       dummy.updateMatrix();
-      for (let i = 0; i < TOTAL_THRUST; i++) thrustRef.current.setMatrixAt(i, dummy.matrix);
+      for (let i = 0; i < TOTAL_THRUST; i++)
+        thrustRef.current.setMatrixAt(i, dummy.matrix);
       thrustRef.current.instanceMatrix.needsUpdate = true;
     }
     if (laserRef.current) {
       dummy.scale.setScalar(0);
       dummy.updateMatrix();
-      for (let i = 0; i < LASER_COUNT; i++) laserRef.current.setMatrixAt(i, dummy.matrix);
+      for (let i = 0; i < LASER_COUNT; i++)
+        laserRef.current.setMatrixAt(i, dummy.matrix);
       laserRef.current.instanceMatrix.needsUpdate = true;
     }
   }, [dummy]);
@@ -159,7 +166,7 @@ export default function Spaceship({ scrollProgress }: SpaceshipProps) {
     const t = clock.getElapsedTime();
 
     if (progress < 0.62) {
-      groupRef.current.position.set(200, 0, -80);
+      groupRef.current.position.set(250, 0, -80);
       triggered.current = false;
       return;
     }
@@ -175,10 +182,10 @@ export default function Spaceship({ scrollProgress }: SpaceshipProps) {
     groupRef.current.position.set(
       lerp(150, -120, flyT),
       lerp(1, 6, flyT),
-      lerp(-180, 0, flyT)
+      lerp(-180, 0, flyT),
     );
 
-    const d = Math.min(delta, 0.05); 
+    const d = Math.min(delta, 1);
     const pd = pData.current;
 
     for (let i = 0; i < TOTAL_THRUST; i++) {
@@ -195,7 +202,7 @@ export default function Spaceship({ scrollProgress }: SpaceshipProps) {
       dummy.position.set(
         off.x + pd[base + 2] * spread,
         off.y + pd[base + 3] * spread,
-        off.z + tail
+        off.z + tail,
       );
       dummy.scale.setScalar(0.022 + age * 0.09);
       dummy.updateMatrix();
@@ -204,44 +211,53 @@ export default function Spaceship({ scrollProgress }: SpaceshipProps) {
       let r, g, blue;
       if (age < 0.2) {
         const tt = age / 0.2;
-        r = 1; g = 1; blue = lerp(1, 0.35, tt);
+        r = 1;
+        g = 1;
+        blue = lerp(1, 0.35, tt);
       } else if (age < 0.45) {
         const tt = (age - 0.2) / 0.25;
-        r = 1; g = lerp(1, 0.42, tt); blue = lerp(0.35, 0, tt);
+        r = 1;
+        g = lerp(1, 0.42, tt);
+        blue = lerp(0.35, 0, tt);
       } else if (age < 0.72) {
         const tt = (age - 0.45) / 0.27;
-        r = lerp(1, 0.62, tt); g = lerp(0.42, 0.07, tt); blue = 0;
+        r = lerp(1, 0.62, tt);
+        g = lerp(0.42, 0.07, tt);
+        blue = 0;
       } else {
         const tt = (age - 0.72) / 0.28;
-        r = lerp(0.62, 0.04, tt); g = lerp(0.07, 0, tt); blue = 0;
+        r = lerp(0.62, 0.04, tt);
+        g = lerp(0.07, 0, tt);
+        blue = 0;
       }
 
       thrustRef.current.setColorAt(i, tempColor.setRGB(r, g, blue));
     }
 
     thrustRef.current.instanceMatrix.needsUpdate = true;
-    if (thrustRef.current.instanceColor) thrustRef.current.instanceColor.needsUpdate = true;
+    if (thrustRef.current.instanceColor)
+      thrustRef.current.instanceColor.needsUpdate = true;
 
     const LASER_SPEED = 70;
-    const FIRE_START = 1.8; 
+    const FIRE_START = 1.8;
 
     for (let i = 0; i < LASER_COUNT; i++) {
       const isPort = i % 2 === 0;
       const burstIndex = Math.floor(i / 2);
-      const fireTime = FIRE_START + burstIndex * 0.15; 
-      
+      const fireTime = FIRE_START + burstIndex * 0.15;
+
       const timeSinceFired = elapsed - fireTime;
-      
+
       if (timeSinceFired > 0 && timeSinceFired < 1.2) {
-        const zPos = -0.4 - (timeSinceFired * LASER_SPEED);
+        const zPos = -0.4 - timeSinceFired * LASER_SPEED;
         dummy.position.set(isPort ? -2.2 : 2.2, -0.05, zPos);
-        dummy.rotation.set(Math.PI / 2, 0, 0); 
+        dummy.rotation.set(Math.PI / 2, 0, 0);
         dummy.scale.setScalar(1);
       } else {
         dummy.position.set(0, 0, 0);
         dummy.scale.setScalar(0);
       }
-      
+
       dummy.updateMatrix();
       laserRef.current.setMatrixAt(i, dummy.matrix);
     }
@@ -250,59 +266,123 @@ export default function Spaceship({ scrollProgress }: SpaceshipProps) {
 
   return (
     <group ref={groupRef} rotation={[0.04, 2.2, 0.45]} scale={4}>
-      <instancedMesh ref={thrustRef} args={[undefined, undefined, TOTAL_THRUST]} frustumCulled={false}>
+      <instancedMesh
+        ref={thrustRef}
+        args={[undefined, undefined, TOTAL_THRUST]}
+        frustumCulled={false}
+      >
         <sphereGeometry args={[1, 5, 4]} />
         <meshBasicMaterial toneMapped={false} />
       </instancedMesh>
 
-      <instancedMesh ref={laserRef} args={[undefined, undefined, LASER_COUNT]} frustumCulled={false}>
+      <instancedMesh
+        ref={laserRef}
+        args={[undefined, undefined, LASER_COUNT]}
+        frustumCulled={false}
+      >
         <cylinderGeometry args={[0.03, 0.03, 1.8, 6]} />
         <meshBasicMaterial color="#ff2255" toneMapped={false} />
       </instancedMesh>
 
-      <pointLight position={[-0.65, -0.05, 2.0]} color="#ff7722" intensity={12} distance={5.5} />
-      <pointLight position={[0.65, -0.05, 2.0]} color="#ff7722" intensity={12} distance={5.5} />
+      <pointLight
+        position={[-0.65, -0.05, 2.0]}
+        color="#ff7722"
+        intensity={12}
+        distance={5.5}
+      />
+      <pointLight
+        position={[0.65, -0.05, 2.0]}
+        color="#ff7722"
+        intensity={12}
+        distance={5.5}
+      />
 
       <mesh position={[0, 0, -1.8]} rotation={[-Math.PI / 2, 0, 0]}>
         <coneGeometry args={[0.4, 2.8, 16]} />
-        <meshStandardMaterial color="#ffffff" metalness={0.9} roughness={0.1} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial
+          color="#ffffff"
+          metalness={0.9}
+          roughness={0.1}
+          onBeforeCompile={customGrungeShader}
+        />
       </mesh>
 
       <mesh position={[0, 0, 0.3]} rotation={[-Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.4, 0.5, 1.8, 16]} />
-        <meshStandardMaterial color="#ffffff" metalness={0.9} roughness={0.1} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial
+          color="#ffffff"
+          metalness={0.9}
+          roughness={0.1}
+          onBeforeCompile={customGrungeShader}
+        />
       </mesh>
 
       <mesh position={[-1.6, -0.05, 0.4]} rotation={[0, 0.4, 0]}>
         <boxGeometry args={[2.5, 0.08, 1.5]} />
-        <meshStandardMaterial color="#f0f0f0" metalness={0.8} roughness={0.15} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial
+          color="#f0f0f0"
+          metalness={0.8}
+          roughness={0.15}
+          onBeforeCompile={customGrungeShader}
+        />
       </mesh>
       <mesh position={[1.6, -0.05, 0.4]} rotation={[0, -0.4, 0]}>
         <boxGeometry args={[2.5, 0.08, 1.5]} />
-        <meshStandardMaterial color="#f0f0f0" metalness={0.8} roughness={0.15} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial
+          color="#f0f0f0"
+          metalness={0.8}
+          roughness={0.15}
+          onBeforeCompile={customGrungeShader}
+        />
       </mesh>
 
       <mesh position={[-2.7, 0.2, 0.8]} rotation={[0, 0, 0.2]}>
         <boxGeometry args={[0.06, 0.6, 1.2]} />
-        <meshStandardMaterial color="#ff3333" metalness={0.6} roughness={0.2} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial
+          color="#ff3333"
+          metalness={0.6}
+          roughness={0.2}
+          onBeforeCompile={customGrungeShader}
+        />
       </mesh>
       <mesh position={[2.7, 0.2, 0.8]} rotation={[0, 0, -0.2]}>
         <boxGeometry args={[0.06, 0.6, 1.2]} />
-        <meshStandardMaterial color="#ff3333" metalness={0.6} roughness={0.2} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial
+          color="#ff3333"
+          metalness={0.6}
+          roughness={0.2}
+          onBeforeCompile={customGrungeShader}
+        />
       </mesh>
 
       <mesh position={[0, 0.25, -0.5]} scale={[0.6, 0.4, 1.4]}>
         <sphereGeometry args={[0.5, 16, 16]} />
-        <meshPhysicalMaterial color="#111111" transmission={0.1} metalness={0.9} roughness={0.2} clearcoat={0.5} />
+        <meshPhysicalMaterial
+          color="#111111"
+          transmission={0.1}
+          metalness={0.9}
+          roughness={0.2}
+          clearcoat={0.5}
+        />
       </mesh>
 
       <mesh position={[-0.65, -0.05, 0.8]} rotation={[Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.22, 0.28, 1.4, 12]} />
-        <meshStandardMaterial color="#e0e0e0" metalness={0.95} roughness={0.1} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial
+          color="#e0e0e0"
+          metalness={0.95}
+          roughness={0.1}
+          onBeforeCompile={customGrungeShader}
+        />
       </mesh>
       <mesh position={[0.65, -0.05, 0.8]} rotation={[Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.22, 0.28, 1.4, 12]} />
-        <meshStandardMaterial color="#e0e0e0" metalness={0.95} roughness={0.1} onBeforeCompile={customGrungeShader} />
+        <meshStandardMaterial
+          color="#e0e0e0"
+          metalness={0.95}
+          roughness={0.1}
+          onBeforeCompile={customGrungeShader}
+        />
       </mesh>
 
       <mesh position={[-0.65, -0.05, 1.5]} rotation={[Math.PI / 2, 0, 0]}>

--- a/components/overlay/HUDOverlay.tsx
+++ b/components/overlay/HUDOverlay.tsx
@@ -79,11 +79,29 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
   }, [scrollProgress]);
 
   const scrollTo = (progress: number) => {
-    const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
-    window.scrollTo({
-      top: progress * scrollHeight,
-      behavior: 'smooth',
-    });
+    // Add a tiny offset (0.01) to ensure we land definitively inside the target progress threshold,
+    // overcoming any GSAP scrub interpolation rounding errors.
+    const targetProgress = progress + 0.01;
+    
+    // Find the scroll spacer to calculate exact pixel distance
+    const container = document.getElementById('scroll-container');
+    const spacer = container?.parentElement;
+    
+    if (spacer) {
+      // The track length is spacer height minus one viewport height
+      const scrollableDistance = spacer.offsetHeight - window.innerHeight;
+      window.scrollTo({
+        top: spacer.offsetTop + (targetProgress * scrollableDistance),
+        behavior: 'smooth',
+      });
+    } else {
+      // Fallback
+      const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+      window.scrollTo({
+        top: targetProgress * scrollHeight,
+        behavior: 'smooth',
+      });
+    }
   };
 
   return (

--- a/components/overlay/HUDOverlay.tsx
+++ b/components/overlay/HUDOverlay.tsx
@@ -121,6 +121,7 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
 
       {/* Table of Contents */}
       <div className={styles.tocContainer}>
+        <div className={styles.tocTitle}>U7•RΔ9//ZΩ</div>
         <ol className={styles.tocList}>
           <li className={styles.tocItem}>
             <a

--- a/components/overlay/HUDOverlay.tsx
+++ b/components/overlay/HUDOverlay.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { ArrowDownIcon } from '@heroicons/react/24/outline';
+import { ArrowDownIcon, ArrowUpIcon } from '@heroicons/react/24/outline';
 import IntroOverlay from './IntroOverlay';
 import AboutOverlay from './AboutOverlay';
 import CraftOverlay from './CraftOverlay';
@@ -28,6 +28,7 @@ interface VisState {
 }
 
 type ActiveSection = 'intro' | 'about' | 'craft' | 'final' | null;
+type PromptType = 'start' | 'end';
 
 export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
   const [vis, setVis] = useState<VisState>({
@@ -38,6 +39,7 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
   });
   const [activeSection, setActiveSection] = useState<ActiveSection>(null);
   const [showPrompt, setShowPrompt] = useState<boolean>(true);
+  const [promptType, setPromptType] = useState<PromptType>('start');
   const rafRef = useRef<number>(0);
 
   useEffect(() => {
@@ -69,7 +71,12 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
       else if (p >= 0.15) nextActive = 'intro';
 
       setActiveSection((prev) => (prev === nextActive ? prev : nextActive));
-      setShowPrompt(p < 0.1);
+      
+      const isStart = p < 0.1;
+      const isEnd = p > 0.95;
+      setShowPrompt(isStart || isEnd);
+      if (isStart) setPromptType('start');
+      else if (isEnd) setPromptType('end');
 
       rafRef.current = requestAnimationFrame(tick);
     };
@@ -82,21 +89,22 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
     // Add a tiny offset (0.01) to ensure we land definitively inside the target progress threshold,
     // overcoming any GSAP scrub interpolation rounding errors.
     const targetProgress = progress + 0.01;
-    
+
     // Find the scroll spacer to calculate exact pixel distance
     const container = document.getElementById('scroll-container');
     const spacer = container?.parentElement;
-    
+
     if (spacer) {
       // The track length is spacer height minus one viewport height
       const scrollableDistance = spacer.offsetHeight - window.innerHeight;
       window.scrollTo({
-        top: spacer.offsetTop + (targetProgress * scrollableDistance),
+        top: spacer.offsetTop + targetProgress * scrollableDistance,
         behavior: 'smooth',
       });
     } else {
       // Fallback
-      const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const scrollHeight =
+        document.documentElement.scrollHeight - window.innerHeight;
       window.scrollTo({
         top: targetProgress * scrollHeight,
         behavior: 'smooth',
@@ -113,13 +121,13 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
 
       {/* Table of Contents */}
       <div className={styles.tocContainer}>
-        <ul className={styles.tocList}>
+        <ol className={styles.tocList}>
           <li className={styles.tocItem}>
             <a
               onClick={() => scrollTo(0.15)}
               className={`${styles.tocLink} ${activeSection === 'intro' ? styles.active : ''}`}
             >
-              System.init
+              $ whoami
             </a>
           </li>
           <li className={styles.tocItem}>
@@ -127,7 +135,7 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
               onClick={() => scrollTo(0.35)}
               className={`${styles.tocLink} ${activeSection === 'about' ? styles.active : ''}`}
             >
-              Profiles
+              system // init
             </a>
           </li>
           <li className={styles.tocItem}>
@@ -135,7 +143,7 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
               onClick={() => scrollTo(0.52)}
               className={`${styles.tocLink} ${activeSection === 'craft' ? styles.active : ''}`}
             >
-              Craft
+              Core.exe
             </a>
           </li>
           <li className={styles.tocItem}>
@@ -146,21 +154,26 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
               Connect
             </a>
           </li>
-        </ul>
+        </ol>
       </div>
 
       {/* Scroll Prompt */}
       <div className={`${styles.scrollPromptContainer} ${showPrompt ? styles.visible : ''}`}>
-        <span className={styles.scrollPromptText}>System Ready // Scroll to Explore</span>
+        <span className={styles.scrollPromptText}>
+          {promptType === 'end' ? 'SCROLL TO TOP' : 'System Ready // Scroll to Explore'}
+        </span>
         <button
           className={`${styles.scrollPromptButton} ${styles.bouncing}`}
-          onClick={() => scrollTo(0.15)}
-          aria-label="Scroll to first slide"
+          onClick={() => scrollTo(promptType === 'end' ? 0 : 0.15)}
+          aria-label={promptType === 'end' ? "Scroll to top" : "Scroll to first slide"}
         >
-          <ArrowDownIcon className={styles.heroSize} />
+          {promptType === 'end' ? (
+            <ArrowUpIcon className={styles.heroSize} />
+          ) : (
+            <ArrowDownIcon className={styles.heroSize} />
+          )}
         </button>
       </div>
     </div>
   );
 }
-

--- a/components/overlay/HUDOverlay.tsx
+++ b/components/overlay/HUDOverlay.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { ArrowDownIcon } from '@heroicons/react/24/outline';
 import IntroOverlay from './IntroOverlay';
 import AboutOverlay from './AboutOverlay';
 import CraftOverlay from './CraftOverlay';
@@ -16,7 +17,7 @@ import styles from './Overlay.module.sass';
 // 0.82–1.00: "Want to know more?" Galaxy fills frame.
 
 interface HUDOverlayProps {
-  scrollProgress: React.RefObject<number>;
+  scrollProgress: React.RefObject<number | null>;
 }
 
 interface VisState {
@@ -26,6 +27,8 @@ interface VisState {
   final: boolean;
 }
 
+type ActiveSection = 'intro' | 'about' | 'craft' | 'final' | null;
+
 export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
   const [vis, setVis] = useState<VisState>({
     intro: false,
@@ -33,6 +36,8 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
     craft: false,
     final: false,
   });
+  const [activeSection, setActiveSection] = useState<ActiveSection>(null);
+  const [showPrompt, setShowPrompt] = useState<boolean>(true);
   const rafRef = useRef<number>(0);
 
   useEffect(() => {
@@ -57,6 +62,15 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
         return next;
       });
 
+      let nextActive: ActiveSection = null;
+      if (p >= 0.82) nextActive = 'final';
+      else if (p >= 0.52) nextActive = 'craft';
+      else if (p >= 0.35) nextActive = 'about';
+      else if (p >= 0.15) nextActive = 'intro';
+
+      setActiveSection((prev) => (prev === nextActive ? prev : nextActive));
+      setShowPrompt(p < 0.1);
+
       rafRef.current = requestAnimationFrame(tick);
     };
 
@@ -64,12 +78,71 @@ export default function HUDOverlay({ scrollProgress }: HUDOverlayProps) {
     return () => cancelAnimationFrame(rafRef.current);
   }, [scrollProgress]);
 
+  const scrollTo = (progress: number) => {
+    const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+    window.scrollTo({
+      top: progress * scrollHeight,
+      behavior: 'smooth',
+    });
+  };
+
   return (
     <div className={styles.overlay}>
       <IntroOverlay visible={vis.intro} />
       <AboutOverlay visible={vis.about} />
       <CraftOverlay visible={vis.craft} />
       <FinalOverlay visible={vis.final} />
+
+      {/* Table of Contents */}
+      <div className={styles.tocContainer}>
+        <ul className={styles.tocList}>
+          <li className={styles.tocItem}>
+            <a
+              onClick={() => scrollTo(0.15)}
+              className={`${styles.tocLink} ${activeSection === 'intro' ? styles.active : ''}`}
+            >
+              System.init
+            </a>
+          </li>
+          <li className={styles.tocItem}>
+            <a
+              onClick={() => scrollTo(0.35)}
+              className={`${styles.tocLink} ${activeSection === 'about' ? styles.active : ''}`}
+            >
+              Profiles
+            </a>
+          </li>
+          <li className={styles.tocItem}>
+            <a
+              onClick={() => scrollTo(0.52)}
+              className={`${styles.tocLink} ${activeSection === 'craft' ? styles.active : ''}`}
+            >
+              Craft
+            </a>
+          </li>
+          <li className={styles.tocItem}>
+            <a
+              onClick={() => scrollTo(0.82)}
+              className={`${styles.tocLink} ${activeSection === 'final' ? styles.active : ''}`}
+            >
+              Connect
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      {/* Scroll Prompt */}
+      <div className={`${styles.scrollPromptContainer} ${showPrompt ? styles.visible : ''}`}>
+        <span className={styles.scrollPromptText}>System Ready // Scroll to Explore</span>
+        <button
+          className={`${styles.scrollPromptButton} ${styles.bouncing}`}
+          onClick={() => scrollTo(0.15)}
+          aria-label="Scroll to first slide"
+        >
+          <ArrowDownIcon className={styles.heroSize} />
+        </button>
+      </div>
     </div>
   );
 }
+

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -131,9 +131,9 @@
 // ── Table of Contents ───────────────────────────────────────────────────────
 .tocContainer
   position: absolute
-  right: 2vw
-  top: 50%
-  transform: translateY(-50%)
+  left: 70vw
+  top: 65vh
+  transform: translate(-50%, -50%)
   background: rgba(10, 10, 15, 0.4)
   border: 1px solid rgba(240, 240, 255, 0.1)
   border-radius: 12px

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -262,8 +262,8 @@
   background: #09090f
   padding: 0 0.5rem
   font-family: var(--font-geist-mono), monospace
-  font-size: 0.65rem
+  font-size: 0.6rem
   letter-spacing: 0.2em
   color: rgba(240, 240, 255, 0.5)
-  text-shadow: 0 0 5px rgba(240, 240, 255, 0.3)
+  text-shadow: 0 0 5px rgba(240, 240, 255, 0.9)
   pointer-events: none

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -131,14 +131,14 @@
 // ── Table of Contents ───────────────────────────────────────────────────────
 .tocContainer
   position: absolute
-  left: 70vw
-  top: 65vh
+  left: 75vw
+  top: 75vh
   transform: translate(-50%, -50%)
   background: rgba(10, 10, 15, 0.2)
   border: 1px solid rgba(240, 240, 255, 0.1)
   border-radius: 4px
-  padding: 1.5rem
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.5), 0 0 10px rgba(240, 240, 255, 0.05)
+  padding: 1rem
+  box-shadow: 0 0 30px rgba(255, 255, 255, 0.25)
   backdrop-filter: blur(8px)
   pointer-events: auto
   z-index: 10
@@ -176,8 +176,8 @@
   &::before
     content: ''
     display: inline-block
-    width: 6px
-    height: 6px
+    width: 3px
+    height: 3px
     background: rgba(240, 240, 255, 0.3)
     border-radius: 50%
     transition: all 0.3s ease
@@ -198,7 +198,7 @@
     &::before
       background: #ffffff
       box-shadow: 0 0 10px #ffffff
-      transform: scale(1.5)
+      transform: scale(2)
 
 // ── Scroll Prompt ───────────────────────────────────────────────────────────
 .scrollPromptContainer

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -126,3 +126,129 @@
     background-position: 200% center
   100%
     background-position: 0% center
+
+
+// ── Table of Contents ───────────────────────────────────────────────────────
+.tocContainer
+  position: absolute
+  right: 2vw
+  top: 50%
+  transform: translateY(-50%)
+  background: rgba(10, 10, 15, 0.4)
+  border: 1px solid rgba(240, 240, 255, 0.1)
+  border-radius: 12px
+  padding: 1.5rem
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.5), 0 0 10px rgba(240, 240, 255, 0.05)
+  backdrop-filter: blur(8px)
+  pointer-events: auto
+  z-index: 10
+  display: flex
+  flex-direction: column
+  gap: 1rem
+
+.tocList
+  list-style: none
+  padding: 0
+  margin: 0
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.tocItem
+  display: block
+
+.tocLink
+  font-family: var(--font-geist-mono), monospace
+  font-size: 0.8rem
+  letter-spacing: 0.1em
+  text-transform: uppercase
+  color: rgba(240, 240, 255, 0.4)
+  text-decoration: none
+  transition: all 0.3s ease
+  cursor: pointer
+  display: flex
+  align-items: center
+  gap: 0.5rem
+
+  &::before
+    content: ''
+    display: inline-block
+    width: 6px
+    height: 6px
+    background: rgba(240, 240, 255, 0.3)
+    border-radius: 50%
+    transition: all 0.3s ease
+
+  &:hover
+    color: rgba(240, 240, 255, 0.8)
+    text-shadow: 0 0 8px rgba(240, 240, 255, 0.3)
+
+    &::before
+      background: rgba(240, 240, 255, 0.8)
+      box-shadow: 0 0 8px rgba(240, 240, 255, 0.5)
+
+  &.active
+    color: #ffffff
+    font-weight: 700
+    text-shadow: 0 0 12px rgba(240, 240, 255, 0.6), 0 0 20px rgba(240, 240, 255, 0.3)
+    
+    &::before
+      background: #ffffff
+      box-shadow: 0 0 10px #ffffff
+      transform: scale(1.5)
+
+// ── Scroll Prompt ───────────────────────────────────────────────────────────
+.scrollPromptContainer
+  position: absolute
+  bottom: 5vh
+  left: 50%
+  transform: translateX(-50%)
+  display: flex
+  flex-direction: column
+  align-items: center
+  gap: 1rem
+  pointer-events: auto
+  z-index: 10
+  transition: opacity 0.5s ease
+  opacity: 0
+
+  &.visible
+    opacity: 1
+
+.scrollPromptText
+  font-family: var(--font-geist-mono), monospace
+  font-size: 0.75rem
+  letter-spacing: 0.2em
+  text-transform: uppercase
+  color: rgba(240, 240, 255, 0.7)
+  text-shadow: 0 0 8px rgba(240, 240, 255, 0.3)
+
+.scrollPromptButton
+  background: rgba(240, 240, 255, 0.05)
+  border: 1px solid rgba(240, 240, 255, 0.2)
+  border-radius: 50%
+  width: 3rem
+  height: 3rem
+  display: flex
+  align-items: center
+  justify-content: center
+  cursor: pointer
+  transition: all 0.3s ease
+  color: rgba(240, 240, 255, 0.8)
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5)
+
+  &:hover
+    background: rgba(240, 240, 255, 0.1)
+    border-color: rgba(240, 240, 255, 0.5)
+    color: #ffffff
+    box-shadow: 0 0 15px rgba(240, 240, 255, 0.2)
+    transform: translateY(2px)
+
+  @keyframes bounce
+    0%, 100%
+      transform: translateY(0)
+    50%
+      transform: translateY(5px)
+
+  &.bouncing
+    animation: bounce 2s infinite ease-in-out

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -135,10 +135,10 @@
   top: 75vh
   transform: translate(-50%, -50%)
   background: rgba(10, 10, 15, 0.2)
-  border: 1px solid rgba(240, 240, 255, 0.1)
-  border-radius: 4px
-  padding: 1rem
-  box-shadow: 0 0 30px rgba(255, 255, 255, 0.25)
+  border: 1px solid (rgba(255, 255, 255, 0.9))
+  border-radius: 0px
+  padding: 1rem 1rem 1rem 4rem
+  box-shadow: 4px 4px 0px (rgba(255, 255, 255, 0.9))
   backdrop-filter: blur(8px)
   pointer-events: auto
   z-index: 10
@@ -152,7 +152,7 @@
   margin: 0
   display: flex
   flex-direction: column
-  gap: 0.75rem
+  gap: 0.25rem
 
 .tocItem
   display: block
@@ -255,3 +255,15 @@
 
   &.bouncing
     animation: bounce 2s infinite ease-in-out
+.tocTitle
+  position: absolute
+  top: -0.65rem
+  left: -0.5rem
+  background: #09090f
+  padding: 0 0.5rem
+  font-family: var(--font-geist-mono), monospace
+  font-size: 0.65rem
+  letter-spacing: 0.2em
+  color: rgba(240, 240, 255, 0.5)
+  text-shadow: 0 0 5px rgba(240, 240, 255, 0.3)
+  pointer-events: none

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -136,7 +136,7 @@
   transform: translate(-50%, -50%)
   background: rgba(10, 10, 15, 0.4)
   border: 1px solid rgba(240, 240, 255, 0.1)
-  border-radius: 12px
+  border-radius: 4px
   padding: 1.5rem
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.5), 0 0 10px rgba(240, 240, 255, 0.05)
   backdrop-filter: blur(8px)
@@ -168,6 +168,9 @@
   cursor: pointer
   display: flex
   align-items: center
+  justify-content: flex-start
+  flex-direction: row-reverse
+  text-align: right
   gap: 0.5rem
 
   &::before

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -134,7 +134,7 @@
   left: 70vw
   top: 65vh
   transform: translate(-50%, -50%)
-  background: rgba(10, 10, 15, 0.75)
+  background: rgba(10, 10, 15, 0.2)
   border: 1px solid rgba(240, 240, 255, 0.1)
   border-radius: 4px
   padding: 1.5rem

--- a/components/overlay/Overlay.module.sass
+++ b/components/overlay/Overlay.module.sass
@@ -134,7 +134,7 @@
   left: 70vw
   top: 65vh
   transform: translate(-50%, -50%)
-  background: rgba(10, 10, 15, 0.4)
+  background: rgba(10, 10, 15, 0.75)
   border: 1px solid rgba(240, 240, 255, 0.1)
   border-radius: 4px
   padding: 1.5rem

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -138,9 +138,31 @@ test.describe('Homepage', () => {
     await expect(panels.final(page)).toHaveClass(isShowing)
     const link = panels.final(page).locator('a[href="/contact"]')
     await expect(link).toHaveAttribute('href', '/contact')
-    // Playwright's click action automatically checks for actionability and intercepting elements.
-    // Setting trial: true verifies the link can be cleanly clicked without getting blocked by invisible overlays,
-    // avoiding an actual navigation to keep the test fast.
     await link.click({ trial: true })
+  })
+
+  // ── ToC Overlay (progress 0–1.0) ────────────────────────────────────────
+
+  test('Table of Contents container is present and interactive', async ({ page }) => {
+    // The ToC Container should always be visible/present
+    const toc = page.locator('[class*="tocContainer"]')
+    await expect(toc).toBeVisible()
+    await expect(toc).toContainText('U7•RΔ9//ZΩ')
+  })
+
+  test('Scroll prompts appear at start and end of page', async ({ page }) => {
+    // At top (start)
+    const promptContainer = page.locator('[class*="scrollPromptContainer"]')
+    await expect(promptContainer).toHaveClass(isShowing)
+    await expect(promptContainer).toContainText('System Ready // Scroll to Explore')
+    
+    // Scroll past 0.1, prompt should hide
+    await scrollTo(page, 0.25)
+    await expect(promptContainer).not.toHaveClass(isShowing)
+
+    // Scroll to very bottom, prompt should reverse
+    await scrollTo(page, 0.98)
+    await expect(promptContainer).toHaveClass(isShowing)
+    await expect(promptContainer).toContainText('SCROLL TO TOP')
   })
 })


### PR DESCRIPTION
### Description

This PR implements the requested visual polish to the scroll-driven homepage cinematic overlay.

- Adds a floating, semi-transparent Table of Contents widget to the HUD overlay (anchored right/lower-third) with retro-futuristic styling and a clipping tab title (`U7•RΔ9//ZΩ`).
- Table of Contents links use native smooth-scrolling to snap the user directly to threshold marks. 
- Implements active state tracking (e.g., `.active`) synced to the `scrollProgress` reference. Calculates pixel heights precisely and overrides GSAP's scroll rounding logic via slight offsets to guarantee tag updates lock correctly.
- Implements dynamic scrolling prompts: Before scrolling, users see a bouncing down-arrow and `System Ready // Scroll to Explore`. Once they hit the bottom of the canvas (`progress > 0.95`), it fades back in as an upward pointing `SCROLL TO TOP` button to reset the cinematic.
- Pulls in minor formatting, timing, and flight-trigger parameter tweaks authored separately.