### PR TITLE
docs(spec-017): ship content-strategy bookkeeping (disposition, calendar, voice guide, brief template)

### DIFF
--- a/app/(site)/articles/posts/three-js-portfolio-website-for-software-engineer.mdx
+++ b/app/(site)/articles/posts/three-js-portfolio-website-for-software-engineer.mdx
@@ -11,8 +11,6 @@ One day it hit me: nobody was *really* reading the copy on my homepage. My old s
 
 The site is the portfolio now, not the words about the portfolio. No one cares about the words, they care about the work. The 3D scene is the work, and the copy that is shown now is more human. The homepage is the hook, the portfolio and contact pages are the close.
 
-The video walks through the build:
-
 <div className="not-prose relative w-full aspect-video md:aspect-auto md:h-[500px] lg:h-[600px] my-8 overflow-hidden rounded-lg">
   <iframe
     src="https://www.youtube-nocookie.com/embed/H0wzqgMeGpU"

--- a/docs/documentation/guides/voice-and-style.md
+++ b/docs/documentation/guides/voice-and-style.md
@@ -1,0 +1,76 @@
+---
+title: 'Voice and style'
+spec: SPEC-017
+audience: 'humans drafting copy; AI agents drafting or refreshing articles'
+status: living-document
+---
+
+# Voice and style
+
+One page. Every article, landing page, and homepage block on coffey.codes follows these rules. Short on purpose, because long style guides erode in practice. When in doubt, the rule below wins.
+
+## The seven rules
+
+### 1. No em-dashes
+
+Use commas, periods, parentheses, or two sentences. The em-dash reads as AI-generated rhetorical filler and is forbidden across the site.
+
+Bad: `The audit found something interesting — three of the top four articles are declining.`
+
+Good: `The audit found something interesting: three of the top four articles are declining.`
+
+Or: `The audit found something interesting. Three of the top four articles are declining.`
+
+### 2. No marketing tricolons
+
+Patterns like `fast, reliable, scalable` or `clean, modern, maintainable` are decoration. Pick the one adjective that's true and drop the rest.
+
+Bad: `A fast, reliable, scalable way to ship features.`
+
+Good: `A way to ship features that doesn't break in production.`
+
+### 3. No closing-flourish summaries
+
+End the article when the work is done. Do not write a `## Wrapping up` or `## Key takeaways` section that re-states the body. If the reader wants a TL;DR, they will scroll up. The article ends on the last technical point.
+
+### 4. No parallel-structure decoration
+
+A list of three rhetorical pairs is decoration, not information. Use a list only when the items are genuinely items (steps, options, files, results), not when they're a rhythm pattern.
+
+Bad: `Plan the work, do the work, ship the work.`
+
+Good: Whatever the actual steps are, named precisely.
+
+### 5. No AI-slop tone
+
+Banned phrases (non-exhaustive): `let's dive in`, `in the world of X`, `imagine a world where`, `the importance of X cannot be overstated`, `buckle up`, `at the end of the day`, `it's worth noting that`, `in conclusion`, `to summarize`, `the journey`, `unlock the power of`, `game changer`, `paradigm shift`.
+
+The voice check is: does this read like Anthony wrote it, or like a pattern-completing model wrote it? If the latter, rewrite or delete.
+
+### 6. No selling
+
+Articles describe work. They do not invite the reader to hire the author. No `If you'd like to discuss this, contact me`, no `Need help with X? Let's chat`, no CTAs at the bottom of an article. The contact form is the only invitation surface on the site and it lives in the nav.
+
+Win Without Pitching posture: present, do not pursue. The article ends; it does not push.
+
+### 7. Specific over general
+
+Replace abstractions with the specific thing. `The system was slow` is empty; `Each dispatcher request triggered four sequential database round-trips` is the point. Numbers, names, file paths, and code snippets are stronger than adjectives.
+
+## Inline code
+
+Backtick anything that is a literal code token, file path, function name, env var, CLI flag, or a verdict string from one of the keyword tools (`WELL_TARGETED`, `OPPORTUNITY`, etc.). The MDX pipeline and the case-study renderer both turn single-backtick spans into `<code>`.
+
+## Heading style
+
+Sentence case for h2 and h3 (`## Why this matters`, not `## Why This Matters`). Title case is reserved for the article `title` frontmatter field.
+
+## Voice check before merge
+
+Read the draft once through against these seven rules before opening the PR. The author is the reviewer; this guide is the standard. If the draft reads like work, ship it. If it reads like marketing, rewrite it.
+
+## Related
+
+- [SPEC-017](../../specs/active/SPEC-017-content-strategy.md), the spec that owns this guide
+- [`content-disposition.md`](../../strategy/content-disposition.md), per-article bucket decisions
+- [`editorial-calendar.md`](../../strategy/editorial-calendar.md), Q3 and Q4 slots

