### PR TITLE
docs: archive SPEC-019, mark complete [SPEC-019]

### DIFF
--- a/docs/specs/archive/SPEC-019-case-study-content-rewrite-postgis-fleet-optimization.md
+++ b/docs/specs/archive/SPEC-019-case-study-content-rewrite-postgis-fleet-optimization.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-019
 title: 'Case Study Content Rewrite: PostGIS Fleet Optimization'
-status: ready
+status: complete
 created: 2026-05-14
 author: Anthony Coffey
 reviewers: []
@@ -91,9 +91,9 @@ Before: all dimensions near 0. After: all dimensions at 4–5.
 - [x] Replace both chart blocks with capability-score (0–5) before/after data
 - [x] Remove the PDF download CTA: drop `pdfPath` field + interface member, delete `components/CaseStudyPdfCta.tsx`, delete `public/case-studies/` (and PDF asset), drop the related vi.mock and e2e assertion
 - [x] Update the e2e Challenge-text assertion to match the new copy
-- [ ] Verify `/case-study/postgis-fleet-optimization` renders correctly in dev
-- [ ] Spot-check mobile layout — no truncation issues on stats/charts
-- [ ] Move spec to `docs/specs/archive/` when merged
+- [x] Verify `/case-study/postgis-fleet-optimization` renders correctly in dev
+- [x] Spot-check mobile layout — no truncation issues on stats/charts
+- [x] Move spec to `docs/specs/archive/` when merged
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

- Stacked on top of #179. Moves `SPEC-019` from `docs/specs/active/` → `docs/specs/archive/` and flips status `ready` → `complete`. Final verification + archive tasks ticked off.
- Base branch is `claude/mystifying-newton-a49759` so it picks up the spec doc from #179. GitHub will auto-retarget to `main` once #179 merges. Merge this one second.

## Test plan

- [x] `git mv` preserves history (rename detected as 96% similarity)
- [x] No code touched — docs-only change
- [ ] Confirm #179 merges first so the rebase onto main is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
