### PR TITLE
fix: run CI on push to main to unblock Vercel production checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds `push: branches: [main]` to the CI workflow trigger so ESLint, TypeScript, and Vitest run against the merge commit. Their auto-generated status check names match the names Vercel's required deployment checks are watching for.

## Why

After merging to main, Vercel kicks off a production deployment for a brand-new merge SHA and waits on four required checks. PR #144 fixed the Playwright E2E one. The other three (ESLint, TypeScript, Vitest) were never posted because CI only ran on \`pull_request\`, so production deployments stalled indefinitely waiting on those three.

## Test plan

- [ ] Merge to main, watch the production deployment, confirm the four required checks all turn green and the deployment is promoted without admin override