### PR TITLE
docs: SPEC-018 postscript — Q3 audit Bing finding + agent brief snapshot section

### DIFF
--- a/docs/documentation/agents/coffey-codes.md
+++ b/docs/documentation/agents/coffey-codes.md
@@ -136,6 +136,25 @@ npm run test:e2e       # Playwright e2e (requires dev server)
 npm run typecheck      # tsc --noEmit
 ```
 
+### Pull and compare SEO snapshots
+
+`scripts/seo-snapshot.mjs` (SPEC-018) pulls GSC, GA4, and Bing in one shot, writing a dated JSON file to `docs/strategy/data/`. Snapshots are committed to git so older periods (GSC's window only goes back 16 months) stay diffable.
+
+```bash
+node scripts/seo-snapshot.mjs                  # all configured engines, 365d
+node scripts/seo-snapshot.mjs --engines=gsc    # one engine only
+node scripts/seo-snapshot.mjs --dry-run        # print plan, skip API calls
+node scripts/seo-snapshot-diff.mjs older.json newer.json
+```
+
+Setup (env vars in `.env` or `.env.local`):
+
+- `GSC_SERVICE_ACCOUNT_KEY_PATH` or `GSC_SERVICE_ACCOUNT_JSON` (Google service account; same account used for GA4)
+- `GA4_PROPERTY_ID` (currently `416080229`; Data API enabled in Cloud, service account granted Viewer in GA4 Property Access)
+- `BING_WEBMASTER_API_KEY` (generated in Bing Webmaster Tools → Settings → API Access)
+
+Each engine skips gracefully if its env vars are missing. Full script header doc is in `scripts/seo-snapshot.mjs`.
+
 Vitest + Testing Library + jsdom is configured for unit and component tests (220+ tests across 40 files). Playwright e2e lives in `e2e/` and exercises rendered pages against a live dev server. TDD (RED → GREEN → REFACTOR) is the expected workflow per `docs/documentation/development-standards.md`.
 
 ## Known Gotchas

--- a/docs/strategy/seo-audit-2026-Q3.md
+++ b/docs/strategy/seo-audit-2026-Q3.md
@@ -125,6 +125,21 @@ Three plausible causes, in order of likelihood:
 
 Either way, the Q2 audit's Bing section interpretation ("no comparison possible") stands. Re-test at the next quarterly.
 
+### Postscript (2026-05-11, SPEC-018)
+
+The SPEC-018 snapshot script bypasses the MCP and calls the Bing Webmaster Tools REST API directly (`GetRankAndTrafficStats`, `GetQueryStats`) with a fresh API key generated through the Webmaster Tools UI. Result in `docs/strategy/data/snapshot-2026-05-11.json`:
+
+```json
+"bing": { "totals": { "clicks": 0, "impressions": 0, "ctr": 0 }, "topQueries": [], "_note": "empty response" }
+```
+
+The direct API returns the same empty result the MCP does. This eliminates cause #1 (MCP-side bug) from the list above. The remaining causes are now ordered:
+
+1. **Bing Webmaster API permission scope**: the UI-generated API key may not return performance data even though the account is verified. Cross-check the [Bing Webmaster Tools UI](https://www.bing.com/webmasters/) Search Performance report directly; if the UI shows clicks/impressions, file a support ticket about API key scope. If the UI is also empty, move to #2.
+2. **Bing Webmaster Tools genuinely has no recorded data** for the property despite GA4 seeing 114 Bing sessions in 180 days. This would be a Bing-side data-pipeline gap, not anything actionable from the codebase.
+
+Next quarterly audit (target 2026-08-10): re-run the snapshot, diff against this baseline using `scripts/seo-snapshot-diff.mjs`, see if `bing.totals.impressions` has moved off zero.
+
 ## 9.5 GA4 cross-reference (180 days, post-config-change)
 
 Compared against the Q2 pull. The GA4 walk-through on 2026-05-10 changed three things: `form_start` toggled OFF as a key event, `form_submit` GTM tag created and toggled ON as a key event, Google EU Consent Policy attestation affirmed.


### PR DESCRIPTION
## Summary

- Q3 audit Section 9 postscript: SPEC-018's direct Bing API call returns the same empty response the MCP did, eliminating the MCP-side-bug hypothesis. Remaining causes shift to API key scope or genuinely-absent Bing data.
- Agent brief picks up a 'Pull and compare SEO snapshots' section covering the two scripts, the three env vars, and graceful-skip behavior.

Follow-up to the merged [#174](https://github.com/anthonycoffey/coffey.codes/pull/174); no code changes.

## Test plan

- [ ] Read the Q3 audit postscript; verify the diagnosis chain still reads cleanly.
- [ ] Read the agent brief task entry; verify the env var names match what's in scripts/seo-snapshot.mjs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)