### PR TITLE
fix(seo): datePublished + dateModified ISO 8601 with timezone [SPEC-016]

### DIFF
--- a/__tests__/articles/slug-page.test.tsx
+++ b/__tests__/articles/slug-page.test.tsx
@@ -135,6 +135,34 @@ describe('Article page JSON-LD publisher schema', () => {
   });
 });
 
+describe('Article page JSON-LD datetime hygiene', () => {
+  // Schema.org permits date-only values on datePublished / dateModified,
+  // but Google's Rich Results Test downgrades date-only to a
+  // "missing timezone" warning. Always emit a full ISO 8601 datetime.
+  const ISO_DATETIME_WITH_TZ =
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/;
+
+  it('datePublished is an ISO 8601 datetime with timezone, even when frontmatter is date-only', async () => {
+    const element = await Blog({
+      params: Promise.resolve({ slug: 'test-article' }),
+    });
+    const html = renderToStaticMarkup(element);
+    const blogPosting = findJsonLdByType(html, 'BlogPosting');
+
+    expect(blogPosting!.datePublished).toMatch(ISO_DATETIME_WITH_TZ);
+  });
+
+  it('dateModified is an ISO 8601 datetime with timezone', async () => {
+    const element = await Blog({
+      params: Promise.resolve({ slug: 'test-article' }),
+    });
+    const html = renderToStaticMarkup(element);
+    const blogPosting = findJsonLdByType(html, 'BlogPosting');
+
+    expect(blogPosting!.dateModified).toMatch(ISO_DATETIME_WITH_TZ);
+  });
+});
+
 describe('Article page CWV image hygiene', () => {
   it('the avatar image (above the fold on every article) is marked priority and has a sizes hint', async () => {
     const element = await Blog({

--- a/app/(site)/articles/[slug]/page.tsx
+++ b/app/(site)/articles/[slug]/page.tsx
@@ -9,6 +9,13 @@ import Link from 'next/link';
 import { formatDate } from '@/utils/date';
 import Image from 'next/image';
 
+// Normalize a date-or-datetime string to an ISO 8601 datetime with timezone.
+// Google's Rich Results Test flags date-only values on schema.org
+// `datePublished` / `dateModified` as missing-timezone warnings.
+function toIsoDatetime(value: string): string {
+  return value.includes('T') ? value : `${value}T00:00:00.000Z`;
+}
+
 // Per-slug component overrides — keeps heavy 3D scene clients out of
 // the global MDX registry so non-3D articles don't ship dynamic-import
 // wrappers for three.js / @react-three/* code.
@@ -100,9 +107,12 @@ export default async function Blog({ params }) {
             '@context': 'https://schema.org',
             '@type': 'BlogPosting',
             headline: post.metadata.title,
-            datePublished: post.metadata.publishedAt,
-            dateModified:
-              post.metadata.updated || post.mtime || post.metadata.publishedAt,
+            datePublished: toIsoDatetime(post.metadata.publishedAt),
+            dateModified: toIsoDatetime(
+              post.metadata.updated ||
+                post.mtime ||
+                post.metadata.publishedAt,
+            ),
             description: post.metadata.summary,
             image: post.metadata.image
               ? `${baseUrl}${post.metadata.image}`


### PR DESCRIPTION
## Summary

Fixes the two Rich Results Test warnings you found on the Expo Location article ([test result](https://search.google.com/test/rich-results/result?id=iKAy8vD3lbJSNdWeQcfsWQ)):

- `Invalid datetime value for "datePublished" (optional)`
- `Datetime property "datePublished" is missing a timezone (optional)`

Schema.org allows date-only values for these fields, but Google's Rich Results Test downgrades them. Frontmatter `publishedAt: '2025-03-24'` (date-only) was passing through to JSON-LD as-is.

## What changes

Single helper in [app/(site)/articles/[slug]/page.tsx](app/(site)/articles/[slug]/page.tsx):

```ts
function toIsoDatetime(value: string): string {
  return value.includes('T') ? value : `${value}T00:00:00.000Z`;
}
```

Applied to both `datePublished` and `dateModified`. Full ISO datetimes (like `post.mtime` from `fs.statSync`) pass through unchanged; date-only frontmatter values get `T00:00:00.000Z` appended.

## Test coverage

Added a "JSON-LD datetime hygiene" describe block to `__tests__/articles/slug-page.test.tsx`. Two assertions, both passing:

- `datePublished` matches the ISO 8601 datetime-with-timezone regex
- `dateModified` matches the same regex

## Verification

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 264/264 passing (was 262, +2 from this PR)
- [x] `npm run build` succeeds
- [ ] Post-deploy: re-run the Rich Results Test on the Expo Location URL. The two warnings should be gone, and the rest of the result stays passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)