### PR TITLE
feat: add resume download link to footer + homepage scroll outro

### DIFF
--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -32,6 +32,7 @@ vi.mock('@heroicons/react/20/solid', () => ({
   EnvelopeIcon: () => null,
   RssIcon: () => null,
   ArrowUpCircleIcon: () => null,
+  ArrowDownTrayIcon: () => null,
   CodeBracketIcon: () => null,
   ChatBubbleOvalLeftIcon: () => null,
   CalendarDaysIcon: () => null,

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,6 +9,7 @@ import {
   EnvelopeIcon,
   RssIcon,
   ArrowUpCircleIcon,
+  ArrowDownTrayIcon,
   CodeBracketIcon,
   ChatBubbleOvalLeftIcon,
   CalendarDaysIcon,
@@ -154,6 +155,15 @@ export default function Footer() {
                 <CalendarDaysIcon className="h-4 w-4" />
                 Schedule a Call
               </Link>
+              <a
+                href="/Anthony%20Coffey%20-%20Resume.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-full border-2 border-border text-c-text text-sm font-semibold hover:bg-surface-hover transition-colors no-underline"
+              >
+                <ArrowDownTrayIcon className="h-4 w-4" />
+                Download Resume
+              </a>
             </div>
           </div>
         </div>

--- a/components/overlay/FinalOverlay.tsx
+++ b/components/overlay/FinalOverlay.tsx
@@ -13,6 +13,15 @@ export default function FinalOverlay({ visible }: FinalOverlayProps) {
       <p className={styles.bodyLine}>
         <a href="/contact">&rarr;&nbsp;&nbsp;reach out</a>
       </p>
+      <p className={styles.bodyLine}>
+        <a
+          href="/Anthony%20Coffey%20-%20Resume.pdf"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          &rarr;&nbsp;&nbsp;view the resume
+        </a>
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The resume PDF at `/Anthony Coffey - Resume.pdf` exists in `/public` and is actively maintained (git history shows ~10 "resume update" commits), but there is no link to it from any page on the site. The audit's 15 clicks / 365 days came entirely from Google search at avg position 39.8.

This PR adds two access points.

## Changes

| File | Change |
| --- | --- |
| [components/Footer.tsx](components/Footer.tsx) | Adds "Download Resume" as a third button in the "Get in touch" CTA column alongside "Start a Conversation" and "Schedule a Call". Universal across every page that renders the Footer. |
| [components/overlay/FinalOverlay.tsx](components/overlay/FinalOverlay.tsx) | Adds "view the resume" as a second link in the homepage scroll outro panel, below the existing "reach out" link. Matches the existing arrow-prefix link style. High-intent moment: only seen after the visitor scrolls the whole 3D experience. |
| [__tests__/components/Footer.test.tsx](__tests__/components/Footer.test.tsx) | Adds `ArrowDownTrayIcon` to the heroicons mock so the existing scroll-reflow test still resolves the new import. |

Both links open the PDF in a new tab with `rel="noopener noreferrer"`. GA4's enhanced-measurement `file_download` event fires automatically on click (already keyed as a soft lead per [docs/strategy/ga4-events.md](docs/strategy/ga4-events.md)).

## Why now

You decided on 2026-05-10 to keep `file_download` ON as a key event because resume downloads are a meaningful lead indicator. That decision is wasted if visitors can't find the resume from the site itself. The fix is small and the leverage is real: every conversion-attribution path that ran through the homepage in the audit data now has a clean way to fire `file_download` deliberately, not by happenstance from a Google search.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 262/262 passing
- [x] `npm run build` succeeds
- [ ] Post-deploy: visit `/` and scroll to the FinalOverlay panel. The "view the resume" link should open the PDF in a new tab.
- [ ] Post-deploy: visit `/articles` (or any non-homepage route). The Footer "Get in touch" column should show three buttons. The third opens the PDF.
- [ ] Post-deploy: click the link, then check GA4 Realtime → Events. A `file_download` event should appear within a minute.

## Voice check

Win Without Pitching applies: a resume link presents credentials, it does not pursue. Label is direct ("Download Resume", "view the resume"), no marketing flourish. No em-dashes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)