### PR TITLE
chore: drop master from test trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [master, main]
+    branches: [main]
   repository_dispatch:
     types: [vercel.deployment.ready]
 


### PR DESCRIPTION
Cleanup of transitional state from PR #139. Now that the default branch is `main` and `master` no longer exists, the test workflow only needs to trigger on PRs targeting `main`.