### PR TITLE
feat: add resume + testimonials inline on contact and portfolio

### DIFF
--- a/__tests__/contact/page.test.tsx
+++ b/__tests__/contact/page.test.tsx
@@ -38,10 +38,16 @@ vi.mock('@/components/ui/Button', () => ({
 }));
 
 vi.mock('@heroicons/react/24/outline', () => ({
+  ArrowDownTrayIcon: () => null,
   CalendarDaysIcon: () => null,
+  DocumentTextIcon: () => null,
   EnvelopeIcon: () => null,
   PhoneIcon: () => null,
   MapPinIcon: () => null,
+}));
+
+vi.mock('@/components/Testimonials', () => ({
+  default: () => <div data-testid="testimonials" />,
 }));
 
 vi.mock('@heroicons/react/24/solid', () => ({

--- a/__tests__/portfolio/page.test.tsx
+++ b/__tests__/portfolio/page.test.tsx
@@ -41,6 +41,7 @@ vi.mock('@/components/ui/Button', () => ({
 }));
 
 vi.mock('@heroicons/react/24/solid', () => ({
+  ArrowDownTrayIcon: () => null,
   ChatBubbleOvalLeftIcon: () => null,
   CalendarDaysIcon: () => null,
   ArrowTopRightOnSquareIcon: () => null,
@@ -50,6 +51,10 @@ vi.mock('@heroicons/react/24/solid', () => ({
   ClockIcon: () => null,
   CodeBracketSquareIcon: () => null,
   XMarkIcon: () => null,
+}));
+
+vi.mock('@/components/Testimonials', () => ({
+  default: () => <div data-testid="testimonials" />,
 }));
 
 import PortfolioPage from '@/app/(site)/portfolio/page';

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -2,8 +2,11 @@ import ContactForm from '@/components/ContactForm';
 import RetroWindow from '@/components/ui/RetroWindow';
 import Button from '@/components/ui/Button';
 import PageHeader from '@/components/PageHeader';
+import Testimonials from '@/components/Testimonials';
 import {
+  ArrowDownTrayIcon,
   CalendarDaysIcon,
+  DocumentTextIcon,
   EnvelopeIcon,
   PhoneIcon,
   MapPinIcon,
@@ -71,6 +74,31 @@ export default async function ContactPage() {
             </div>
           </RetroWindow>
 
+          <RetroWindow title="resume.pdf">
+            <div className="p-5">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="p-3 bg-bg-alt rounded-full border border-border flex-shrink-0">
+                  <DocumentTextIcon className="h-5 w-5 text-accent1-dark" />
+                </div>
+                <p className="font-semibold text-c-heading text-sm">Resume</p>
+              </div>
+              <p className="text-c-muted text-sm mb-4 leading-relaxed">
+                Prefer to skim my background first? Grab the PDF.
+              </p>
+              <Button
+                as="a"
+                href="/Anthony%20Coffey%20-%20Resume.pdf"
+                variant="secondary"
+                size="sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ArrowDownTrayIcon className="h-4 w-4" />
+                Download Resume
+              </Button>
+            </div>
+          </RetroWindow>
+
           <RetroWindow title="calendar.txt">
             <div className="p-5">
               <div className="flex items-center gap-3 mb-3">
@@ -108,6 +136,13 @@ export default async function ContactPage() {
           </div>
         </RetroWindow>
       </div>
+
+      <section className="mt-12">
+        <h2 className="font-outfit text-2xl md:text-3xl font-bold mb-4 text-c-heading">
+          What clients have said
+        </h2>
+        <Testimonials />
+      </section>
     </>
   );
 }

--- a/app/(site)/portfolio/page.tsx
+++ b/app/(site)/portfolio/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useState, useEffect } from 'react';
 import {
+  ArrowDownTrayIcon,
   ChatBubbleOvalLeftIcon,
   CalendarDaysIcon,
   ArrowTopRightOnSquareIcon,
@@ -14,6 +15,7 @@ import {
 import RetroWindow from '@/components/ui/RetroWindow';
 import Button from '@/components/ui/Button';
 import PageHeader from '@/components/PageHeader';
+import Testimonials from '@/components/Testimonials';
 
 import Image from 'next/image';
 
@@ -428,6 +430,14 @@ const PortfolioSection: React.FC = () => {
         </div>
       )}
 
+      {/* Testimonials */}
+      <section className="mt-4 mb-12">
+        <h2 className="font-outfit text-2xl md:text-3xl font-bold mb-4 text-c-heading">
+          What clients have said
+        </h2>
+        <Testimonials />
+      </section>
+
       {/* Bottom CTA */}
       <div className="bg-accent2 border-2 border-border p-8 rounded-2xl text-center mt-4">
         <h2 className="font-outfit text-2xl md:text-3xl font-bold mb-3 text-c-heading">
@@ -450,6 +460,16 @@ const PortfolioSection: React.FC = () => {
           >
             <CalendarDaysIcon className="h-5 w-5" />
             Book Free Consultation
+          </Button>
+          <Button
+            as="a"
+            href="/Anthony%20Coffey%20-%20Resume.pdf"
+            variant="secondary"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <ArrowDownTrayIcon className="h-5 w-5" />
+            Download Resume
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Two pages get explicit credentials surfaces inline (Footer already gets them via the layout, but inline placement is more visible).

## Changes

### [app/(site)/contact/page.tsx](app/(site)/contact/page.tsx)

- New `resume.pdf` RetroWindow in the left column between `location.txt` and `calendar.txt`. Matches the filename-as-title convention already used by the other windows.
- Testimonials below the 2-column grid with a "What clients have said" heading.

### [app/(site)/portfolio/page.tsx](app/(site)/portfolio/page.tsx)

- "Download Resume" added to the bottom CTA section as a third button alongside "Start Your Project" and "Book Free Consultation".
- Testimonials between the polaroid grid and the bottom CTA. Flow: see work → see proof → take action.

### Test fixes

- `__tests__/contact/page.test.tsx`: heroicons `24/outline` mock gains `ArrowDownTrayIcon` and `DocumentTextIcon`; new mock for Testimonials.
- `__tests__/portfolio/page.test.tsx`: heroicons `24/solid` mock gains `ArrowDownTrayIcon`; new mock for Testimonials.

## Context

The user noticed there was no resume download link anywhere on the site. PR #166 added one to the Footer and the homepage scroll outro. This PR extends the placement to the two pages where credentials matter most for conversion (contact has the form, portfolio has the work proof).

The Testimonials component was orphaned: it existed in [components/Testimonials.tsx](components/Testimonials.tsx) and had test coverage, but no current page rendered it (used to live on the old homepage layout). `grep Testimonials` confirmed no other render surface.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 262/262 passing
- [x] `npm run build` succeeds
- [ ] Post-deploy: visit `/contact`. New `resume.pdf` RetroWindow should appear between location and calendar windows. Testimonials carousel should render below the 2-column grid.
- [ ] Post-deploy: visit `/portfolio`. Testimonials should render between the polaroid grid and the bottom CTA. Bottom CTA should have three buttons.
- [ ] Click the Download Resume button on either page. PDF opens in a new tab. GA4 file_download event fires in Realtime.
- [ ] Testimonials carousel should auto-advance every 5 seconds on both pages and pause on hover.

## Notes

- This PR is independent of #166 (different files). Mergeable in either order.
- No em-dashes, no marketing tricolons, no closing-flourish copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)