### PR TITLE
OG card coverage across taxonomy + style fixes [SPEC-016]

### DIFF
--- a/__tests__/articles/category-page.test.tsx
+++ b/__tests__/articles/category-page.test.tsx
@@ -49,6 +49,7 @@ vi.mock('@heroicons/react/20/solid', () => ({
   TagIcon: () => null,
   FolderIcon: () => null,
   MagnifyingGlassIcon: () => null,
+  CpuChipIcon: () => null,
 }));
 
 import {

--- a/__tests__/articles/page.test.tsx
+++ b/__tests__/articles/page.test.tsx
@@ -36,6 +36,7 @@ vi.mock('@heroicons/react/20/solid', () => ({
   TagIcon: () => null,
   FolderIcon: () => null,
   MagnifyingGlassIcon: () => null,
+  CpuChipIcon: () => null,
 }));
 
 import {

--- a/__tests__/articles/tag-page.test.tsx
+++ b/__tests__/articles/tag-page.test.tsx
@@ -56,6 +56,7 @@ vi.mock('@heroicons/react/20/solid', () => ({
   TagIcon: () => null,
   FolderIcon: () => null,
   MagnifyingGlassIcon: () => null,
+  CpuChipIcon: () => null,
 }));
 
 import {

--- a/app/(site)/articles/categories/page.tsx
+++ b/app/(site)/articles/categories/page.tsx
@@ -2,15 +2,32 @@ import { getAllCategories } from '@/app/(site)/articles/utils';
 import Link from 'next/link';
 import { FolderIcon } from '@heroicons/react/20/solid';
 import PageHeader from '@/components/PageHeader';
+import { baseUrl } from '@/app/sitemap';
 
 import type { Metadata } from 'next';
 
 export function generateMetadata(): Metadata {
+  const description =
+    'Browse articles by category, software engineering, AI/ML, cloud computing, and web development from Anthony Coffey.';
+  const ogImage = `${baseUrl}/og?title=${encodeURIComponent('All Categories')}&category=${encodeURIComponent('Articles')}`;
+
   return {
     title: 'Articles Categories',
-    description:
-      'Browse articles by category — software engineering, AI/ML, cloud computing, and web development from Anthony Coffey.',
+    description,
     alternates: { canonical: '/articles/categories' },
+    openGraph: {
+      type: 'website',
+      url: '/articles/categories',
+      title: 'Articles Categories',
+      description,
+      images: [{ url: ogImage }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: 'Articles Categories',
+      description,
+      images: [ogImage],
+    },
   };
 }
 

--- a/app/(site)/articles/category/[category]/page.tsx
+++ b/app/(site)/articles/category/[category]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@heroicons/react/20/solid';
 import SearchBox from '@/components/SearchBox';
 import PageHeader from '@/components/PageHeader';
+import { baseUrl } from '@/app/sitemap';
 
 export const dynamicParams = true;
 
@@ -38,16 +39,28 @@ export async function generateMetadata({ params, searchParams }) {
     resolvedSearchParams?.page && Number(resolvedSearchParams.page) > 1;
   const decodedCategory = capitalizeWords(decodeURIComponent(category));
   const title = `${decodedCategory} Articles`;
-  const description = `Articles categorized under ${decodedCategory} — software engineering insights and deep dives by Anthony Coffey.`;
+  const description = `Articles categorized under ${decodedCategory}, software engineering insights and deep dives by Anthony Coffey.`;
   const url = `/articles/category/${encodeURIComponent(category)}`;
+  const ogImage = `${baseUrl}/og?title=${encodeURIComponent(decodedCategory)}&category=${encodeURIComponent('Category')}`;
 
   return {
     title,
     description,
     alternates: { canonical: url },
     robots: isPaginated ? { index: false, follow: true } : undefined,
-    openGraph: { type: 'website', url, title, description },
-    twitter: { card: 'summary_large_image', title, description },
+    openGraph: {
+      type: 'website',
+      url,
+      title,
+      description,
+      images: [{ url: ogImage }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
   };
 }
 

--- a/app/(site)/articles/page.tsx
+++ b/app/(site)/articles/page.tsx
@@ -14,17 +14,19 @@ import {
 import Link from 'next/link';
 import SearchBox from '@/components/SearchBox';
 import PageHeader from '@/components/PageHeader';
+import { baseUrl } from '@/app/sitemap';
 
 import type { Metadata } from 'next';
 
 export async function generateMetadata({ searchParams }): Promise<Metadata> {
   const params = await searchParams;
   const isPaginated = params.page && Number(params.page) > 1;
+  const ogImage = `${baseUrl}/og?title=${encodeURIComponent('Articles')}&category=${encodeURIComponent('Anthony Coffey')}`;
 
   return {
     title: { absolute: 'Articles by Anthony Coffey' },
     description:
-      'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey — Austin-based AI consultant and software engineer.',
+      'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey, Austin-based AI consultant and software engineer.',
     alternates: { canonical: '/articles' },
     robots: isPaginated ? { index: false, follow: true } : undefined,
     openGraph: {
@@ -33,12 +35,14 @@ export async function generateMetadata({ searchParams }): Promise<Metadata> {
         'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey.',
       url: '/articles',
       type: 'website',
+      images: [{ url: ogImage }],
     },
     twitter: {
       card: 'summary_large_image',
       title: 'Articles by Anthony Coffey',
       description:
         'Articles on software engineering, AI/ML, cloud architecture, and web development by Anthony Coffey.',
+      images: [ogImage],
     },
   };
 }

--- a/app/(site)/articles/tag/[tag]/page.tsx
+++ b/app/(site)/articles/tag/[tag]/page.tsx
@@ -16,6 +16,7 @@ import {
 } from '@heroicons/react/20/solid';
 import SearchBox from '@/components/SearchBox';
 import PageHeader from '@/components/PageHeader';
+import { baseUrl } from '@/app/sitemap';
 
 export const dynamicParams = true;
 
@@ -34,16 +35,28 @@ export async function generateMetadata({ params, searchParams }) {
     resolvedSearchParams?.page && Number(resolvedSearchParams.page) > 1;
   const decodedTag = capitalizeWords(decodeURIComponent(tag));
   const title = `${decodedTag} Articles`;
-  const description = `Articles tagged ${decodedTag} — technical write-ups and deep dives by Anthony Coffey.`;
+  const description = `Articles tagged ${decodedTag}, technical write-ups and deep dives by Anthony Coffey.`;
   const url = `/articles/tag/${encodeURIComponent(tag)}`;
+  const ogImage = `${baseUrl}/og?title=${encodeURIComponent(decodedTag)}&category=${encodeURIComponent('Tag')}`;
 
   return {
     title,
     description,
     alternates: { canonical: url },
     robots: isPaginated ? { index: false, follow: true } : undefined,
-    openGraph: { type: 'website', url, title, description },
-    twitter: { card: 'summary_large_image', title, description },
+    openGraph: {
+      type: 'website',
+      url,
+      title,
+      description,
+      images: [{ url: ogImage }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
   };
 }
 

--- a/app/(site)/articles/tags/page.tsx
+++ b/app/(site)/articles/tags/page.tsx
@@ -2,15 +2,32 @@ import { getAllTags } from '@/app/(site)/articles/utils';
 import Link from 'next/link';
 import { TagIcon } from '@heroicons/react/20/solid';
 import PageHeader from '@/components/PageHeader';
+import { baseUrl } from '@/app/sitemap';
 
 import type { Metadata } from 'next';
 
 export function generateMetadata(): Metadata {
+  const description =
+    'Browse articles by tag, React, Next.js, AWS, AI/ML, Git, and other technologies covered by Anthony Coffey.';
+  const ogImage = `${baseUrl}/og?title=${encodeURIComponent('All Tags')}&category=${encodeURIComponent('Articles')}`;
+
   return {
     title: 'Articles Tags',
-    description:
-      'Browse articles by tag — React, Next.js, AWS, AI/ML, Git, and other technologies covered by Anthony Coffey.',
+    description,
     alternates: { canonical: '/articles/tags' },
+    openGraph: {
+      type: 'website',
+      url: '/articles/tags',
+      title: 'Articles Tags',
+      description,
+      images: [{ url: ogImage }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: 'Articles Tags',
+      description,
+      images: [ogImage],
+    },
   };
 }
 

--- a/app/(site)/case-studies/page.tsx
+++ b/app/(site)/case-studies/page.tsx
@@ -5,26 +5,30 @@ import {
 import Link from 'next/link';
 import PageHeader from '@/components/PageHeader';
 import { caseStudies } from './case-studies';
+import { baseUrl } from '@/app/sitemap';
 
 import type { Metadata } from 'next';
 
+const CASE_STUDIES_DESCRIPTION =
+  'Software engineering case studies by Anthony Coffey, geospatial tech, fleet optimization, and real-world problem solving.';
+const CASE_STUDIES_OG_IMAGE = `${baseUrl}/og?title=${encodeURIComponent('Case Studies')}&category=${encodeURIComponent('Anthony Coffey')}`;
+
 export const metadata: Metadata = {
   title: 'Case Studies',
-  description:
-    'Software engineering case studies by Anthony Coffey — geospatial tech, fleet optimization, and real-world problem solving.',
+  description: CASE_STUDIES_DESCRIPTION,
   alternates: { canonical: '/case-studies' },
   openGraph: {
     type: 'website',
     url: '/case-studies',
     title: 'Case Studies by Anthony Coffey',
-    description:
-      'Software engineering case studies by Anthony Coffey — geospatial tech, fleet optimization, and real-world problem solving.',
+    description: CASE_STUDIES_DESCRIPTION,
+    images: [{ url: CASE_STUDIES_OG_IMAGE }],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Case Studies by Anthony Coffey',
-    description:
-      'Software engineering case studies by Anthony Coffey — geospatial tech, fleet optimization, and real-world problem solving.',
+    description: CASE_STUDIES_DESCRIPTION,
+    images: [CASE_STUDIES_OG_IMAGE],
   },
 };
 

--- a/app/(site)/case-study/[slug]/page.tsx
+++ b/app/(site)/case-study/[slug]/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({
   if (!study) return { title: 'Case Study Not Found' };
 
   const url = `${baseUrl}/case-study/${study.slug}`;
-  const ogImage = `${baseUrl}/og?title=${encodeURIComponent(study.title)}`;
+  const ogImage = `${baseUrl}/og?title=${encodeURIComponent(study.title)}&category=${encodeURIComponent('Case Study')}`;
 
   return {
     title: study.title,
@@ -66,7 +66,7 @@ export default async function CaseStudyPage({
     '@type': 'Article',
     headline: study.title,
     description: study.description,
-    image: `${baseUrl}/og?title=${encodeURIComponent(study.title)}`,
+    image: `${baseUrl}/og?title=${encodeURIComponent(study.title)}&category=${encodeURIComponent('Case Study')}`,
     url,
     author: { '@type': 'Person', name: 'Anthony Coffey', url: baseUrl },
     publisher: {

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -13,12 +13,29 @@ import {
 import { EnvelopeOpenIcon } from '@heroicons/react/24/solid';
 
 import type { Metadata } from 'next';
+import { baseUrl } from '@/app/sitemap';
+
+const CONTACT_DESCRIPTION =
+  'Get in touch with Anthony Coffey, an AI consultant and software engineer in Austin, TX, for web, mobile, or AI/ML work. Book a free 30-minute consultation.';
+const CONTACT_OG_IMAGE = `${baseUrl}/og?title=${encodeURIComponent('Contact')}&category=${encodeURIComponent('Anthony Coffey')}`;
 
 export const metadata: Metadata = {
   title: 'Contact',
-  description:
-    'Get in touch with Anthony Coffey, an AI consultant and software engineer in Austin, TX, for web, mobile, or AI/ML work. Book a free 30-minute consultation.',
+  description: CONTACT_DESCRIPTION,
   alternates: { canonical: '/contact' },
+  openGraph: {
+    type: 'website',
+    url: '/contact',
+    title: 'Contact Anthony Coffey',
+    description: CONTACT_DESCRIPTION,
+    images: [{ url: CONTACT_OG_IMAGE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Contact Anthony Coffey',
+    description: CONTACT_DESCRIPTION,
+    images: [CONTACT_OG_IMAGE],
+  },
 };
 
 export default async function ContactPage() {


### PR DESCRIPTION
## Summary

Branch picked up two related improvements:

1. **Testimonial slider gap fix** (your commit `8012de5`) — visual polish on the existing Testimonials component
2. **Styled OG card coverage across taxonomy + contact + case studies** — closes the per-page OG gap surfaced in the Q3 audit (PR #169)

## OG coverage matrix

Before this PR, only article slug pages used the styled `/og` card. Everything else fell back to the static `/og-image.jpg` via the layout default.

| Route | Title | Kicker |
| --- | --- | --- |
| `/articles` | Articles | Anthony Coffey |
| `/articles/categories` | All Categories | Articles |
| `/articles/tags` | All Tags | Articles |
| `/articles/category/[category]` | <category name> | Category |
| `/articles/tag/[tag]` | <tag name> | Tag |
| `/case-studies` | Case Studies | Anthony Coffey |
| `/case-study/[slug]` | <study title> | Case Study |
| `/contact` | Contact | Anthony Coffey |

Not touched (intentional):
- `/` (homepage) — has its own bespoke OG (`/og-image.jpg`)
- `/portfolio` — client component, can't export Next.js metadata
- `/lp/*` — landing pages have their own targeted OG; leave alone

Each route now emits both `openGraph.images` and `twitter.images` pointing at the dynamic OG endpoint with the new `category` kicker param.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 266/266 passing (added `CpuChipIcon` to three test mocks because importing `baseUrl` from `@/app/sitemap` transitively pulls in `case-studies.ts` which uses that icon)
- [x] `npm run build` succeeds
- [ ] Post-deploy: visit a few of the new routes' source HTML and confirm the `og:image` URL points at `/og?title=...&category=...` for each
- [ ] Optional: paste a few into Twitter / LinkedIn share preview to see the kicker render

## Notes

- Voice cleanup: replaced three em-dashes in the taxonomy descriptions with commas while I was in those files
- Pairs with PR #169 (Q3 audit) which documented this exact gap in Section 14 as "Per-page OG images: Partial. Articles now get styled OG cards with category kicker. Taxonomy hubs and / still use static /og-image.jpg." This PR closes that partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)