### PR TITLE
chore: rename master branch to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [master, main]
   repository_dispatch:
     types: [vercel.deployment.ready]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   repository_dispatch:
     types: [vercel.deployment.ready]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,11 @@ Full detail: `docs/documentation/development-standards.md`
 
 ## Version control
 
-- **Strategy:** Trunk-based — short-lived branches off `master`, deleted after merge
+- **Strategy:** Trunk-based — short-lived branches off `main`, deleted after merge
 - **Branch naming:** `feature/`, `fix/`, `refactor/`
 - **Commit format:** `<type>: <description> [SPEC-XXX]`
 - **Commit types:** `feat`, `fix`, `refactor`, `docs`, `test`, `style`
-- **Deployment:** Push to `master` → Vercel auto-deploys
+- **Deployment:** Push to `main` → Vercel auto-deploys
 
 ## Custom slash commands
 

--- a/docs/documentation/agents/coffey-codes.md
+++ b/docs/documentation/agents/coffey-codes.md
@@ -31,7 +31,7 @@ Personal website, portfolio, and blog for Anthony Coffey (coffey.codes). It serv
 | 3D Graphics | Three.js, @react-three/fiber, @react-three/drei |
 | Animation | motion |
 | Icons | @heroicons/react |
-| Hosting | Vercel (auto-deploys from `master`) |
+| Hosting | Vercel (auto-deploys from `main`) |
 | Package Manager | npm |
 
 ## Key Dependencies

--- a/docs/documentation/development-standards.md
+++ b/docs/documentation/development-standards.md
@@ -153,12 +153,12 @@ docs: add agent brief for coffey.codes
 
 ### Branching Strategy
 
-Trunk-based development. All branches are cut from `master` and merged back via pull request. Branches are deleted after merging.
+Trunk-based development. All branches are cut from `main` and merged back via pull request. Branches are deleted after merging.
 
-**CRITICAL RULE: NEVER commit directly to `master`.** 
+**CRITICAL RULE: NEVER commit directly to `main`.** 
 All updates, no matter how small or trivial, must be made on a separate branch and merged via Pull Request. No exceptions.
 
-- `master` — production. Auto-deploys to Vercel.
+- `main` — production. Auto-deploys to Vercel.
 - Feature/fix branches — short-lived, one spec per branch.
 
 ---
@@ -177,4 +177,4 @@ See `CLAUDE.md` at the project root for the full code style guide (TypeScript co
 | Build | `npm build` | Production build |
 | Lint | `npm lint` | ESLint check |
 | Lint fix | `npm lint:fix` | ESLint auto-fix |
-| Deploy | Push to `master` | Auto-deploy via Vercel |
+| Deploy | Push to `main` | Auto-deploy via Vercel |

--- a/docs/documentation/repos/coffey-codes.md
+++ b/docs/documentation/repos/coffey-codes.md
@@ -1,7 +1,7 @@
 # coffey.codes — Technical Reference
 
 **Repo:** https://github.com/anthonycoffey/coffey.codes  
-**Deployment:** Vercel (auto-deploys from `master`)  
+**Deployment:** Vercel (auto-deploys from `main`)  
 **Last updated:** 2026-04-13
 
 ---
@@ -61,7 +61,7 @@ coffey.codes/
 | Animation | motion | UI animations |
 | Icons | @heroicons/react | |
 | Package Manager | npm | `package.json` |
-| Hosting | Vercel | Auto-deploy from `master` |
+| Hosting | Vercel | Auto-deploy from `main` |
 | Analytics | Google Tag Manager | GTM-KJC6Q389 |
 
 ## Key Technical Decisions
@@ -137,7 +137,7 @@ npm lint            # ESLint
 npm lint:fix        # ESLint auto-fix
 ```
 
-**Deployment:** Push to `master` → Vercel auto-deploys.
+**Deployment:** Push to `main` → Vercel auto-deploys.
 
 ## Known Issues / Pending Work
 
@@ -150,8 +150,8 @@ npm lint:fix        # ESLint auto-fix
 
 ## Version Control
 
-- **Strategy:** Trunk-based. Feature branches from `master`, short-lived, deleted after merge.
+- **Strategy:** Trunk-based. Feature branches from `main`, short-lived, deleted after merge.
 - **Branch naming:** `feature/`, `fix/`, `chore/`, `refactor/`
-- **Deployment branch:** `master` (protected, auto-deploys to Vercel)
+- **Deployment branch:** `main` (protected, auto-deploys to Vercel)
 
 See [Development Standards](../development-standards.md) for full conventions.


### PR DESCRIPTION
## Summary
- Update CI workflow trigger from `master` to `main` ([.github/workflows/test.yml](.github/workflows/test.yml))
- Update branch references in CLAUDE.md and `docs/documentation/*` to `main`

## Migration steps after merge
1. Rename `master` → `main` on GitHub (via API or Settings → Branches)
2. Update Vercel Production Branch from `master` to `main`
3. Local rename (`git branch -m master main && git fetch origin && git branch -u origin/main main`)

## Test plan
- [ ] CI workflow runs against this PR (still triggers on `master` since the file change isn't yet merged)
- [ ] After merge + branch rename, confirm a follow-up PR triggers `Test` workflow against `main`