### PR TITLE
perf: gate homepage Spaceship on >=1024px (SPEC-012 slice 1)

### DIFF
--- a/components/canvas/WorldCanvas.tsx
+++ b/components/canvas/WorldCanvas.tsx
@@ -5,6 +5,7 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { sampleMerkaba } from '@/utils/merkaba';
 import { EffectComposer, Bloom, Vignette } from '@react-three/postprocessing';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import CameraRig from './CameraRig';
 import UFO from './objects/UFO';
 import Planet from './objects/Planet';
@@ -153,6 +154,10 @@ interface WorldCanvasProps {
 }
 
 export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
+  // Spaceship (with thrust particles, lasers, and per-frame work) is desktop-only.
+  // Below 1024px the scene reads cleaner and avoids the GPU/CPU cost on mobile.
+  const showSpaceship = useMediaQuery('(min-width: 1024px)');
+
   return (
     <div
       style={{
@@ -206,7 +211,7 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
         <Planet scrollProgress={scrollProgress} />
         <Satellite scrollProgress={scrollProgress} />
         <Galaxy scrollProgress={scrollProgress} />
-        <Spaceship scrollProgress={scrollProgress} />
+        {showSpaceship && <Spaceship scrollProgress={scrollProgress} />}
 
         <EffectComposer multisampling={0}>
           <Bloom

--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Subscribes to a CSS media query and returns whether it currently matches.
+ *
+ * The initializer reads matchMedia synchronously when available so the first
+ * client render is already correct (avoids a flash of the wrong tier in
+ * components that mount client-only, e.g. dynamic({ ssr: false })).
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function')
+      return false;
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function')
+      return;
+    const mql = window.matchMedia(query);
+    const update = () => setMatches(mql.matches);
+    update();
+    mql.addEventListener('change', update);
+    return () => mql.removeEventListener('change', update);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary

First slice of [SPEC-012](docs/specs/active/SPEC-012-homepage-3d-mobile-tier.md). The homepage 3D scene was running the full Spaceship object on every device — thrust particles (140), laser geometry, and per-frame state updates. On phones (<1024 px) the scene reads cleaner without it, and skipping render avoids the GPU/CPU work.

## Changes

- **New** `hooks/useMediaQuery.ts` — small reusable matchMedia hook. Synchronous initial read so client-only mounts (`dynamic({ ssr: false })`) don't flash the wrong tier. Guarded against environments without matchMedia (jsdom).
- **Modified** `components/canvas/WorldCanvas.tsx` — `<Spaceship />` only renders when `(min-width: 1024px)` matches.

## Test plan

- [ ] Vercel preview build — confirm Spaceship is **absent** on a phone-width viewport (DevTools mobile emulation, or actual phone).
- [ ] Confirm Spaceship is **present** at >=1024 px (typical desktop / iPad landscape).
- [ ] Resize across the breakpoint mid-session — Spaceship should appear/disappear correctly via the matchMedia listener.
- [ ] Confirm scroll-driven camera/animation continues to work on both tiers without errors in console.

## Notes

Independent of [#154](https://github.com/anthonycoffey/coffey.codes/pull/154) (SPEC-011) — branched off `main`, no overlap. Subsequent SPEC-012 slices (DPR cap on mobile, post-processing code-split, particle reduction, visibility pause) will follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)