### PR TITLE
Spec close-out: SPEC-015 complete + archive, SPEC-016 in-progress

### DIFF
--- a/docs/specs/active/SPEC-016-seo-strategy.md
+++ b/docs/specs/active/SPEC-016-seo-strategy.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-016
 title: 'SEO strategy, post-audit (technical and on-page)'
-status: draft
+status: in-progress
 created: 2026-05-10
 author: Anthony Coffey
 reviewers: []

--- a/docs/specs/archive/SPEC-015-seo-audit-data-driven.md
+++ b/docs/specs/archive/SPEC-015-seo-audit-data-driven.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-015
 title: 'SEO audit — data-driven, via search-console MCP'
-status: review-pending
+status: complete
 created: 2026-05-10
 author: Anthony Coffey
 reviewers: []


### PR DESCRIPTION
## Summary

Post-merge bookkeeping for #161.

- SPEC-015 status `review-pending` → `complete`, moved to `docs/specs/archive/`. Audit deliverable (`docs/strategy/seo-audit-2026-Q2.md`) stays in place as an active reference.
- SPEC-016 status `draft` → `in-progress`. Easy wins shipped in #161; the remaining must-haves (GA4 admin work, Bing diagnostic, Q3 re-audit, deferred title rewrites) are open work.
- SPEC-017 stays `draft`. No implementation has begun.

## Test plan

- [x] `git log` shows the rename, not delete-and-add
- [x] No content changes other than `status:` frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)