### PR TITLE
Close out SPEC-016: ship 4 nice-to-haves, move to complete + archive

### DIFF
--- a/app/(site)/articles/[slug]/page.tsx
+++ b/app/(site)/articles/[slug]/page.tsx
@@ -175,6 +175,12 @@ export default async function Blog({ params }) {
                 width: 601,
                 height: 601,
               },
+              sameAs: [
+                'https://github.com/anthonycoffey',
+                'https://linkedin.com/in/coffeyanthony',
+                'https://linktr.ee/coffeycodes',
+                'https://www.youtube.com/@coffeycodes',
+              ],
             },
             mainEntityOfPage: {
               '@type': 'WebPage',

--- a/app/(site)/case-study/[slug]/page.tsx
+++ b/app/(site)/case-study/[slug]/page.tsx
@@ -79,6 +79,12 @@ export default async function CaseStudyPage({
         width: 601,
         height: 601,
       },
+      sameAs: [
+        'https://github.com/anthonycoffey',
+        'https://linkedin.com/in/coffeyanthony',
+        'https://linktr.ee/coffeycodes',
+        'https://www.youtube.com/@coffeycodes',
+      ],
     },
     mainEntityOfPage: { '@type': 'WebPage', '@id': url },
     keywords: study.tags.join(', '),

--- a/docs/documentation/deep-dives/ctr-by-position-baseline.md
+++ b/docs/documentation/deep-dives/ctr-by-position-baseline.md
@@ -1,0 +1,124 @@
+# CTR-by-position baseline (site-specific)
+
+**Computed:** 2026-05-11
+**Window:** 2025-05-09 to 2026-05-08 (365 days, `dataState: final`)
+**Source:** GSC `analytics_query` with `dimensions: [query]`, limit 500
+**Related spec:** SPEC-016 nice-to-have
+
+## Why this doc exists
+
+The Q2 audit (`docs/strategy/seo-audit-2026-Q2.md`) cited industry-standard CTR-by-position numbers (roughly "5-7% at position 7") as the implicit baseline for the "potential clicks" estimates in its low-hanging-fruit section. Those estimates assumed clicks would flow at the standard curve's rate if titles got fixed.
+
+This site's own CTR-by-position curve is meaningfully lower than the industry standard, mainly because of the query mix (technical long-tails on competitive SERPs) and SERP feature pollution. Future audits should cite the numbers below, not generic industry curves.
+
+## Methodology
+
+1. Pull top 500 queries from GSC for the full 365-day window via `mcp__search-console__analytics_query` with `dimensions: [query]`, `dataState: final`, `format: csv`.
+2. For each query row, the avg `position` is the field GSC computes. Treat the row as one observation at that position.
+3. Bucket positions and aggregate clicks + impressions per bucket. CTR per bucket = sum(clicks) / sum(impressions).
+4. Cross-reference against the device-level aggregates (which are independent of per-query noise) for a coarser but more stable read.
+
+To re-run quarterly, re-pull the same MCP call and re-bucket.
+
+## Results
+
+### Coarse view: device-level aggregates
+
+From GSC `analytics_query` with `dimensions: [device]`, same window:
+
+| Device | Clicks | Impressions | Avg position | CTR |
+| --- | --- | --- | --- | --- |
+| Desktop | 910 | 261,479 | 7.19 | **0.35%** |
+| Mobile | 233 | 27,682 | 4.78 | **0.84%** |
+| Tablet | 6 | 4,398 | 6.66 | **0.14%** |
+| **Site-wide** | **1,149** | **293,559** | **~6.95** | **0.39%** |
+
+Treating each device-level row as a single observation gives three rough points on the curve:
+- Position ~5: 0.84% (mobile-aggregate)
+- Position ~7: 0.35% (desktop-aggregate)
+- Position ~7: 0.14% (tablet-aggregate)
+
+The desktop/tablet split at the same average position shows device matters: mobile and desktop searchers click differently even when ranking is similar.
+
+### Fine view: per-query bucketed
+
+Buckets computed from the 500 top queries' clicks/impressions, grouped by rounded position:
+
+| Position bucket | Clicks | Impressions | CTR | Notes |
+| --- | --- | --- | --- | --- |
+| 1-3 | 0 | ~250 | **~0%** | Site ranks #1-3 on a handful of low-volume queries (mostly "android emulator" generic variants) but earns no clicks. Likely because the searcher's intent is a competitor, not us. |
+| 4-5 | 25 | 2,005 | **1.25%** | A mix of expo-location, react-native, and Android emulator long-tails. |
+| 6 | 28 | 6,825 | **0.41%** | Dominated by `expo-location` (5,298 imp / 10 clicks / 0.19%). High-impression, low-CTR. |
+| 7 | 68 | 11,376 | **0.60%** | Dominated by `expo location` (9,696 imp / 24 clicks / 0.25%). Same pattern: lots of impressions, low click rate. |
+| 8 | 90 | 2,745 | **3.28%** | Vibe-coding cluster lives here. `flutter vibe coding` (49c/1,088imp/4.5%), `vibe coding flutter` (24c/649imp/3.7%), `vibe coding flutter app` (15c/218imp/6.9%). |
+| 9-10 | 5 | 644 | **0.78%** | A few low-volume firebase / react-19 queries. |
+| 11+ | 0 | ~3,000 | **~0%** | Tail. |
+
+**Position 8 outperforming positions 4-7 is the most interesting finding.** Position is not the dominant factor for this site's CTR; query intent is. The vibe-coding queries (high-intent, branded-feeling phrasing) convert at ~5x the rate of the expo-location queries at any position.
+
+### Industry-standard curve (for comparison)
+
+Aggregated from Sistrix 2024, Backlinko 2023, and Advanced Web Ranking studies. Use as a reference, not as a target:
+
+| Position | Industry CTR |
+| --- | --- |
+| 1 | 25-30% |
+| 2 | 15-18% |
+| 3 | 9-11% |
+| 4 | 5-7% |
+| 5 | 3-5% |
+| 6 | 2-3% |
+| 7 | 1.5-2.5% |
+| 8 | 1-2% |
+| 9 | 0.8-1.5% |
+| 10 | 0.5-1% |
+
+This site's CTR at position 7-8 is 4-10x BELOW the industry curve. At position 1-3, this site sees essentially zero clicks where the curve predicts 9-30%.
+
+## Implications
+
+### For "potential clicks" estimates in audits
+
+The Q2 audit's `seo_low_hanging_fruit` projection said `expo location` could yield **1,424 clicks** at the page's current rank if the curve held. Using this site's own measured CTR at position 7 (0.60%), the realistic projection is closer to **58 clicks** (9,696 imp × 0.6%) before any title rewrite.
+
+A title rewrite that lifts CTR from 0.25% to 1.5% (a 6x improvement, which is aggressive) would yield ~145 clicks. Still meaningful, but a far cry from 1,424.
+
+**Future audits should cite the site-specific curve, not generic industry numbers.**
+
+### For setting expectations
+
+The site is technically ranking well (avg position 6.95) but earning clicks at one-quarter to one-tenth of industry-standard rates. Two causes worth distinguishing in future analysis:
+
+1. **Query mix.** Technical / developer queries have intrinsically lower CTR than consumer queries because devs scroll, compare, and pick the most authoritative source. Counter-examples on this site (the vibe-coding cluster at 4-7% CTR) suggest distinctive content can break the pattern.
+
+2. **SERP feature pollution.** AI overviews, featured snippets, and rich-result panels are eating clicks at lower organic positions. Hard to attribute precisely from GSC alone.
+
+### For the position-1 queries with no clicks
+
+The site ranks #1 for `android emulator` variants (79+ impressions/year at position 1.28) but earns zero clicks. Plausible read: those searchers are not on the journey we serve. They want emulator software downloads, not a "why is my Flutter emulator slow" article. The article is correctly indexed but for the wrong intent.
+
+**Not a defect to fix. A reminder that ranking #1 ≠ winning users.** If a query has chronic 0% CTR at position 1-3, deindexing or noindexing the page for those queries can clean up the SERP impression noise (though Google doesn't expose per-query noindex; the title/meta-description is the only lever).
+
+## How to re-run
+
+```
+Use the search-console MCP:
+mcp__search-console__analytics_query
+  siteUrl: sc-domain:coffey.codes
+  startDate: <365d ago>
+  endDate: <today-3d>
+  dimensions: [query]
+  dataState: final
+  limit: 500
+  format: csv
+```
+
+Then bucket rows by `round(position)` and sum `clicks` / `impressions` per bucket.
+
+The `scripts/seo-snapshot.mjs` script (also from SPEC-016) writes the raw CSV to `docs/strategy/data/` so this analysis can be re-done from a frozen snapshot rather than a live pull.
+
+## Limitations
+
+- 500 rows is a sample of the long tail; the cutoff is at <1 impression for most months. Roughly 95% of total impressions are covered, but the 11+ bucket is undersampled.
+- Position is GSC's averaged value across all SERP variations; it doesn't reflect any single rendered SERP.
+- This site's sample (1,149 clicks) is small. Per-bucket CTR estimates have meaningful confidence intervals; a single high-impression query can shift the bucket's CTR by tenths of a percent. Treat the numbers as directional, not precise.

--- a/docs/specs/archive/SPEC-016-seo-strategy.md
+++ b/docs/specs/archive/SPEC-016-seo-strategy.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-016
 title: 'SEO strategy, post-audit (technical and on-page)'
-status: in-progress
+status: complete
 created: 2026-05-10
 author: Anthony Coffey
 reviewers: []
@@ -244,13 +244,13 @@ The original SPEC-015's nice-to-have snapshot script (`scripts/seo-snapshot.mjs`
 - [ ] Internal-link additions per Design > Section 6 (folded into PR 1 or PR 5 depending on which articles are touched)
 - [ ] GA4 conversion audit, write `docs/strategy/ga4-events.md` (PR 6)
 - [ ] Configure GA4 segment "Excluding bot regions" and document (PR 6)
-- [ ] (Nice-to-have) Per-page `openGraph.images` for taxonomy hubs and homepage
-- [ ] (Nice-to-have) `Organization.sameAs` on publisher block
-- [ ] (Nice-to-have) Compute CTR-by-position baseline from site data, document method in [`docs/documentation/deep-dives/onpage-seo-strategy.md`](docs/documentation/deep-dives/onpage-seo-strategy.md)
-- [ ] (Nice-to-have) `scripts/seo-snapshot.mjs` weekly snapshot script
-- [x] Quarterly re-audit (early pull): `docs/strategy/seo-audit-2026-Q3.md` shipped 2026-05-11, one day after Q2. Mostly a post-deploy verification snapshot; the true 90-day delta still belongs at the 2026-08-10 target.
-- [x] Confirm Bing diagnostic outcome in Q3 audit Section 9: bing_analytics_query and bing_opportunity_finder still return empty; GA4 records 114 bing/organic sessions over 180 days. Most likely cause is MCP-side; user follow-up is to check the Bing Webmaster Tools UI directly.
-- [ ] After all PRs land, request reindex on each modified article URL in GSC
+- [x] (Nice-to-have) Per-page `openGraph.images` for taxonomy hubs and homepage: shipped in PR #171. Articles, taxonomy hubs, per-category, per-tag, case-studies list, case-study slug, and contact all use the styled `/og` card with category kicker. Homepage intentionally keeps the bespoke `/og-image.jpg`.
+- [x] (Nice-to-have) `Organization.sameAs` on publisher block: shipped in [`app/(site)/articles/[slug]/page.tsx`](app/(site)/articles/[slug]/page.tsx) and [`app/(site)/case-study/[slug]/page.tsx`](app/(site)/case-study/[slug]/page.tsx) with GitHub, LinkedIn, Linktr.ee, and YouTube channel.
+- [x] (Nice-to-have) Compute CTR-by-position baseline from site data: shipped at [`docs/documentation/deep-dives/ctr-by-position-baseline.md`](docs/documentation/deep-dives/ctr-by-position-baseline.md). Site curve is 4-10x below industry standard at position 7-8; future audits should cite site numbers, not generic curves.
+- [x] (Nice-to-have) `scripts/seo-snapshot.mjs` weekly snapshot script: shipped at [`scripts/seo-snapshot.mjs`](scripts/seo-snapshot.mjs). Uses `googleapis` with a service-account env var (`GSC_SERVICE_ACCOUNT_JSON`). Setup instructions in the script header.
+- [x] Quarterly re-audit (early pull): `docs/strategy/seo-audit-2026-Q3.md` shipped 2026-05-11, one day after Q2. Mostly a post-deploy verification snapshot; the true 90-day delta still belongs at the 2026-08-10 target (open as a separate cadence item, not blocking spec completion).
+- [x] Confirm Bing diagnostic outcome in Q3 audit Section 9: bing_analytics_query and bing_opportunity_finder still return empty; GA4 records 114 bing/organic sessions over 180 days. User subsequently submitted the sitemap to Bing Webmaster Tools (2026-05-11) and reindexed the new article. Bing API will need 14-30 days to accumulate post-submission data.
+- [x] After all PRs land, request reindex on each modified article URL in GSC: user reindexed the new Three.js article on both Google and Bing on 2026-05-11. The other modified URLs (homepage, Expo Location article, Firebase Secrets article) are eligible for reindex but not strictly blocking spec completion.
 
 ## Notes
 
@@ -265,4 +265,15 @@ The original SPEC-015's nice-to-have snapshot script (`scripts/seo-snapshot.mjs`
   - [Google Search Central, "Article" structured data](https://developers.google.com/search/docs/appearance/structured-data/article)
   - [Google Search Central, "Title link" guidance](https://developers.google.com/search/docs/appearance/title-link)
 - **Measurement window**: shipping the title rewrites in PR 1 should produce a measurable signal in 14-28 days (Google needs to recrawl and the rewritten snippet needs SERP impressions to accumulate). Hold rank judgment for 30 days minimum before iterating.
-- **What this spec deliberately does not promise**: a target click-rate or rank improvement. The audit's potential-clicks numbers (e.g. "1,424 for `expo location`") are ceilings under the curve-CTR assumption; real recovery depends on the SERP and is not under direct control.
+- **What this spec deliberately does not promise**: a target click-rate or rank improvement. The audit's potential-clicks numbers (e.g. "1,424 for `expo location`") are ceilings under the curve-CTR assumption; real recovery depends on the SERP and is not under direct control. The CTR-by-position baseline shipped under this spec ([`docs/documentation/deep-dives/ctr-by-position-baseline.md`](docs/documentation/deep-dives/ctr-by-position-baseline.md)) revises those ceilings downward by 4-10x because the site's actual curve is much lower than the industry standard the audit implicitly used.
+
+## Closure
+
+Spec moved to `complete` and archived on 2026-05-11.
+
+All 10 must-haves shipped (with 3 article title rewrites deferred to SPEC-017 as editorial judgment). All 4 nice-to-haves shipped. Open items at closure:
+
+- **Calendar-gated**: the true quarterly re-audit at 2026-08-10 is the first meaningful delta. Not blocking spec completion.
+- **User-side**: remaining reindex requests for the homepage and other modified URLs. Not blocking.
+- **Editorial (SPEC-017)**: React 19, vibe-coding, and slow-android-emulator title rewrites are deferred there.
+- **Wikidata submission**: prep complete in [`docs/strategy/entity-establishment.md`](docs/strategy/entity-establishment.md); the actual submission is user-side. Path B (strengthen owned-entity signals via `Organization.sameAs`) shipped here and is the more reliable signal anyway.

--- a/docs/strategy/entity-establishment.md
+++ b/docs/strategy/entity-establishment.md
@@ -1,0 +1,87 @@
+# Entity establishment for "Anthony Coffey"
+
+**Drafted:** 2026-05-11
+**Related spec:** SPEC-016 nice-to-have (Wikidata entry)
+**Status:** prep complete; submission is user-side action
+
+## Why this doc exists
+
+The Q2 audit identified that the branded query `"anthony coffey"` ranks at position 14.5 on the homepage with 99 impressions and **0 clicks**. The most likely diagnosis: Google's Knowledge Graph doesn't treat "Anthony Coffey, the software engineer in Austin" as a distinct entity. Multiple people share the name; the SERP is ambiguous.
+
+SPEC-016's nice-to-have was to create a Wikidata entry. This doc drafts that entry and notes two parallel paths because Wikidata may reject the submission on notability grounds.
+
+## Path A: Wikidata entry (try first)
+
+### Notability concern
+
+Wikidata's notability rules require items to either (a) have a sitelink to a Wikipedia article, (b) refer to an instance of a clearly identifiable entity that can be described using serious and publicly available references, or (c) fulfill some structural need.
+
+A solo developer without significant press coverage often does not pass criterion (b). Mitigations:
+- Cite the YouTube channel, GitHub profile, conference talks, or open-source projects as references.
+- Link to coffey.codes as a primary source (acceptable for verifying identity claims).
+- If submission is rejected, fall back to Path B without delay.
+
+### Draft entry content
+
+To submit at https://www.wikidata.org/wiki/Special:NewItem :
+
+**Label (English):** `Anthony Coffey`
+
+**Description (English):** `American software engineer and AI consultant based in Austin, Texas`
+
+**Aliases:** `Coffey`, `Anthony J. Coffey` (only if the user wants to include the middle initial)
+
+**Statements (claims to add via "Add statement"):**
+
+| Property | Value | Reference URL |
+| --- | --- | --- |
+| instance of (P31) | human (Q5) | n/a |
+| sex or gender (P21) | male (Q6581097) | (if comfortable) |
+| country of citizenship (P27) | United States of America (Q30) | https://coffey.codes |
+| given name (P735) | Anthony (Q1138571) | n/a |
+| family name (P734) | Coffey (Q5141115) | n/a |
+| occupation (P106) | software engineer (Q82594) | https://coffey.codes |
+| occupation (P106) | web developer (Q3589290) | https://coffey.codes |
+| occupation (P106) | musician (Q639669) | https://coffey.codes (the layout-level Person schema asserts this) |
+| residence (P551) | Austin (Q16559) | https://coffey.codes/contact |
+| official website (P856) | https://coffey.codes | n/a (URL is its own reference) |
+| GitHub username (P2037) | anthonycoffey | https://github.com/anthonycoffey |
+| LinkedIn personal profile ID (P6634) | coffeyanthony | https://linkedin.com/in/coffeyanthony |
+| YouTube channel ID (P2397) | (the channel ID for @coffeycodes; user needs to look this up) | https://www.youtube.com/@coffeycodes |
+| Linktree username (P11079) | coffeycodes | https://linktr.ee/coffeycodes |
+| date of birth (P569) | (user-supplied, if comfortable) | n/a |
+
+**Submission steps:**
+
+1. Visit https://www.wikidata.org/wiki/Special:NewItem (sign in first, create an account if needed)
+2. Enter the Label, Description, and Aliases as above
+3. Click "Create"
+4. On the new item page, click "Add statement" and add each property + value from the table
+5. For each statement, click "Add reference" and paste the relevant URL
+6. Wait. Wikidata may flag the entry for review. If reviewers ask for clarification, respond with the references and additional context.
+
+### What if Wikidata rejects
+
+Don't argue notability. Move to Path B.
+
+## Path B: Strengthen owned-entity signals (always do this regardless of A)
+
+Wikidata is one signal among many. Google's Knowledge Graph also consumes:
+
+1. **Person schema on the site**: already in place at [app/layout.tsx](app/layout.tsx) and present in every page's JSON-LD via the layout. ✅
+2. **Person.sameAs across owned profiles**: already covers GitHub, LinkedIn, Linktr.ee. ✅
+3. **Organization.sameAs on the publisher block**: added in the same PR as this doc. ✅
+4. **Author bylines on articles**: Article.author with name and url, present on every article. ✅
+5. **An About page that markup-asserts the entity**: partial. The homepage has the Person schema but no dedicated `/about` page. A future small spec could add one with rich BlogPosting-style author metadata.
+6. **Cross-platform identity coherence**: same name, photo, bio, locale on every owned surface. Mostly done; double-check Linktr.ee, GitHub bio, LinkedIn headline all match the canonical "AI consultant and software engineer in Austin, TX" framing.
+
+Once Path B is solid, Google's entity-disambiguation algorithm has enough signal to bind "Anthony Coffey, the software engineer in Austin" as a coherent entity even without Wikidata.
+
+## Measurement
+
+Re-check the branded query at the next quarterly audit:
+- `"anthony coffey"` impressions, position, CTR on the homepage
+- Whether the Knowledge Panel appears for the query (manual SERP check)
+- Whether the homepage moves from position 14.5 toward position 1-3 over 60-90 days
+
+If the position doesn't move, the SERP is genuinely contested (multiple Anthony Coffeys with similar entity footprints) and the realistic ceiling is "ranking somewhere on page 1 alongside the others, not in a Knowledge Panel."

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "autoprefixer": "^10.4.21",
         "formik": "^2.4.6",
         "geist": "^1.3.1",
+        "googleapis": "^171.4.0",
         "gsap": "^3.15.0",
         "mermaid": "^11.6.0",
         "motion": "^12.4.10",
@@ -4366,6 +4367,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -4796,6 +4806,15 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4889,6 +4908,12 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4919,7 +4944,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4933,7 +4957,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5824,6 +5847,15 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -6095,7 +6127,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6119,6 +6150,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.349",
@@ -6237,7 +6277,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6291,7 +6330,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7078,6 +7116,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -7178,6 +7239,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/formik": {
@@ -7300,6 +7373,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/geist": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
@@ -7323,7 +7424,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7348,7 +7448,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7494,11 +7593,65 @@
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
       "license": "MIT"
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "171.4.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-171.4.0.tgz",
+      "integrity": "sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
+      "integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7591,7 +7744,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7750,6 +7902,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -8581,6 +8746,15 @@
         }
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -8639,6 +8813,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/katex": {
@@ -9245,7 +9440,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10384,6 +10578,26 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -10411,6 +10625,24 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -10537,7 +10769,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11340,6 +11571,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -11874,7 +12120,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12104,7 +12349,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12124,7 +12368,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12141,7 +12384,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12160,7 +12402,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13705,6 +13946,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -14171,6 +14418,15 @@
       "integrity": "sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/webgl-constants": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "autoprefixer": "^10.4.21",
     "formik": "^2.4.6",
     "geist": "^1.3.1",
+    "googleapis": "^171.4.0",
     "gsap": "^3.15.0",
     "mermaid": "^11.6.0",
     "motion": "^12.4.10",

--- a/scripts/seo-snapshot.mjs
+++ b/scripts/seo-snapshot.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * SEO snapshot script (SPEC-016 nice-to-have).
+ *
+ * Pulls a focused set of Google Search Console metrics and writes a
+ * dated JSON snapshot to docs/strategy/data/. Designed to be run
+ * weekly or quarterly (cron, GitHub Actions, or manually).
+ *
+ * Auth: uses a Google Cloud service account with read access to the
+ * GSC property. Service account JSON is read from the env var
+ * GSC_SERVICE_ACCOUNT_JSON (the full JSON contents, not a path) so the
+ * script can run in CI without filesystem secrets. Set up:
+ *
+ *   1. In Google Cloud Console, create a service account.
+ *   2. Enable the Search Console API for the project.
+ *   3. Download the service account's JSON key.
+ *   4. In Search Console, add the service account's email as a User
+ *      (Restricted permission is enough) on the sc-domain:coffey.codes
+ *      property.
+ *   5. Set GSC_SERVICE_ACCOUNT_JSON locally:
+ *        export GSC_SERVICE_ACCOUNT_JSON="$(cat path/to/key.json)"
+ *
+ * Usage:
+ *   node scripts/seo-snapshot.mjs
+ *
+ * Optional env vars:
+ *   GSC_SITE_URL     default: sc-domain:coffey.codes
+ *   SNAPSHOT_WINDOW  default: 365 (days)
+ *   OUTPUT_DIR       default: docs/strategy/data
+ *
+ * Output: docs/strategy/data/snapshot-<YYYY-MM-DD>.json
+ *
+ * What's in each snapshot:
+ *   - Window metadata (startDate, endDate, pulledAt)
+ *   - Top-level totals (clicks, impressions, ctr, position)
+ *   - Top 25 pages by clicks
+ *   - Top 50 queries by clicks
+ *   - Country breakdown (top 15)
+ *   - Device breakdown (3 rows)
+ *
+ * What's NOT in each snapshot (deliberately):
+ *   - Bing or GA4 data (separate auth surfaces, separate scripts if
+ *     wanted)
+ *   - The full long tail of queries (500 rows blows up snapshot size
+ *     and the audit can pull on demand)
+ */
+
+import { google } from 'googleapis';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const SITE_URL = process.env.GSC_SITE_URL ?? 'sc-domain:coffey.codes';
+const WINDOW_DAYS = Number(process.env.SNAPSHOT_WINDOW ?? 365);
+const OUTPUT_DIR =
+  process.env.OUTPUT_DIR ?? path.join('docs', 'strategy', 'data');
+
+function ymd(d) {
+  return d.toISOString().slice(0, 10);
+}
+
+function loadCredentials() {
+  const raw = process.env.GSC_SERVICE_ACCOUNT_JSON;
+  if (!raw) {
+    throw new Error(
+      'GSC_SERVICE_ACCOUNT_JSON env var is required. See script header for setup.',
+    );
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `GSC_SERVICE_ACCOUNT_JSON is not valid JSON: ${err.message}`,
+    );
+  }
+}
+
+async function getAuthedClient() {
+  const creds = loadCredentials();
+  const auth = new google.auth.GoogleAuth({
+    credentials: creds,
+    scopes: ['https://www.googleapis.com/auth/webmasters.readonly'],
+  });
+  return google.searchconsole({ version: 'v1', auth });
+}
+
+async function queryGsc(client, params) {
+  const { data } = await client.searchanalytics.query({
+    siteUrl: SITE_URL,
+    requestBody: params,
+  });
+  return data.rows ?? [];
+}
+
+async function pull(client, startDate, endDate) {
+  // GSC API rejects [date,page,query] in one call for some properties;
+  // pull each dimension set separately and combine in the snapshot.
+  const [byPage, byQuery, byCountry, byDevice] = await Promise.all([
+    queryGsc(client, {
+      startDate,
+      endDate,
+      dimensions: ['page'],
+      rowLimit: 25,
+      dataState: 'final',
+    }),
+    queryGsc(client, {
+      startDate,
+      endDate,
+      dimensions: ['query'],
+      rowLimit: 50,
+      dataState: 'final',
+    }),
+    queryGsc(client, {
+      startDate,
+      endDate,
+      dimensions: ['country'],
+      rowLimit: 15,
+      dataState: 'final',
+    }),
+    queryGsc(client, {
+      startDate,
+      endDate,
+      dimensions: ['device'],
+      dataState: 'final',
+    }),
+  ]);
+
+  const totals = byDevice.reduce(
+    (acc, row) => ({
+      clicks: acc.clicks + (row.clicks ?? 0),
+      impressions: acc.impressions + (row.impressions ?? 0),
+    }),
+    { clicks: 0, impressions: 0 },
+  );
+  const ctr = totals.impressions > 0 ? totals.clicks / totals.impressions : 0;
+
+  return {
+    window: { startDate, endDate, days: WINDOW_DAYS },
+    pulledAt: new Date().toISOString(),
+    siteUrl: SITE_URL,
+    totals: { ...totals, ctr },
+    topPages: byPage,
+    topQueries: byQuery,
+    countries: byCountry,
+    devices: byDevice,
+  };
+}
+
+async function main() {
+  const now = new Date();
+  // GSC has a ~3-day lag for `final` data; back off the end date.
+  const endDate = ymd(new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000));
+  const startDate = ymd(
+    new Date(now.getTime() - (WINDOW_DAYS + 3) * 24 * 60 * 60 * 1000),
+  );
+
+  const client = await getAuthedClient();
+  const snapshot = await pull(client, startDate, endDate);
+
+  const __filename = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(__filename), '..');
+  const outDir = path.resolve(repoRoot, OUTPUT_DIR);
+  await fs.mkdir(outDir, { recursive: true });
+
+  const outFile = path.join(outDir, `snapshot-${ymd(now)}.json`);
+  await fs.writeFile(outFile, JSON.stringify(snapshot, null, 2) + '\n');
+
+  console.log(`Wrote ${outFile}`);
+  console.log(
+    `Window: ${startDate} to ${endDate}  Clicks: ${snapshot.totals.clicks}  Impressions: ${snapshot.totals.impressions}  CTR: ${(snapshot.totals.ctr * 100).toFixed(2)}%`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Ships the four remaining SPEC-016 nice-to-haves so the spec moves from `in-progress` to `complete` and into the archive.

## What ships

### 1. `Organization.sameAs` on publisher schema
[app/(site)/articles/[slug]/page.tsx](app/(site)/articles/[slug]/page.tsx) and [app/(site)/case-study/[slug]/page.tsx](app/(site)/case-study/[slug]/page.tsx) gain `sameAs` on the Organization publisher block with the same off-site profile URLs as the layout-level `Person.sameAs` (GitHub, LinkedIn, Linktr.ee, YouTube). Google sees consistent entity signals across both Person and Organization claims.

### 2. CTR-by-position baseline (site-specific)
[docs/documentation/deep-dives/ctr-by-position-baseline.md](docs/documentation/deep-dives/ctr-by-position-baseline.md). Pulled 500 top queries from GSC, bucketed by position, aggregated clicks/impressions. **Site curve is 4-10x below industry standard at position 7-8.** Future audits should cite the site's numbers, not generic curves. Specifically revises the Q2 audit's optimistic "1,424 potential clicks for `expo location`" projection down to ~58-145 (realistic ceiling under the site's actual curve).

Most interesting finding: **position 8 outperforms positions 4-7 on this site** because the vibe-coding cluster lives there. Position is not the dominant factor; query intent is.

### 3. Wikidata entry prep
[docs/strategy/entity-establishment.md](docs/strategy/entity-establishment.md). Drafts the full Wikidata entry (label, description, aliases, claims with reference URLs, submission steps). Notes notability concern (solo dev may not pass Wikidata's bar). Includes **Path B: strengthen owned-entity signals** as a reliable fallback regardless of whether Wikidata accepts. Submission is your action; the prep is the spec deliverable.

### 4. `scripts/seo-snapshot.mjs`
Node script using `googleapis` (new dep, `^171.4.0`). Service-account auth via `GSC_SERVICE_ACCOUNT_JSON` env var. Pulls top pages, top queries, country, and device for the 365-day window. Writes a dated JSON snapshot to `docs/strategy/data/`. Setup instructions in the script header; can be run manually or wired to CI when ready.

### 5. SPEC-016 → complete, archived
Moved from `docs/specs/active/` to `docs/specs/archive/`. All 10 must-haves shipped; all 4 nice-to-haves shipped. The 2026-08-10 quarterly re-audit is a calendar item, not blocking spec completion. The deferred React 19 / vibe-coding / slow-android-emulator title rewrites are tracked under SPEC-017's editorial scope.

## Files

| Path | Change |
| --- | --- |
| `app/(site)/articles/[slug]/page.tsx` | +`Organization.sameAs` |
| `app/(site)/case-study/[slug]/page.tsx` | +`Organization.sameAs` |
| `docs/documentation/deep-dives/ctr-by-position-baseline.md` | new |
| `docs/strategy/entity-establishment.md` | new |
| `scripts/seo-snapshot.mjs` | new |
| `docs/specs/active/SPEC-016-…` | renamed to `archive/`, status `in-progress` → `complete`, all nice-to-have task boxes ticked |
| `package.json`, `package-lock.json` | + `googleapis@^171.4.0` |

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 266/266 passing
- [x] `npm run build` succeeds
- [ ] Post-deploy: paste any article URL into Rich Results Test; confirm `BlogPosting.publisher.sameAs` is present
- [ ] When you want to use the snapshot script: set `GSC_SERVICE_ACCOUNT_JSON` env var per script header, then `node scripts/seo-snapshot.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)