### PR TITLE
fix: unblock Vercel production deployment checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.deployment.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -72,11 +70,3 @@ jobs:
 
       - name: Run typecheck
         run: npm run typecheck
-
-      - name: Notify Vercel
-        if: always()
-        uses: vercel/repository-dispatch/actions/status@v1
-        with:
-          name: 'Vercel - coffey-codes: ESLint, Vitest & TypeScript'
-          state: ${{ steps.playwright.outcome == 'success' && 'success' || 'error' }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   e2e:
     name: Playwright
-    if: github.event.deployment_status.state == 'success' && github.event.deployment.environment != 'Production'
+    if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 


### PR DESCRIPTION
## Summary

- Run E2E tests against Production deployments so Vercel's deployment check receives a status
- Remove dead Notify Vercel step from the CI typecheck job (referenced a non-existent step ID on a pull_request event)

## Why

Production deployments at Vercel were stalling indefinitely because no workflow posted a GitHub status against the production deployment SHA. CI runs only on \`pull_request\` (pre-merge), and the E2E workflow explicitly skipped the Production environment, so post-merge production deployments waited for a check that never arrived.

## Test plan

- [ ] Merge to main, watch a production deployment, confirm the E2E job runs against the production target_url and the deployment check completes
- [ ] Confirm preview deployments still get checked as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)