### PR TITLE
feat: emit Markdown summary alongside JSON for each SEO snapshot

### DIFF
--- a/docs/strategy/data/snapshot-2026-05-11.md
+++ b/docs/strategy/data/snapshot-2026-05-11.md
@@ -1,0 +1,158 @@
+---
+title: SEO snapshot — 2026-05-11
+tags: [seo, snapshot, gsc, ga4, bing, keywords]
+date: 2026-05-11
+window_start: 2025-05-08
+window_end: 2026-05-08
+---
+
+# SEO snapshot — 2026-05-11
+
+**Window:** 2025-05-08 → 2026-05-08 (365 days)  
+**Site:** `sc-domain:coffey.codes`  
+**Pulled:** 2026-05-11T06:15:28.869Z
+
+## Headline numbers
+
+| Source | Clicks | Impressions | CTR | Sessions |
+|---|---:|---:|---:|---:|
+| Google Search Console | 1,152 | 294,996 | 0.39% | — |
+| Bing Webmaster *(empty response)* | 0 | 0 | 0.00% | — |
+| GA4 (all channels) | — | — | — | 8,318 |
+| GA4 (excluding bot regions: China, Singapore) | — | — | — | 6,716 |
+
+## GSC — top pages
+
+| URL | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| /articles/building-location-based-features-using-expo-location | 390 | 151,786 | 0.26% | 6.8 |
+| /articles/vibe-coding-building-an-app-entirely-with-ai-prompts | 248 | 9,062 | 2.74% | 8.5 |
+| /articles/slow-android-emulator-flutter-dev | 237 | 71,286 | 0.33% | 5.8 |
+| /articles/managing-secrets-firebase-apphosting-yaml-nextjs | 180 | 43,542 | 0.41% | 7.5 |
+| /articles/react-19-features-and-design-patterns | 52 | 15,329 | 0.34% | 8.6 |
+| /Anthony%20Coffey%20-%20Resume.pdf | 15 | 465 | 3.23% | 39.7 |
+| /articles/authorize-net-for-react-native-expo-sdk-49 | 15 | 885 | 1.69% | 11.5 |
+| / | 4 | 310 | 1.29% | 13.9 |
+| /contact | 4 | 221 | 1.81% | 26.4 |
+| /articles/setting-up-ci-cd-for-firebase-functions-using-github-actions | 3 | 594 | 0.51% | 12.1 |
+| /articles/how-to-end-a-process-by-port-number | 2 | 706 | 0.28% | 19.9 |
+| /articles/step-by-step-building-your-blog-with-next-js-and-mdx | 1 | 632 | 0.16% | 17.5 |
+| /articles/tag/unit%20testing? | 1 | 9 | 11.11% | 6.3 |
+| /articles | 0 | 96 | 0.00% | 8.4 |
+| /articles/building-an-mdx-powered-blog-using-app-router-next-js | 0 | 264 | 0.00% | 24.4 |
+
+## GSC — top queries
+
+| Query | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| flutter vibe coding | 49 | 1,088 | 4.50% | 8.5 |
+| expo location | 24 | 9,696 | 0.25% | 7.7 |
+| vibe coding flutter | 24 | 649 | 3.70% | 8.3 |
+| vibe coding flutter app | 15 | 218 | 6.88% | 7.4 |
+| expo-location | 10 | 5,298 | 0.19% | 6.6 |
+| vibe code flutter app | 9 | 157 | 5.73% | 7.5 |
+| expo geofencing | 7 | 216 | 3.24% | 7.6 |
+| firebase apphosting:secrets:grantaccess | 7 | 386 | 1.81% | 6.2 |
+| firebase apphosting:secrets:set | 6 | 192 | 3.13% | 5.4 |
+| vibe code flutter | 6 | 144 | 4.17% | 8.2 |
+| expo location accuracy | 5 | 132 | 3.79% | 5.6 |
+| flutter vibe code | 4 | 53 | 7.55% | 7.5 |
+| expo geolocation | 3 | 495 | 0.61% | 6.9 |
+| expo location example | 3 | 47 | 6.38% | 8.5 |
+| react native expo location | 3 | 230 | 1.30% | 5.1 |
+| requestforegroundpermissionsasync | 3 | 224 | 1.34% | 7.8 |
+| android emulator slow | 2 | 387 | 0.52% | 7.4 |
+| apphosting.yaml | 2 | 449 | 0.45% | 8.5 |
+| expo gps | 2 | 259 | 0.77% | 7.6 |
+| expo location api | 2 | 237 | 0.84% | 5.0 |
+| expo location permission | 2 | 56 | 3.57% | 8.7 |
+| expo location tracking | 2 | 33 | 6.06% | 6.4 |
+| firebase app hosting secrets | 2 | 204 | 0.98% | 6.5 |
+| flutter vibe coding platform | 2 | 31 | 6.45% | 8.0 |
+| location.watchpositionasync | 2 | 63 | 3.17% | 6.7 |
+| react 19 best practices | 2 | 73 | 2.74% | 9.6 |
+| vibe coding for flutter | 2 | 57 | 3.51% | 8.5 |
+| why android emulator is slow | 2 | 84 | 2.38% | 4.7 |
+| android emulator very slow | 1 | 136 | 0.74% | 6.8 |
+| apphosting.yaml firebase | 1 | 88 | 1.14% | 8.4 |
+
+## GSC — countries
+
+| Country | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| usa | 184 | 170,752 | 0.11% | 6.9 |
+| ind | 85 | 11,767 | 0.72% | 7.1 |
+| deu | 72 | 4,959 | 1.45% | 6.6 |
+| gbr | 47 | 11,745 | 0.40% | 5.8 |
+| fra | 43 | 4,078 | 1.05% | 7.4 |
+| can | 35 | 6,816 | 0.51% | 7.2 |
+| esp | 35 | 3,253 | 1.08% | 7.2 |
+| bel | 30 | 1,050 | 2.86% | 6.4 |
+| ita | 27 | 2,666 | 1.01% | 7.9 |
+| idn | 26 | 2,997 | 0.87% | 6.4 |
+
+## GSC — devices
+
+| Device | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| DESKTOP | 913 | 262,889 | 0.35% | 7.2 |
+| MOBILE | 233 | 27,709 | 0.84% | 4.8 |
+| TABLET | 6 | 4,398 | 0.14% | 6.7 |
+
+## GA4 — traffic sources
+
+| Channel | Source | Medium | Sessions | Conversions |
+|---|---|---|---:|---:|
+| Direct | (direct) | (none) | 6,086 | 62 |
+| Organic Search | google | organic | 1,549 | 7 |
+| Organic Search | bing | organic | 238 | 0 |
+| Unassigned | (not set) | (not set) | 111 | 5 |
+| Organic Search | duckduckgo | organic | 109 | 1 |
+| Referral | chatgpt.com | referral | 62 | 0 |
+| Organic Social | m.facebook.com | referral | 31 | 1 |
+| Referral | github.com | referral | 27 | 1 |
+| Organic Social | facebook.com | referral | 25 | 0 |
+| Referral | vercel.com | referral | 24 | 3 |
+
+### GA4 — traffic sources (bot regions excluded)
+
+| Channel | Source | Medium | Sessions | Conversions |
+|---|---|---|---:|---:|
+| Direct | (direct) | (none) | 4,567 | 60 |
+| Organic Search | google | organic | 1,529 | 6 |
+| Organic Search | bing | organic | 231 | 0 |
+| Organic Search | duckduckgo | organic | 109 | 1 |
+| Referral | chatgpt.com | referral | 62 | 0 |
+| Unassigned | (not set) | (not set) | 56 | 5 |
+| Organic Social | m.facebook.com | referral | 31 | 1 |
+| Referral | github.com | referral | 27 | 1 |
+| Organic Social | facebook.com | referral | 25 | 0 |
+| Referral | vercel.com | referral | 24 | 3 |
+
+## GA4 — organic landing pages
+
+| Page | Sessions | Bounce | Engaged | Avg dur |
+|---|---:|---:|---:|---:|
+| /articles/building-location-based-features-using-expo-location | 464 | 39.22% | 60.78% | 3m 5s |
+| /articles/vibe-coding-building-an-app-entirely-with-ai-prompts | 422 | 36.97% | 63.03% | 2m 8s |
+| (not set) | 336 | 98.51% | 1.49% | 4s |
+| /articles/slow-android-emulator-flutter-dev | 243 | 49.38% | 50.62% | 3m 8s |
+| /articles/managing-secrets-firebase-apphosting-yaml-nextjs | 221 | 36.20% | 63.80% | 3m 58s |
+| /articles/react-19-features-and-design-patterns | 76 | 53.95% | 46.05% | 2m 39s |
+| /articles/how-to-see-when-a-file-was-deleted-or-changed-with-git-log | 47 | 51.06% | 48.94% | 2m 26s |
+| / | 28 | 21.43% | 78.57% | 3m 48s |
+| /articles/preventing-unnecessary-re-renders-in-react-apps | 25 | 52.00% | 48.00% | 2m 56s |
+| /articles/authorize-net-for-react-native-expo-sdk-49 | 18 | 50.00% | 50.00% | 1m 5s |
+
+## GA4 — user behavior (devices)
+
+| Device | Active users | Sessions | Engagement |
+|---|---:|---:|---:|
+| desktop | 6,815 | 7,813 | 19.34% |
+| mobile | 500 | 593 | 44.86% |
+| tablet | 7 | 9 | 44.44% |
+
+## Notes
+
+- Bot regions excluded from `*ExBotRegions` slices: China, Singapore (per SPEC-018).
+- Full structured data: `snapshot-2026-05-11.json` next to this file.