--- a/docs/specs/active/SPEC-017-content-strategy.md
+++ b/docs/specs/active/SPEC-017-content-strategy.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-017
 title: 'Content strategy, post-audit (editorial direction and authority)'
-status: draft
+status: in-progress
 created: 2026-05-10
 author: Anthony Coffey
 reviewers: []
@@ -11,6 +11,10 @@ affected_repos: [coffey.codes]
 ## Reviewer Notes
 
 <!-- Leave empty until code review. When requesting changes, reviewer adds feedback here: -->
+
+## Status
+
+**2026-05-11**: Bookkeeping (one-shot) shipped. The three required docs ([`content-disposition.md`](../../strategy/content-disposition.md), [`editorial-calendar.md`](../../strategy/editorial-calendar.md), [`voice-and-style.md`](../../documentation/guides/voice-and-style.md)) plus the nice-to-have [`content-brief-template.md`](../../templates/content-brief-template.md) are in place. The remaining tasks are long-running editorial commitments tied to the 2026-Q3 and 2026-Q4 calendar slots; the spec stays `in-progress` until the Q3 review (target 2026-08-10) is written.
 
 ---
 
@@ -206,10 +210,10 @@ When a Bucket B article is deprecated by `noindex` (rare, only for articles with
 
 ### Bookkeeping (one-shot)
 
-- [ ] Create [`docs/strategy/content-disposition.md`](docs/strategy/content-disposition.md) with all 26 articles bucketed (A / B / C)
-- [ ] Create [`docs/strategy/editorial-calendar.md`](docs/strategy/editorial-calendar.md) with Q3 and Q4 2026 slots
-- [ ] Create [`docs/documentation/guides/voice-and-style.md`](docs/documentation/guides/voice-and-style.md)
-- [ ] (Nice-to-have) Create [`docs/templates/content-brief-template.md`](docs/templates/content-brief-template.md)
+- [x] Create [`docs/strategy/content-disposition.md`](../../strategy/content-disposition.md) with all 26 articles bucketed (A / B / C)
+- [x] Create [`docs/strategy/editorial-calendar.md`](../../strategy/editorial-calendar.md) with Q3 and Q4 2026 slots
+- [x] Create [`docs/documentation/guides/voice-and-style.md`](../../documentation/guides/voice-and-style.md)
+- [x] (Nice-to-have) Create [`docs/templates/content-brief-template.md`](../../templates/content-brief-template.md)
 
 ### Q3 2026 (target ship dates per acceptance criterion #5)
 

--- a/docs/strategy/content-disposition.md
+++ b/docs/strategy/content-disposition.md
@@ -1,0 +1,70 @@
+---
+title: 'Content disposition, 2026-Q2 cycle'
+date: 2026-05-11
+spec: SPEC-017
+source: docs/strategy/seo-audit-2026-Q2.md
+status: living-document
+author: Anthony Coffey
+---
+
+# Content disposition, 2026-Q2 cycle
+
+One row per published article. Each article sits in exactly one bucket. Buckets and mechanics are defined in [SPEC-017](../specs/active/SPEC-017-content-strategy.md). Source data is [`seo-audit-2026-Q2.md`](./seo-audit-2026-Q2.md); click counts and trends in this table are from its 365-day window (2025-05-08 to 2026-05-07).
+
+This is a living document. Revisit at every quarterly content review.
+
+## Bucket legend
+
+- **A. Refresh.** Material body update plus a `## Updated YYYY-MM-DD` note. The article keeps its slug and original `publishedAt`. The editorial bet is that an updated version recovers traffic.
+- **B. Deprecate.** Either a 308 redirect to a sibling article (SPEC-013 single-hop convention) or kept published with `noindex` and an archival note. The decision per article is recorded inline.
+- **C. Keep as-is.** No editorial action this cycle. The article costs nothing to leave published; cumulative tail-impressions are not zero. Re-evaluate at the annual review.
+
+## Disposition table
+
+| # | Slug | Pillar | publishedAt | 365d clicks | Bucket | Decision / reason |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | [`vibe-coding-building-an-app-entirely-with-ai-prompts`](../../app/(site)/articles/posts/vibe-coding-building-an-app-entirely-with-ai-prompts.mdx) | Mobile Development | 2025-04-03 | 248 | A | Highest CTR cluster on the site (4-7% across 6 query variants). Trend -33% at 90 days. Refresh + companion piece is the highest-leverage editorial move (Q3 calendar). |
+| 2 | [`slow-android-emulator-flutter-dev`](../../app/(site)/articles/posts/slow-android-emulator-flutter-dev.mdx) | Mobile Development | 2025-04-16 | 236 | A | 71,131 impressions on stable evergreen queries. -16% at 90 days. Striking-distance demand still real (audit Section 5). Recategorized from `Development` per SPEC-016 quick win #3. |
+| 3 | [`managing-secrets-firebase-apphosting-yaml-nextjs`](../../app/(site)/articles/posts/managing-secrets-firebase-apphosting-yaml-nextjs.mdx) | Cloud & DevOps | 2025-03-14 | 180 | A | Steepest decline of any top page (-60% at 90 days). Firebase CLI may have shifted; reverify body against current `firebase apphosting:secrets:*` behavior. |
+| 4 | [`react-19-features-and-design-patterns`](../../app/(site)/articles/posts/react-19-features-and-design-patterns.mdx) | Web Development | 2025-03-17 | 52 | A | Anchor URLs (`#actions-api`, `#streaming-patterns`, `#react-compiler`) rank at positions 6.0-6.4 but earn zero clicks. Refresh decision at refresh-time: tighten body, or split into multiple shorter pieces. |
+| 5 | [`embracing-clean-code-principles`](../../app/(site)/articles/posts/embracing-clean-code-principles.mdx) | Software Engineering | 2024-04-11 | 0 | B | Zero traffic in audit Section 10. Topic is SERP-saturated. **Decision pending** per SPEC-017 must-have #7; default action is redirect to `/articles` unless refresh angle emerges. |
+| 6 | [`javascript-design-patterns`](../../app/(site)/articles/posts/javascript-design-patterns.mdx) | Software Engineering | 2023-02-20 | 0 | B | Zero traffic; 2023 article. SERP saturated. **Decision pending**; default redirect. |
+| 7 | [`tips-for-troubleshooting-and-debugging-code`](../../app/(site)/articles/posts/tips-for-troubleshooting-and-debugging-code.mdx) | Software Engineering | 2023-02-13 | 0 | B | Zero traffic; 2023 article. Generic title. **Decision pending**; default redirect. |
+| 8 | [`unit-testing-in-python-with-pytest`](../../app/(site)/articles/posts/unit-testing-in-python-with-pytest.mdx) | Software Engineering | 2023-02-16 | 0 | B | Zero traffic; 2023 article. Pytest docs are the canonical resource. **Decision pending**; default redirect. |
+| 9 | [`authorize-net-for-react-native-expo-sdk-49`](../../app/(site)/articles/posts/authorize-net-for-react-native-expo-sdk-49.mdx) | Mobile Development | 2024-04-08 | 15 | C | 1.69% CTR at position 11.48. Long-tail Expo + payments piece. Cumulative tail impressions are real. |
+| 10 | [`setting-up-ci-cd-for-firebase-functions-using-github-actions`](../../app/(site)/articles/posts/setting-up-ci-cd-for-firebase-functions-using-github-actions.mdx) | Cloud & DevOps | 2025-03-11 | 3 | C | Small but non-zero. Adjacent to Bucket A `managing-secrets-firebase-apphosting-yaml-nextjs`. Internal-link opportunity at next refresh. |
+| 11 | [`how-to-end-a-process-by-port-number`](../../app/(site)/articles/posts/how-to-end-a-process-by-port-number.mdx) | Tools & Productivity | 2023-11-18 | 2 | C | Single-snippet utility piece. Evergreen reference; no refresh angle. |
+| 12 | [`building-interactive-3d-experiences-with-react-three-fiber`](../../app/(site)/articles/posts/building-interactive-3d-experiences-with-react-three-fiber.mdx) | Web Development | 2025-03-29 | (<3) | C | Adjacent to `three-js-portfolio-website-for-software-engineer`. Internal-link candidate. |
+| 13 | [`building-an-mdx-powered-blog-using-app-router-next-js`](../../app/(site)/articles/posts/building-an-mdx-powered-blog-using-app-router-next-js.mdx) | Web Development | 2024-10-01 | (<3) | C | Adjacent to `step-by-step-building-your-blog-with-next-js-and-mdx`. Possible consolidation at next cycle. |
+| 14 | [`step-by-step-building-your-blog-with-next-js-and-mdx`](../../app/(site)/articles/posts/step-by-step-building-your-blog-with-next-js-and-mdx.mdx) | Web Development | 2025-03-25 | (<3) | C | See #13. |
+| 15 | [`preventing-unnecessary-re-renders-in-react-apps`](../../app/(site)/articles/posts/preventing-unnecessary-re-renders-in-react-apps.mdx) | Web Development | 2025-03-27 | (<3) | C | 33% bounce, 269s avg duration in GA4 (audit Section 9.5). Engaged when found. |
+| 16 | [`micro-frontends-architecture-benefits-challenges-best-practices`](../../app/(site)/articles/posts/micro-frontends-architecture-benefits-challenges-best-practices.mdx) | Web Development | 2024-10-22 | (<3) | C | Theoretical-overview piece. No striking-distance signal. |
+| 17 | [`implementing-localization-in-nextjs`](../../app/(site)/articles/posts/implementing-localization-in-nextjs.mdx) | Web Development | 2026-02-26 | n/a (post-audit) | C | Published after the audit window closed. Re-evaluate at Q3 review with first quarter of data. |
+| 18 | [`fixing-broken-routes-after-nextjs-16-upgrade`](../../app/(site)/articles/posts/fixing-broken-routes-after-nextjs-16-upgrade.mdx) | Web Development | 2026-02-01 | n/a (post-audit) | C | Released after audit froze. Re-evaluate Q3. |
+| 19 | [`production-grade-ci-cd-with-nextjs-vercel-and-github-actions`](../../app/(site)/articles/posts/production-grade-ci-cd-with-nextjs-vercel-and-github-actions.mdx) | Cloud & DevOps | 2026-04-24 | n/a (post-audit) | C | Released after audit froze. Re-evaluate Q3. |
+| 20 | [`three-js-portfolio-website-for-software-engineer`](../../app/(site)/articles/posts/three-js-portfolio-website-for-software-engineer.mdx) | Web Development | 2026-05-10 | n/a (post-audit) | C | Published on the audit's last day. Re-evaluate Q3. |
+| 21 | [`how-to-deploy-a-flask-rest-api-on-google-cloud-run`](../../app/(site)/articles/posts/how-to-deploy-a-flask-rest-api-on-google-cloud-run.mdx) | Cloud & DevOps | 2025-03-02 | (<3) | C | Long-tail Python + Cloud Run piece. |
+| 22 | [`essential-tips-for-effective-aws-iam-policy-management`](../../app/(site)/articles/posts/essential-tips-for-effective-aws-iam-policy-management.mdx) | Cloud & DevOps | 2024-04-09 | (<3) | C | AWS docs are SERP-dominant; this remains a personal-reference piece. |
+| 23 | [`working-with-aws-lambda-beginners-guide`](../../app/(site)/articles/posts/working-with-aws-lambda-beginners-guide.mdx) | Cloud & DevOps | 2024-04-09 | (<3) | C | Generic intro; AWS docs cover this. Watch at next review for deprecate candidacy. |
+| 24 | [`best-practices-with-git-version-control`](../../app/(site)/articles/posts/best-practices-with-git-version-control.mdx) | Tools & Productivity | 2023-02-14 | (<3) | C | Evergreen reference; cumulative tail impressions. |
+| 25 | [`how-to-see-when-a-file-was-deleted-or-changed-with-git-log`](../../app/(site)/articles/posts/how-to-see-when-a-file-was-deleted-or-changed-with-git-log.mdx) | Tools & Productivity | 2023-11-14 | (<3) | C | Single-command snippet piece. |
+| 26 | [`tools-for-productive-development`](../../app/(site)/articles/posts/tools-for-productive-development.mdx) | Tools & Productivity | 2023-02-15 | (<3) | C | Tool-list piece. Watch at next review for deprecate candidacy (stack moves; 2023 picks may have rotted). |
+
+26 articles tracked. The audit's frozen count was 26; the post-audit additions in rows 17 through 20 bring the current site total to 27 (`three-js-portfolio-website-for-software-engineer` landed the day the audit froze).
+
+## Software Engineering pillar (SPEC-017 must-have #7)
+
+The four Bucket B articles each need an explicit refresh-or-redirect decision before the next quarterly review (target 2026-08-10). Recording each decision below as it's made.
+
+| Slug | Decision | Date | Reasoning |
+| --- | --- | --- | --- |
+| `embracing-clean-code-principles` | _pending_ |  |  |
+| `javascript-design-patterns` | _pending_ |  |  |
+| `tips-for-troubleshooting-and-debugging-code` | _pending_ |  |  |
+| `unit-testing-in-python-with-pytest` | _pending_ |  |  |
+
+Default action if no refresh angle surfaces by 2026-08-10: 308 redirect to `/articles`, MDX renamed to `.archived.mdx` to keep history in git.
+
+## Change log
+
+- 2026-05-11. Initial bucketing per SPEC-017 must-have #7. Bucket A and B mirror SPEC-017 Design > Disposition matrix. All four Software Engineering pillar articles defaulted to Bucket B with `_pending_` decisions; final decision recorded inline at refresh / redirect time.

--- a/docs/strategy/editorial-calendar.md
+++ b/docs/strategy/editorial-calendar.md
@@ -1,0 +1,103 @@
+---
+title: 'Editorial calendar, 2026 H2'
+date: 2026-05-11
+spec: SPEC-017
+status: living-document
+author: Anthony Coffey
+---
+
+# Editorial calendar, 2026 H2
+
+Cadence: **one new article per 4-6 weeks**, **one refresh per quarter**. Targets, not quotas. Skipping a slot is preferable to publishing a piece that fails the voice bar in [`voice-and-style.md`](../documentation/guides/voice-and-style.md).
+
+The "what this demonstrates" field is required on every slot. Articles that cannot articulate what the work shows are not on this calendar.
+
+Audit signals cited below trace to [`seo-audit-2026-Q2.md`](./seo-audit-2026-Q2.md).
+
+## Q3 2026 (July - September)
+
+### Slot 1. Refresh `vibe-coding-building-an-app-entirely-with-ai-prompts`
+
+| Field | Value |
+| --- | --- |
+| Type | Refresh (Bucket A) |
+| Target ship | 2026-09-30 |
+| Status | planned |
+| Pillar | Mobile Development |
+| Target queries | `flutter vibe coding`, `vibe coding flutter app`, `vibe code flutter app` (audit Section 4, 6-7% CTR cluster) |
+| What this demonstrates | A real Flutter project shipped end-to-end on AI-driven workflows; the body documents which decisions held up and which broke after ~12 months of distance from the original draft. |
+| Audit signal | -33% at 90 days. Highest CTR cluster on the site. 2,290 impressions across 6 vibe-coding queries (Section 4). |
+| Refresh angle | Revisit the decisions in the original; note what AI-assisted workflow changes since 2025-04 (newer models, better agentic tooling); refresh any code that no longer compiles against current Flutter. |
+
+### Slot 2. New: Expo Location deep-dive
+
+| Field | Value |
+| --- | --- |
+| Type | New article |
+| Target ship | 2026-10-15 |
+| Status | planned |
+| Pillar | Mobile Development |
+| Target queries | `expo-location requestForegroundPermissionsAsync`, `expo-location permissionstatus.granted`, `expo-location hasservicesenabledasync`, `expo geofencing`, `expo background location` (audit Section 5, 14 striking-distance queries on the parent article) |
+| What this demonstrates | A working geofencing + background-location implementation, including the permission-prompt UX edge cases that the parent article surfaces but does not solve. |
+| Audit signal | ~3,600 potential clicks across the top-25 low-hanging-fruit list (Section 6). Parent article has 150,793 impressions at 0.26% CTR; the function-name long-tails are losing the click decision. |
+| Notes | This piece is the deep-dive sibling to `building-location-based-features-using-expo-location`. The parent stays as the overview; the new article is the function-by-function reference. Internal-link both directions. |
+
+### Slot 3 (optional). Vibe-coding companion piece
+
+| Field | Value |
+| --- | --- |
+| Type | New article (no commitment date) |
+| Target ship | Ships if the work is genuinely worth writing about; otherwise the slot rolls forward |
+| Status | optional |
+| Pillar | Mobile Development |
+| Target queries | TBD; depends on the project documented |
+| What this demonstrates | A second AI-driven build (different stack, e.g. a small Next.js + agentic-tooling project, or a Swift / Kotlin native build) so the vibe-coding pattern reads as a method, not a one-off. |
+| Audit signal | Cluster CTR is high but volume is low (2,290 impressions). A second post deepens the cluster footprint without diluting the lead piece. |
+
+## Q4 2026 (October - December)
+
+### Slot 4. New: Firebase App Hosting environment-variable patterns
+
+| Field | Value |
+| --- | --- |
+| Type | New article |
+| Target ship | 2026-11-30 |
+| Status | planned |
+| Pillar | Cloud & DevOps |
+| Target queries | `apphosting.yaml`, `next_public_firebase_api_key`, `firebase app hosting environment variables`, `firebase apphosting:secrets:grantaccess`, `firebase apphosting:secrets:set` (audit Section 5 + Section 4) |
+| What this demonstrates | The full env-var lifecycle in a real App Hosting deploy, including the `next_public_*` exposure trap and the `secrets:grantaccess` step that the docs gloss over. |
+| Audit signal | 6 striking-distance queries on the parent article (`managing-secrets-firebase-apphosting-yaml-nextjs`). The parent gets 180 clicks at 0.41% CTR; a companion piece that picks up the function-name long-tails (same pattern as the Expo Location split) is the natural editorial move. |
+
+### Slot 5. Refresh `slow-android-emulator-flutter-dev`
+
+| Field | Value |
+| --- | --- |
+| Type | Refresh (Bucket A) |
+| Target ship | 2026-12-31 |
+| Status | planned |
+| Pillar | Mobile Development |
+| Target queries | Existing top queries (already ranking); the refresh is to recover the -16% trend, not to chase new keywords. |
+| What this demonstrates | Updated diagnostic flow against the current Android Studio / Flutter release. The article is evergreen because emulator slowness recurs every major Android Studio version; refresh it against the version current at refresh time. |
+| Audit signal | -16% at 90 days. 71,131 impressions still flowing. Evergreen topic. |
+
+## Disposition execution (Software Engineering pillar)
+
+Outside the new/refresh cadence above, the four Bucket B articles in [`content-disposition.md`](./content-disposition.md) each need a refresh-or-redirect decision shipped before 2026-08-10 (Q3 review).
+
+This is bookkeeping, not editorial work, and does not consume calendar slots.
+
+## Skipped / slipped slots
+
+Recorded as they happen. A skipped slot is signal, not failure.
+
+| Slot | Original target | Outcome | Reason | Re-scheduled |
+| --- | --- | --- | --- | --- |
+| _(none yet)_ |  |  |  |  |
+
+## Annual review trigger
+
+2026-12-01: re-evaluate the pillar taxonomy from scratch. The five pillars are organizational, not permanent.
+
+## Change log
+
+- 2026-05-11. Initial calendar per SPEC-017 must-have #6. Q3 slots 1 and 2 traced to SPEC-017 Design > Editorial calendar; Slot 3 marked optional. Q4 slots 4 and 5 added per same source.

--- a/docs/templates/content-brief-template.md
+++ b/docs/templates/content-brief-template.md
@@ -1,0 +1,85 @@
+---
+slug: ''
+type: '' # new | refresh
+pillar: '' # Web Development | Mobile Development | Cloud & DevOps | Software Engineering | Tools & Productivity
+target_ship: 'YYYY-MM-DD'
+status: 'planned' # planned | drafted | shipped | skipped
+calendar_slot: '' # e.g. "Q3 2026 Slot 1"
+author: Anthony Coffey
+---
+
+# Content brief: [working title]
+
+A short pre-write step. Fill this in before drafting the article body; the goal is to surface the bad ideas before they cost a draft. Lives next to the article during drafting, then gets deleted at merge (or pasted into the PR body for traceability).
+
+Voice rules: [`voice-and-style.md`](../documentation/guides/voice-and-style.md). The brief itself follows them.
+
+## Working title
+
+<!-- One sentence, sentence case. Title-case the article frontmatter title only when the post is ready to ship. -->
+
+## What this demonstrates
+
+<!-- One or two sentences. The work this article shows; not the topic, but the specific decisions or outputs the reader is going to see. If you can't say this without marketing words, the topic isn't ready. -->
+
+## Target queries
+
+<!-- Pull from docs/strategy/seo-audit-2026-Q?-*.md or the latest seo-snapshot JSON. List 3-8 queries the article can plausibly serve. Annotate with audit signal where available. -->
+
+| Query | Source (audit section / signal) | Notes |
+| --- | --- | --- |
+| `query 1` | striking-distance #N | |
+| `query 2` | low-hanging-fruit #N | |
+
+If there is no audit signal, justify the article on editorial grounds (the work is genuinely worth documenting) per SPEC-017 topic-selection methodology step 3.
+
+## Outline
+
+<!-- Heading-level only. h2 sections in order. Each line is one section. -->
+
+- ## Section one
+- ## Section two
+- ## Section three
+
+## Distinctive angle
+
+<!-- One sentence. What this article does that the existing top results on these queries do not. If the answer is "it explains the topic", that's not an angle, that's a Wikipedia entry. -->
+
+## Internal links
+
+<!-- Inbound: which existing articles will link to this one once it ships. Outbound: which existing articles will this one link to. If both lists are empty, either the pillar is wrong or the topic is too niche to publish. -->
+
+Inbound (existing → new):
+
+-
+
+Outbound (new → existing):
+
+-
+
+## Voice check
+
+- [ ] No em-dashes in the working title or outline
+- [ ] No marketing tricolons
+- [ ] No closing-flourish section (`## Conclusion`, `## Wrapping up`, etc.) in the outline
+- [ ] No "let's dive in" / AI-slop phrasing in the introduction draft
+
+If any box stays unchecked at draft time, rewrite the title and outline before writing the body.
+
+## Refresh-specific fields
+
+<!-- Delete this section for new articles. -->
+
+- **Original `publishedAt`**: YYYY-MM-DD
+- **Last refresh**: YYYY-MM-DD (or "never")
+- **What's changed since last version**: <!-- one paragraph. What in the article is now wrong, stale, or missing. -->
+- **`## Updated YYYY-MM-DD` note for the article body**: <!-- the one-sentence changelog line that will appear near the top of the refreshed article. -->
+
+## Ship checklist
+
+- [ ] Voice check pass (read against [`voice-and-style.md`](../documentation/guides/voice-and-style.md))
+- [ ] Frontmatter `category` is one of the canonical pillars
+- [ ] Frontmatter `summary` is written (not auto-generated)
+- [ ] At least one inbound internal link from an existing article
+- [ ] PR title is `content: <slug> [SPEC-017]` (or `content: refresh <slug> [SPEC-017]` for a refresh)
+- [ ] PR body cites the audit signal or editorial reasoning that justified the slot


### PR DESCRIPTION
## Summary

Closes out the **Bookkeeping (one-shot)** section of [SPEC-017](docs/specs/active/SPEC-017-content-strategy.md). The editorial layer is the only spec still in `active/`; this PR lands the four foundational docs that the rest of the spec depends on so the next quarterly content review and the Q3/Q4 calendar slots have something to execute against.

### Four new docs

- [`docs/strategy/content-disposition.md`](docs/strategy/content-disposition.md) — every article on the site bucketed A (refresh) / B (deprecate) / C (keep as-is), with the four Software Engineering pillar pieces flagged for refresh-or-redirect decisions before the Q3 review.
- [`docs/strategy/editorial-calendar.md`](docs/strategy/editorial-calendar.md) — five slots across 2026 H2 (two refreshes, two new articles, one optional), each with target queries traced to a numbered audit finding.
- [`docs/documentation/guides/voice-and-style.md`](docs/documentation/guides/voice-and-style.md) — the seven voice rules on one page (598 words, under the 600 cap in SPEC-017 acceptance criterion #3).
- [`docs/templates/content-brief-template.md`](docs/templates/content-brief-template.md) — nice-to-have pre-write template with refresh-specific fields and a ship checklist.

### Spec state

SPEC-017 frontmatter bumped `draft` to `in-progress`; the four bookkeeping checkboxes are ticked; a `## Status` note explains why the spec stays open (the Q3/Q4 calendar slots and the 2026-08-10 Q3 review are still pending). The spec is not ready for `review-pending` because the long-running editorial commitments have not landed yet.

### Voice rule compliance

- Em-dash count in the new docs: 1 (the intentional `Bad:` example inside `voice-and-style.md`). All structural em-dashes converted to colons, periods, or commas.
- Word count for `voice-and-style.md`: 598 / 600 budget.

## Test plan

- [ ] Reviewer reads `voice-and-style.md` front to back; does it pass its own rules?
- [ ] Reviewer spot-checks 3 of the 26 article rows in `content-disposition.md` against the audit's numbers in `seo-audit-2026-Q2.md` Section 3.
- [ ] Reviewer confirms the Bucket B pending decisions match the four Software Engineering articles.
- [ ] CI (lint, typecheck, vitest, Playwright) is green; no code changed so this should be a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)