--- a/scripts/lib/snapshot-markdown.mjs
+++ b/scripts/lib/snapshot-markdown.mjs
@@ -1,0 +1,201 @@
+// Renders an SEO snapshot JSON object into a Markdown summary.
+// Pairs with seo-snapshot.mjs — the script writes both `snapshot-<date>.json`
+// (for diff/data-viz tooling) and `snapshot-<date>.md` (for AI tools and
+// human skim). Markdown is intentionally compact and section-cap'd; the raw
+// JSON is still the source of truth for full data.
+
+const fmtInt = (n) => (Number.isFinite(+n) ? Math.round(+n).toLocaleString('en-US') : '—');
+const fmtPct = (n, d = 2) => (Number.isFinite(+n) ? (n * 100).toFixed(d) + '%' : '—');
+const fmtPos = (n) => (Number.isFinite(+n) ? (+n).toFixed(1) : '—');
+const fmtNum = (n, d = 2) => (Number.isFinite(+n) ? (+n).toFixed(d) : '—');
+
+function fmtDuration(seconds) {
+  if (!Number.isFinite(+seconds)) return '—';
+  const s = Math.round(+seconds);
+  const m = Math.floor(s / 60);
+  return m > 0 ? `${m}m ${s % 60}s` : `${s}s`;
+}
+
+function shortenUrl(u) {
+  if (!u) return '';
+  return u
+    .replace(/^https?:\/\/[^/]+/, '')
+    .replace(/^\/+$/, '/')
+    || '/';
+}
+
+// GA4 returns parallel arrays — zip them into objects keyed by header name.
+function ga4Rows(section) {
+  if (!section?.rows?.length) return [];
+  const dimNames = (section.dimensionHeaders ?? []).map((h) => h.name);
+  const metNames = (section.metricHeaders ?? []).map((h) => h.name);
+  return section.rows.map((row) => {
+    const o = {};
+    (row.dimensionValues ?? []).forEach((v, i) => (o[dimNames[i] ?? `dim${i}`] = v.value));
+    (row.metricValues ?? []).forEach((v, i) => (o[metNames[i] ?? `met${i}`] = v.value));
+    return o;
+  });
+}
+
+function renderGscTopPages(rows, limit = 15) {
+  if (!rows?.length) return '_(no GSC top-pages data)_';
+  const head = '| URL | Clicks | Impr | CTR | Pos |\n|---|---:|---:|---:|---:|';
+  const body = rows.slice(0, limit).map((r) => {
+    const url = shortenUrl(r.keys?.[0] ?? '');
+    return `| ${url} | ${fmtInt(r.clicks)} | ${fmtInt(r.impressions)} | ${fmtPct(r.ctr)} | ${fmtPos(r.position)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+function renderGscTopQueries(rows, limit = 30) {
+  if (!rows?.length) return '_(no GSC top-queries data)_';
+  const head = '| Query | Clicks | Impr | CTR | Pos |\n|---|---:|---:|---:|---:|';
+  const body = rows.slice(0, limit).map((r) => {
+    const q = (r.keys?.[0] ?? '').replace(/\|/g, '\\|');
+    return `| ${q} | ${fmtInt(r.clicks)} | ${fmtInt(r.impressions)} | ${fmtPct(r.ctr)} | ${fmtPos(r.position)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+function renderGscBreakdown(rows, label, limit = 10) {
+  if (!rows?.length) return `_(no ${label} data)_`;
+  const head = `| ${label} | Clicks | Impr | CTR | Pos |\n|---|---:|---:|---:|---:|`;
+  const body = rows.slice(0, limit).map((r) => {
+    return `| ${r.keys?.[0] ?? '?'} | ${fmtInt(r.clicks)} | ${fmtInt(r.impressions)} | ${fmtPct(r.ctr)} | ${fmtPos(r.position)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+function renderGa4TrafficSources(section, limit = 10) {
+  const rows = ga4Rows(section);
+  if (!rows.length) return '_(no GA4 traffic-sources data)_';
+  // Sort by sessions DESC (numeric)
+  rows.sort((a, b) => +b.sessions - +a.sessions);
+  const head = '| Channel | Source | Medium | Sessions | Conversions |\n|---|---|---|---:|---:|';
+  const body = rows.slice(0, limit).map((r) => {
+    return `| ${r.sessionDefaultChannelGroup ?? '?'} | ${r.sessionSource ?? '?'} | ${r.sessionMedium ?? '?'} | ${fmtInt(r.sessions)} | ${fmtNum(r.conversions, 0)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+function renderGa4LandingPages(section, limit = 10) {
+  const rows = ga4Rows(section);
+  if (!rows.length) return '_(no GA4 organic-landing-pages data)_';
+  rows.sort((a, b) => +b.sessions - +a.sessions);
+  const head = '| Page | Sessions | Bounce | Engaged | Avg dur |\n|---|---:|---:|---:|---:|';
+  const body = rows.slice(0, limit).map((r) => {
+    return `| ${shortenUrl(r.landingPagePlusQueryString)} | ${fmtInt(r.sessions)} | ${fmtPct(r.bounceRate)} | ${fmtPct(r.engagementRate)} | ${fmtDuration(r.averageSessionDuration)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+function renderGa4UserBehavior(section) {
+  // Devices subsection is the most useful skim.
+  const rows = ga4Rows(section?.devices);
+  if (!rows.length) return '_(no GA4 user-behavior data)_';
+  const head = '| Device | Active users | Sessions | Engagement |\n|---|---:|---:|---:|';
+  const body = rows.map((r) => {
+    return `| ${r.deviceCategory ?? '?'} | ${fmtInt(r.activeUsers)} | ${fmtInt(r.sessions)} | ${fmtPct(r.engagementRate)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+function ga4TotalSessions(section) {
+  const rows = ga4Rows(section);
+  return rows.reduce((sum, r) => sum + (+r.sessions || 0), 0);
+}
+
+export function renderSnapshotMarkdown(snapshot) {
+  const date = (snapshot.pulledAt ?? '').slice(0, 10) || new Date().toISOString().slice(0, 10);
+  const win = snapshot.window ?? snapshot.gsc?.window ?? {};
+
+  const lines = [];
+
+  lines.push(
+    '---',
+    `title: SEO snapshot — ${date}`,
+    `tags: [seo, snapshot, gsc, ga4, bing, keywords]`,
+    `date: ${date}`,
+    `window_start: ${win.startDate ?? ''}`,
+    `window_end: ${win.endDate ?? ''}`,
+    '---',
+    '',
+    `# SEO snapshot — ${date}`,
+    '',
+    `**Window:** ${win.startDate ?? '?'} → ${win.endDate ?? '?'} (${win.days ?? '?'} days)  `,
+    `**Site:** \`${snapshot.siteUrl ?? '?'}\`  `,
+    `**Pulled:** ${snapshot.pulledAt ?? '?'}`,
+    '',
+  );
+
+  // Headline numbers
+  lines.push('## Headline numbers', '');
+  const headRows = [];
+  if (snapshot.gsc?.totals) {
+    headRows.push(`| Google Search Console | ${fmtInt(snapshot.gsc.totals.clicks)} | ${fmtInt(snapshot.gsc.totals.impressions)} | ${fmtPct(snapshot.gsc.totals.ctr)} | — |`);
+  }
+  if (snapshot.bing?.totals) {
+    const note = snapshot.bing._note ? ` *(${snapshot.bing._note})*` : '';
+    headRows.push(`| Bing Webmaster${note} | ${fmtInt(snapshot.bing.totals.clicks)} | ${fmtInt(snapshot.bing.totals.impressions)} | ${fmtPct(snapshot.bing.totals.ctr)} | — |`);
+  }
+  if (snapshot.ga4?.trafficSources) {
+    const total = ga4TotalSessions(snapshot.ga4.trafficSources);
+    headRows.push(`| GA4 (all channels) | — | — | — | ${fmtInt(total)} |`);
+  }
+  if (snapshot.ga4?.trafficSourcesExBotRegions) {
+    const total = ga4TotalSessions(snapshot.ga4.trafficSourcesExBotRegions);
+    headRows.push(`| GA4 (excluding bot regions: ${(snapshot.ga4.botRegionsExcluded ?? []).join(', ') || '—'}) | — | — | — | ${fmtInt(total)} |`);
+  }
+  if (headRows.length) {
+    lines.push('| Source | Clicks | Impressions | CTR | Sessions |', '|---|---:|---:|---:|---:|', ...headRows, '');
+  } else {
+    lines.push('_(no engines returned headline data)_', '');
+  }
+
+  // GSC
+  if (snapshot.gsc) {
+    lines.push('## GSC — top pages', '', renderGscTopPages(snapshot.gsc.topPages), '');
+    lines.push('## GSC — top queries', '', renderGscTopQueries(snapshot.gsc.topQueries), '');
+    lines.push('## GSC — countries', '', renderGscBreakdown(snapshot.gsc.countries, 'Country'), '');
+    lines.push('## GSC — devices', '', renderGscBreakdown(snapshot.gsc.devices, 'Device', 5), '');
+  }
+
+  // GA4
+  if (snapshot.ga4) {
+    lines.push('## GA4 — traffic sources', '', renderGa4TrafficSources(snapshot.ga4.trafficSources), '');
+    if (snapshot.ga4.trafficSourcesExBotRegions) {
+      lines.push('### GA4 — traffic sources (bot regions excluded)', '', renderGa4TrafficSources(snapshot.ga4.trafficSourcesExBotRegions), '');
+    }
+    lines.push('## GA4 — organic landing pages', '', renderGa4LandingPages(snapshot.ga4.organicLandingPages), '');
+    lines.push('## GA4 — user behavior (devices)', '', renderGa4UserBehavior(snapshot.ga4.userBehavior), '');
+  }
+
+  // Bing — only render detail section if there's something useful
+  if (snapshot.bing && (snapshot.bing.topQueries?.length || snapshot.bing.trafficStats?.length)) {
+    lines.push('## Bing — top queries', '');
+    lines.push(renderGscTopQueries(snapshot.bing.topQueries, 15));
+    lines.push('');
+  }
+
+  // Keywords (Google Ads Planner) — terse summary if present
+  if (snapshot.keywords) {
+    const k = snapshot.keywords;
+    lines.push(
+      '## Keywords (Google Ads Planner)',
+      '',
+      `- Historical metrics returned: **${fmtInt(k.historicalMetrics?.length ?? 0)}**`,
+      `- Keyword ideas returned: **${fmtInt(k.ideas?.length ?? 0)}**`,
+      '',
+    );
+  }
+
+  // Notes
+  lines.push('## Notes', '');
+  if (snapshot.ga4?.botRegionsExcluded?.length) {
+    lines.push(`- Bot regions excluded from \`*ExBotRegions\` slices: ${snapshot.ga4.botRegionsExcluded.join(', ')} (per SPEC-018).`);
+  }
+  lines.push('- Full structured data: `snapshot-' + date + '.json` next to this file.');
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/scripts/seo-snapshot.mjs
+++ b/scripts/seo-snapshot.mjs
@@ -76,6 +76,7 @@ import {
   generateKeywordIdeas,
   generateHistoricalMetrics,
 } from './lib/google-ads.mjs';
+import { renderSnapshotMarkdown } from './lib/snapshot-markdown.mjs';
 import { promises as fs } from 'fs';
 import { existsSync, readFileSync } from 'fs';
 import path from 'path';
@@ -640,7 +641,12 @@ async function main() {
   const outFile = path.join(outDir, `snapshot-${ymd(now)}.json`);
   await fs.writeFile(outFile, JSON.stringify(snapshot, null, 2) + '\n');
 
+  // Companion Markdown summary — same data, condensed, RAG-ingestible.
+  const mdFile = path.join(outDir, `snapshot-${ymd(now)}.md`);
+  await fs.writeFile(mdFile, renderSnapshotMarkdown(snapshot));
+
   console.log(`Wrote ${outFile}  (engines: ${enginesWithData.join(', ')})`);
+  console.log(`Wrote ${mdFile}`);
   if (snapshot.gsc) {
     console.log(
       `GSC window: ${startDate} to ${endDate}  Clicks: ${snapshot.gsc.totals.clicks}  Impressions: ${snapshot.gsc.totals.impressions}  CTR: ${(snapshot.gsc.totals.ctr * 100).toFixed(2)}%`,


### PR DESCRIPTION
## Summary

The SEO snapshot script now writes a companion `snapshot-<date>.md` alongside the existing `snapshot-<date>.json` in `docs/strategy/data/`. JSON stays the source of truth for diff tooling and data-viz; Markdown is a condensed, frontmatter-tagged summary aimed at AI/RAG tools that consume the repo's docs tree.

- New `scripts/lib/snapshot-markdown.mjs` — renderer module.
- `scripts/seo-snapshot.mjs` imports the renderer and writes the `.md` file next to the `.json` after the JSON write succeeds.
- Backfilled `docs/strategy/data/snapshot-2026-05-11.md` so today's snapshot ships with both files.

Rendered Markdown is ~6.6 KB and includes:
- Headline numbers across GSC, Bing, and GA4 (with bot-region-excluded variant)
- GSC top pages (15), top queries (30), countries (10), devices
- GA4 traffic sources, organic landing pages, user behavior by device
- Bing + Keywords sections rendered only when present

## Test plan

- [x] \`node scripts/seo-snapshot.mjs --dry-run\` (no-op, just sanity-checks the import chain)
- [x] Run a real snapshot and confirm both \`snapshot-<date>.json\` and \`snapshot-<date>.md\` appear in \`docs/strategy/data/\`
- [x] Spot-check the Markdown — totals match the JSON, top-N tables are sorted DESC

🤖 Generated with [Claude Code](https://claude.com/claude-code)