### PR TITLE
feat(snapshot): --asof flag + three-day backfill (5/9, 5/10, 5/11)

### DIFF
--- a/docs/documentation/agents/coffey-codes.md
+++ b/docs/documentation/agents/coffey-codes.md
@@ -152,6 +152,7 @@ npm run typecheck      # tsc --noEmit
 node scripts/seo-snapshot.mjs                       # all configured engines, 365d
 node scripts/seo-snapshot.mjs --engines=gsc         # one engine only
 node scripts/seo-snapshot.mjs --engines=gsc,keywords  # enrich GSC with Ads
+node scripts/seo-snapshot.mjs --asof=2026-05-09     # anchor "today" to a past date
 node scripts/seo-snapshot.mjs --dry-run             # print plan, skip API calls
 node scripts/seo-snapshot-diff.mjs older.json newer.json
 ```

--- a/docs/documentation/guides/seo-snapshot-setup.md
+++ b/docs/documentation/guides/seo-snapshot-setup.md
@@ -133,6 +133,11 @@ node scripts/seo-snapshot.mjs --engines=gsc,ga4,keywords
 # Custom window
 node scripts/seo-snapshot.mjs --window=180
 
+# Anchor "today" to a past date. Drives both the output filename
+# (snapshot-2026-05-09.json) and the GSC window. Useful for filling
+# a few consecutive snapshots in one sitting.
+node scripts/seo-snapshot.mjs --asof=2026-05-09
+
 # Plan without API calls
 node scripts/seo-snapshot.mjs --dry-run
 ```

--- a/docs/strategy/data/snapshot-2026-05-09.json
+++ b/docs/strategy/data/snapshot-2026-05-09.json
@@ -1,0 +1,3574 @@
+{
+  "window": {
+    "startDate": "2025-05-06",
+    "endDate": "2026-05-06",
+    "days": 365
+  },
+  "pulledAt": "2026-05-11T21:55:51.378Z",
+  "siteUrl": "sc-domain:coffey.codes",
+  "gsc": {
+    "window": {
+      "startDate": "2025-05-06",
+      "endDate": "2026-05-06",
+      "days": 365
+    },
+    "totals": {
+      "clicks": 1148,
+      "impressions": 292181,
+      "ctr": 0.0039290713632987775
+    },
+    "topPages": [
+      {
+        "keys": [
+          "https://coffey.codes/articles/building-location-based-features-using-expo-location"
+        ],
+        "clicks": 387,
+        "impressions": 149858,
+        "ctr": 0.0025824447143295653,
+        "position": 6.756022367841557
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/vibe-coding-building-an-app-entirely-with-ai-prompts"
+        ],
+        "clicks": 248,
+        "impressions": 9012,
+        "ctr": 0.027518863737239236,
+        "position": 8.473923657345761
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/slow-android-emulator-flutter-dev"
+        ],
+        "clicks": 236,
+        "impressions": 70981,
+        "ctr": 0.0033248334061227653,
+        "position": 5.842324002197771
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/managing-secrets-firebase-apphosting-yaml-nextjs"
+        ],
+        "clicks": 180,
+        "impressions": 43402,
+        "ctr": 0.004147274319155799,
+        "position": 7.460001843233031
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/react-19-features-and-design-patterns"
+        ],
+        "clicks": 52,
+        "impressions": 14933,
+        "ctr": 0.0034822205852809217,
+        "position": 8.550056920913413
+      },
+      {
+        "keys": [
+          "https://coffey.codes/Anthony%20Coffey%20-%20Resume.pdf"
+        ],
+        "clicks": 15,
+        "impressions": 465,
+        "ctr": 0.03225806451612903,
+        "position": 39.72043010752688
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/authorize-net-for-react-native-expo-sdk-49"
+        ],
+        "clicks": 15,
+        "impressions": 882,
+        "ctr": 0.017006802721088437,
+        "position": 11.487528344671201
+      },
+      {
+        "keys": [
+          "https://coffey.codes/"
+        ],
+        "clicks": 4,
+        "impressions": 310,
+        "ctr": 0.012903225806451613,
+        "position": 13.825806451612904
+      },
+      {
+        "keys": [
+          "https://coffey.codes/contact"
+        ],
+        "clicks": 4,
+        "impressions": 224,
+        "ctr": 0.017857142857142856,
+        "position": 26.379464285714285
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/setting-up-ci-cd-for-firebase-functions-using-github-actions"
+        ],
+        "clicks": 3,
+        "impressions": 594,
+        "ctr": 0.005050505050505051,
+        "position": 12.065656565656566
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/how-to-end-a-process-by-port-number"
+        ],
+        "clicks": 2,
+        "impressions": 706,
+        "ctr": 0.0028328611898017,
+        "position": 19.879603399433428
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/step-by-step-building-your-blog-with-next-js-and-mdx"
+        ],
+        "clicks": 1,
+        "impressions": 633,
+        "ctr": 0.001579778830963665,
+        "position": 17.50394944707741
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/tag/unit%20testing?"
+        ],
+        "clicks": 1,
+        "impressions": 9,
+        "ctr": 0.1111111111111111,
+        "position": 6.333333333333333
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles"
+        ],
+        "clicks": 0,
+        "impressions": 97,
+        "ctr": 0,
+        "position": 8.391752577319588
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/avoiding-unnecessary-re-renders-in-react-apps"
+        ],
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 9
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/building-an-mdx-powered-blog-using-app-router-next-js"
+        ],
+        "clicks": 0,
+        "impressions": 256,
+        "ctr": 0,
+        "position": 24.921875
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/building-interactive-3d-experiences-with-react-three-fiber"
+        ],
+        "clicks": 0,
+        "impressions": 34,
+        "ctr": 0,
+        "position": 9.764705882352942
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/categories"
+        ],
+        "clicks": 0,
+        "impressions": 4,
+        "ctr": 0,
+        "position": 5
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/category/development"
+        ],
+        "clicks": 0,
+        "impressions": 2,
+        "ctr": 0,
+        "position": 10
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/category/web%20development"
+        ],
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 5
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/essential-tips-for-effective-aws-iam-policy-management"
+        ],
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 9
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/how-to-deploy-a-flask-rest-api-on-google-cloud-run"
+        ],
+        "clicks": 0,
+        "impressions": 13,
+        "ctr": 0,
+        "position": 6.153846153846154
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/preventing-unnecessary-re-renders-in-react-apps"
+        ],
+        "clicks": 0,
+        "impressions": 3,
+        "ctr": 0,
+        "position": 36.333333333333336
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/react-19-features-and-design-patterns#actions-api"
+        ],
+        "clicks": 0,
+        "impressions": 711,
+        "ctr": 0,
+        "position": 6.022503516174402
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/react-19-features-and-design-patterns#document-metadata"
+        ],
+        "clicks": 0,
+        "impressions": 17,
+        "ctr": 0,
+        "position": 4.764705882352941
+      }
+    ],
+    "topQueries": [
+      {
+        "keys": [
+          "flutter vibe coding"
+        ],
+        "clicks": 49,
+        "impressions": 1073,
+        "ctr": 0.045666356011183594,
+        "position": 8.387698042870458
+      },
+      {
+        "keys": [
+          "expo location"
+        ],
+        "clicks": 24,
+        "impressions": 9612,
+        "ctr": 0.0024968789013732834,
+        "position": 7.72929671244278
+      },
+      {
+        "keys": [
+          "vibe coding flutter"
+        ],
+        "clicks": 24,
+        "impressions": 647,
+        "ctr": 0.03709428129829984,
+        "position": 8.256568778979908
+      },
+      {
+        "keys": [
+          "vibe coding flutter app"
+        ],
+        "clicks": 15,
+        "impressions": 218,
+        "ctr": 0.06880733944954129,
+        "position": 7.389908256880734
+      },
+      {
+        "keys": [
+          "expo-location"
+        ],
+        "clicks": 10,
+        "impressions": 5256,
+        "ctr": 0.001902587519025875,
+        "position": 6.5932267884322675
+      },
+      {
+        "keys": [
+          "vibe code flutter app"
+        ],
+        "clicks": 9,
+        "impressions": 157,
+        "ctr": 0.05732484076433121,
+        "position": 7.547770700636943
+      },
+      {
+        "keys": [
+          "expo geofencing"
+        ],
+        "clicks": 7,
+        "impressions": 216,
+        "ctr": 0.032407407407407406,
+        "position": 7.583333333333333
+      },
+      {
+        "keys": [
+          "firebase apphosting:secrets:grantaccess"
+        ],
+        "clicks": 7,
+        "impressions": 386,
+        "ctr": 0.018134715025906734,
+        "position": 6.160621761658031
+      },
+      {
+        "keys": [
+          "firebase apphosting:secrets:set"
+        ],
+        "clicks": 6,
+        "impressions": 192,
+        "ctr": 0.03125,
+        "position": 5.447916666666667
+      },
+      {
+        "keys": [
+          "vibe code flutter"
+        ],
+        "clicks": 6,
+        "impressions": 144,
+        "ctr": 0.041666666666666664,
+        "position": 8.208333333333332
+      },
+      {
+        "keys": [
+          "expo location accuracy"
+        ],
+        "clicks": 5,
+        "impressions": 132,
+        "ctr": 0.03787878787878788,
+        "position": 5.613636363636363
+      },
+      {
+        "keys": [
+          "flutter vibe code"
+        ],
+        "clicks": 4,
+        "impressions": 53,
+        "ctr": 0.07547169811320754,
+        "position": 7.471698113207547
+      },
+      {
+        "keys": [
+          "expo geolocation"
+        ],
+        "clicks": 3,
+        "impressions": 494,
+        "ctr": 0.006072874493927126,
+        "position": 6.923076923076923
+      },
+      {
+        "keys": [
+          "expo location example"
+        ],
+        "clicks": 3,
+        "impressions": 47,
+        "ctr": 0.06382978723404255,
+        "position": 8.51063829787234
+      },
+      {
+        "keys": [
+          "react native expo location"
+        ],
+        "clicks": 3,
+        "impressions": 227,
+        "ctr": 0.013215859030837005,
+        "position": 5.066079295154185
+      },
+      {
+        "keys": [
+          "requestforegroundpermissionsasync"
+        ],
+        "clicks": 3,
+        "impressions": 222,
+        "ctr": 0.013513513513513514,
+        "position": 7.833333333333333
+      },
+      {
+        "keys": [
+          "android emulator slow"
+        ],
+        "clicks": 2,
+        "impressions": 386,
+        "ctr": 0.0051813471502590676,
+        "position": 7.383419689119171
+      },
+      {
+        "keys": [
+          "apphosting.yaml"
+        ],
+        "clicks": 2,
+        "impressions": 448,
+        "ctr": 0.004464285714285714,
+        "position": 8.453125
+      },
+      {
+        "keys": [
+          "expo gps"
+        ],
+        "clicks": 2,
+        "impressions": 255,
+        "ctr": 0.00784313725490196,
+        "position": 7.6117647058823525
+      },
+      {
+        "keys": [
+          "expo location api"
+        ],
+        "clicks": 2,
+        "impressions": 236,
+        "ctr": 0.00847457627118644,
+        "position": 5.008474576271187
+      },
+      {
+        "keys": [
+          "expo location permission"
+        ],
+        "clicks": 2,
+        "impressions": 56,
+        "ctr": 0.03571428571428571,
+        "position": 8.660714285714285
+      },
+      {
+        "keys": [
+          "expo location tracking"
+        ],
+        "clicks": 2,
+        "impressions": 33,
+        "ctr": 0.06060606060606061,
+        "position": 6.363636363636363
+      },
+      {
+        "keys": [
+          "firebase app hosting secrets"
+        ],
+        "clicks": 2,
+        "impressions": 204,
+        "ctr": 0.00980392156862745,
+        "position": 6.519607843137255
+      },
+      {
+        "keys": [
+          "flutter vibe coding platform"
+        ],
+        "clicks": 2,
+        "impressions": 31,
+        "ctr": 0.06451612903225806,
+        "position": 8.032258064516128
+      },
+      {
+        "keys": [
+          "location.watchpositionasync"
+        ],
+        "clicks": 2,
+        "impressions": 63,
+        "ctr": 0.031746031746031744,
+        "position": 6.666666666666667
+      },
+      {
+        "keys": [
+          "react 19 best practices"
+        ],
+        "clicks": 2,
+        "impressions": 71,
+        "ctr": 0.028169014084507043,
+        "position": 9.647887323943662
+      },
+      {
+        "keys": [
+          "vibe coding for flutter"
+        ],
+        "clicks": 2,
+        "impressions": 57,
+        "ctr": 0.03508771929824561,
+        "position": 8.491228070175438
+      },
+      {
+        "keys": [
+          "why android emulator is slow"
+        ],
+        "clicks": 2,
+        "impressions": 84,
+        "ctr": 0.023809523809523808,
+        "position": 4.666666666666666
+      },
+      {
+        "keys": [
+          "android emulator very slow"
+        ],
+        "clicks": 1,
+        "impressions": 134,
+        "ctr": 0.007462686567164179,
+        "position": 6.746268656716418
+      },
+      {
+        "keys": [
+          "apphosting.yaml firebase"
+        ],
+        "clicks": 1,
+        "impressions": 88,
+        "ctr": 0.011363636363636364,
+        "position": 8.420454545454547
+      },
+      {
+        "keys": [
+          "expo background location tracking"
+        ],
+        "clicks": 1,
+        "impressions": 105,
+        "ctr": 0.009523809523809525,
+        "position": 7.6761904761904765
+      },
+      {
+        "keys": [
+          "expo location documentation"
+        ],
+        "clicks": 1,
+        "impressions": 304,
+        "ctr": 0.003289473684210526,
+        "position": 5.384868421052632
+      },
+      {
+        "keys": [
+          "expo location geofencing"
+        ],
+        "clicks": 1,
+        "impressions": 61,
+        "ctr": 0.01639344262295082,
+        "position": 4.557377049180328
+      },
+      {
+        "keys": [
+          "expo location permissions"
+        ],
+        "clicks": 1,
+        "impressions": 209,
+        "ctr": 0.004784688995215311,
+        "position": 6.574162679425838
+      },
+      {
+        "keys": [
+          "expo location react native"
+        ],
+        "clicks": 1,
+        "impressions": 220,
+        "ctr": 0.004545454545454545,
+        "position": 5.177272727272728
+      },
+      {
+        "keys": [
+          "expo location services"
+        ],
+        "clicks": 1,
+        "impressions": 78,
+        "ctr": 0.01282051282051282,
+        "position": 4.589743589743589
+      },
+      {
+        "keys": [
+          "expo-location documentation"
+        ],
+        "clicks": 1,
+        "impressions": 339,
+        "ctr": 0.0029498525073746312,
+        "position": 4.775811209439528
+      },
+      {
+        "keys": [
+          "firebase app hosting environment variables"
+        ],
+        "clicks": 1,
+        "impressions": 211,
+        "ctr": 0.004739336492890996,
+        "position": 9.189573459715639
+      },
+      {
+        "keys": [
+          "location expo"
+        ],
+        "clicks": 1,
+        "impressions": 166,
+        "ctr": 0.006024096385542169,
+        "position": 8.650602409638555
+      },
+      {
+        "keys": [
+          "location.getcurrentpositionasync"
+        ],
+        "clicks": 1,
+        "impressions": 15,
+        "ctr": 0.06666666666666667,
+        "position": 9.133333333333333
+      },
+      {
+        "keys": [
+          "next_public_firebase_api_key"
+        ],
+        "clicks": 1,
+        "impressions": 345,
+        "ctr": 0.002898550724637681,
+        "position": 9.30144927536232
+      },
+      {
+        "keys": [
+          "react 19 design patterns and best practices"
+        ],
+        "clicks": 1,
+        "impressions": 13,
+        "ctr": 0.07692307692307693,
+        "position": 4.3076923076923075
+      },
+      {
+        "keys": [
+          "react 19 partial hydration"
+        ],
+        "clicks": 1,
+        "impressions": 82,
+        "ctr": 0.012195121951219513,
+        "position": 7.426829268292683
+      },
+      {
+        "keys": [
+          "vibe coding with flutter"
+        ],
+        "clicks": 1,
+        "impressions": 84,
+        "ctr": 0.011904761904761904,
+        "position": 7.928571428571429
+      },
+      {
+        "keys": [
+          "why is android emulator so slow"
+        ],
+        "clicks": 1,
+        "impressions": 111,
+        "ctr": 0.009009009009009009,
+        "position": 4.684684684684685
+      },
+      {
+        "keys": [
+          "\"$.location.coords\" audit logs geofence"
+        ],
+        "clicks": 0,
+        "impressions": 10,
+        "ctr": 0,
+        "position": 8.2
+      },
+      {
+        "keys": [
+          "\"$.location.coords\" geofence"
+        ],
+        "clicks": 0,
+        "impressions": 3,
+        "ctr": 0,
+        "position": 8
+      },
+      {
+        "keys": [
+          "\"$.location.coords\" jsonpath example"
+        ],
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 10
+      },
+      {
+        "keys": [
+          "\"a react element from an older version of react was rendered\""
+        ],
+        "clicks": 0,
+        "impressions": 12,
+        "ctr": 0,
+        "position": 10.083333333333334
+      },
+      {
+        "keys": [
+          "\"adb emu geo fix\""
+        ],
+        "clicks": 0,
+        "impressions": 2,
+        "ctr": 0,
+        "position": 4
+      }
+    ],
+    "countries": [
+      {
+        "keys": [
+          "usa"
+        ],
+        "clicks": 183,
+        "impressions": 169004,
+        "ctr": 0.0010828146079382736,
+        "position": 6.878482166102577
+      },
+      {
+        "keys": [
+          "ind"
+        ],
+        "clicks": 85,
+        "impressions": 11685,
+        "ctr": 0.007274283269148481,
+        "position": 7.085665382969619
+      },
+      {
+        "keys": [
+          "deu"
+        ],
+        "clicks": 71,
+        "impressions": 4934,
+        "ctr": 0.014389947304418322,
+        "position": 6.618767734089988
+      },
+      {
+        "keys": [
+          "gbr"
+        ],
+        "clicks": 47,
+        "impressions": 11708,
+        "ctr": 0.004014349162965494,
+        "position": 5.81576699692518
+      },
+      {
+        "keys": [
+          "fra"
+        ],
+        "clicks": 43,
+        "impressions": 4034,
+        "ctr": 0.010659395141298959,
+        "position": 7.397372335151215
+      },
+      {
+        "keys": [
+          "can"
+        ],
+        "clicks": 35,
+        "impressions": 6775,
+        "ctr": 0.0051660516605166054,
+        "position": 7.258007380073801
+      },
+      {
+        "keys": [
+          "esp"
+        ],
+        "clicks": 35,
+        "impressions": 3232,
+        "ctr": 0.010829207920792078,
+        "position": 7.24845297029703
+      },
+      {
+        "keys": [
+          "bel"
+        ],
+        "clicks": 30,
+        "impressions": 1048,
+        "ctr": 0.02862595419847328,
+        "position": 6.430343511450381
+      },
+      {
+        "keys": [
+          "ita"
+        ],
+        "clicks": 27,
+        "impressions": 2647,
+        "ctr": 0.010200226671703816,
+        "position": 7.870419342652059
+      },
+      {
+        "keys": [
+          "idn"
+        ],
+        "clicks": 26,
+        "impressions": 2973,
+        "ctr": 0.008745375042045072,
+        "position": 6.358560376723848
+      },
+      {
+        "keys": [
+          "nld"
+        ],
+        "clicks": 24,
+        "impressions": 2292,
+        "ctr": 0.010471204188481676,
+        "position": 6.732984293193717
+      },
+      {
+        "keys": [
+          "bra"
+        ],
+        "clicks": 22,
+        "impressions": 6725,
+        "ctr": 0.0032713754646840148,
+        "position": 7.023048327137547
+      },
+      {
+        "keys": [
+          "aus"
+        ],
+        "clicks": 21,
+        "impressions": 2762,
+        "ctr": 0.007603186097031137,
+        "position": 7.189355539464157
+      },
+      {
+        "keys": [
+          "swe"
+        ],
+        "clicks": 21,
+        "impressions": 1480,
+        "ctr": 0.01418918918918919,
+        "position": 6.719594594594595
+      },
+      {
+        "keys": [
+          "kor"
+        ],
+        "clicks": 19,
+        "impressions": 2270,
+        "ctr": 0.008370044052863436,
+        "position": 7.640088105726872
+      }
+    ],
+    "devices": [
+      {
+        "keys": [
+          "DESKTOP"
+        ],
+        "clicks": 909,
+        "impressions": 260134,
+        "ctr": 0.00349435291042309,
+        "position": 7.189014123490201
+      },
+      {
+        "keys": [
+          "MOBILE"
+        ],
+        "clicks": 233,
+        "impressions": 27650,
+        "ctr": 0.008426763110307415,
+        "position": 4.778951175406871
+      },
+      {
+        "keys": [
+          "TABLET"
+        ],
+        "clicks": 6,
+        "impressions": 4397,
+        "ctr": 0.001364566750056857,
+        "position": 6.6561291789856725
+      }
+    ]
+  },
+  "ga4": {
+    "window": {
+      "startDate": "2025-05-06",
+      "endDate": "2026-05-06",
+      "days": 365
+    },
+    "propertyId": "416080229",
+    "botRegionsExcluded": [
+      "China",
+      "Singapore"
+    ],
+    "trafficSources": {
+      "dimensionHeaders": [
+        {
+          "name": "sessionDefaultChannelGroup"
+        },
+        {
+          "name": "sessionSource"
+        },
+        {
+          "name": "sessionMedium"
+        }
+      ],
+      "metricHeaders": [
+        {
+          "name": "sessions",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "conversions",
+          "type": "TYPE_FLOAT"
+        }
+      ],
+      "rows": [
+        {
+          "dimensionValues": [
+            {
+              "value": "Direct",
+              "oneValue": "value"
+            },
+            {
+              "value": "(direct)",
+              "oneValue": "value"
+            },
+            {
+              "value": "(none)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "6076",
+              "oneValue": "value"
+            },
+            {
+              "value": "61",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "google",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "1545",
+              "oneValue": "value"
+            },
+            {
+              "value": "7",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "bing",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "239",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Unassigned",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "111",
+              "oneValue": "value"
+            },
+            {
+              "value": "5",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "duckduckgo",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "110",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "chatgpt.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "62",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Social",
+              "oneValue": "value"
+            },
+            {
+              "value": "m.facebook.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "31",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "github.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "26",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Social",
+              "oneValue": "value"
+            },
+            {
+              "value": "facebook.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "25",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "vercel.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "22",
+              "oneValue": "value"
+            },
+            {
+              "value": "3",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "in.search.yahoo.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "12",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "gemini.google.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "12",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "perplexity.ai",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "11",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Unassigned",
+              "oneValue": "value"
+            },
+            {
+              "value": "chatgpt.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "11",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "yahoo",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "10",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        }
+      ]
+    },
+    "organicLandingPages": {
+      "dimensionHeaders": [
+        {
+          "name": "landingPagePlusQueryString"
+        }
+      ],
+      "metricHeaders": [
+        {
+          "name": "sessions",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "bounceRate",
+          "type": "TYPE_FLOAT"
+        },
+        {
+          "name": "conversions",
+          "type": "TYPE_FLOAT"
+        },
+        {
+          "name": "engagementRate",
+          "type": "TYPE_FLOAT"
+        },
+        {
+          "name": "averageSessionDuration",
+          "type": "TYPE_SECONDS"
+        }
+      ],
+      "rows": [
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/building-location-based-features-using-expo-location",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "461",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.39045553145336226",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.6095444685466378",
+              "oneValue": "value"
+            },
+            {
+              "value": "185.37360236442515",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/vibe-coding-building-an-app-entirely-with-ai-prompts",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "423",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.37115839243498816",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.62884160756501184",
+              "oneValue": "value"
+            },
+            {
+              "value": "127.22398555082744",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "335",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.9850746268656716",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.014925373134328358",
+              "oneValue": "value"
+            },
+            {
+              "value": "4.422159095522388",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/slow-android-emulator-flutter-dev",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "241",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.49792531120331951",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.50207468879668049",
+              "oneValue": "value"
+            },
+            {
+              "value": "189.02270130290458",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/managing-secrets-firebase-apphosting-yaml-nextjs",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "221",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.36199095022624433",
+              "oneValue": "value"
+            },
+            {
+              "value": "2",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.63800904977375561",
+              "oneValue": "value"
+            },
+            {
+              "value": "237.69706467420812",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/react-19-features-and-design-patterns",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "76",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.53947368421052633",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.46052631578947367",
+              "oneValue": "value"
+            },
+            {
+              "value": "159.01837968421052",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/how-to-see-when-a-file-was-deleted-or-changed-with-git-log",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "48",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.5",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.5",
+              "oneValue": "value"
+            },
+            {
+              "value": "181.61281379166667",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "28",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.21428571428571427",
+              "oneValue": "value"
+            },
+            {
+              "value": "4",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.7857142857142857",
+              "oneValue": "value"
+            },
+            {
+              "value": "228.43832785714287",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/preventing-unnecessary-re-renders-in-react-apps",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "25",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.52",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.48",
+              "oneValue": "value"
+            },
+            {
+              "value": "175.66383539999998",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/authorize-net-for-react-native-expo-sdk-49",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "18",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.5",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.5",
+              "oneValue": "value"
+            },
+            {
+              "value": "64.892102888888886",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/setting-up-ci-cd-for-firebase-functions-using-github-actions",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "17",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.29411764705882354",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.70588235294117652",
+              "oneValue": "value"
+            },
+            {
+              "value": "64.067072058823541",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/building-interactive-3d-experiences-with-react-three-fiber",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "9",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.22222222222222221",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.77777777777777779",
+              "oneValue": "value"
+            },
+            {
+              "value": "139.87847633333334",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/contact",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "7",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.14285714285714285",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.8571428571428571",
+              "oneValue": "value"
+            },
+            {
+              "value": "270.49053214285715",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/how-to-end-a-process-by-port-number",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "6",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.5",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.5",
+              "oneValue": "value"
+            },
+            {
+              "value": "362.753571",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/micro-frontends-architecture-benefits-challenges-best-practices",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "4",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.75",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.25",
+              "oneValue": "value"
+            },
+            {
+              "value": "37.08032775",
+              "oneValue": "value"
+            }
+          ]
+        }
+      ]
+    },
+    "userBehavior": {
+      "devices": {
+        "dimensionHeaders": [
+          {
+            "name": "deviceCategory"
+          }
+        ],
+        "metricHeaders": [
+          {
+            "name": "activeUsers",
+            "type": "TYPE_INTEGER"
+          },
+          {
+            "name": "sessions",
+            "type": "TYPE_INTEGER"
+          },
+          {
+            "name": "engagementRate",
+            "type": "TYPE_FLOAT"
+          }
+        ],
+        "rows": [
+          {
+            "dimensionValues": [
+              {
+                "value": "desktop",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "6804",
+                "oneValue": "value"
+              },
+              {
+                "value": "7794",
+                "oneValue": "value"
+              },
+              {
+                "value": "0.19348216576853991",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "mobile",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "499",
+                "oneValue": "value"
+              },
+              {
+                "value": "593",
+                "oneValue": "value"
+              },
+              {
+                "value": "0.44688026981450252",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "tablet",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "7",
+                "oneValue": "value"
+              },
+              {
+                "value": "9",
+                "oneValue": "value"
+              },
+              {
+                "value": "0.44444444444444442",
+                "oneValue": "value"
+              }
+            ]
+          }
+        ]
+      },
+      "countries": {
+        "dimensionHeaders": [
+          {
+            "name": "country"
+          }
+        ],
+        "metricHeaders": [
+          {
+            "name": "activeUsers",
+            "type": "TYPE_INTEGER"
+          },
+          {
+            "name": "sessions",
+            "type": "TYPE_INTEGER"
+          }
+        ],
+        "rows": [
+          {
+            "dimensionValues": [
+              {
+                "value": "United States",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "4279",
+                "oneValue": "value"
+              },
+              {
+                "value": "4633",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "China",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "955",
+                "oneValue": "value"
+              },
+              {
+                "value": "963",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Singapore",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "741",
+                "oneValue": "value"
+              },
+              {
+                "value": "742",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "India",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "164",
+                "oneValue": "value"
+              },
+              {
+                "value": "256",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Germany",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "150",
+                "oneValue": "value"
+              },
+              {
+                "value": "184",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "France",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "72",
+                "oneValue": "value"
+              },
+              {
+                "value": "100",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "United Kingdom",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "68",
+                "oneValue": "value"
+              },
+              {
+                "value": "93",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "(not set)",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "60",
+                "oneValue": "value"
+              },
+              {
+                "value": "60",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Canada",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "56",
+                "oneValue": "value"
+              },
+              {
+                "value": "74",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Netherlands",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "51",
+                "oneValue": "value"
+              },
+              {
+                "value": "62",
+                "oneValue": "value"
+              }
+            ]
+          }
+        ]
+      },
+      "engagement": {
+        "dimensionHeaders": [],
+        "metricHeaders": [
+          {
+            "name": "averageSessionDuration",
+            "type": "TYPE_SECONDS"
+          },
+          {
+            "name": "engagementRate",
+            "type": "TYPE_FLOAT"
+          }
+        ],
+        "rows": [
+          {
+            "dimensionValues": [],
+            "metricValues": [
+              {
+                "value": "62.924152534947524",
+                "oneValue": "value"
+              },
+              {
+                "value": "0.21183206106870228",
+                "oneValue": "value"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "trafficSourcesExBotRegions": {
+      "dimensionHeaders": [
+        {
+          "name": "sessionDefaultChannelGroup"
+        },
+        {
+          "name": "sessionSource"
+        },
+        {
+          "name": "sessionMedium"
+        }
+      ],
+      "metricHeaders": [
+        {
+          "name": "sessions",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "conversions",
+          "type": "TYPE_FLOAT"
+        }
+      ],
+      "rows": [
+        {
+          "dimensionValues": [
+            {
+              "value": "Direct",
+              "oneValue": "value"
+            },
+            {
+              "value": "(direct)",
+              "oneValue": "value"
+            },
+            {
+              "value": "(none)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "4566",
+              "oneValue": "value"
+            },
+            {
+              "value": "59",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "google",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "1525",
+              "oneValue": "value"
+            },
+            {
+              "value": "6",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "bing",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "232",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "duckduckgo",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "110",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "chatgpt.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "62",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Unassigned",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "56",
+              "oneValue": "value"
+            },
+            {
+              "value": "5",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Social",
+              "oneValue": "value"
+            },
+            {
+              "value": "m.facebook.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "31",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "github.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "26",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Social",
+              "oneValue": "value"
+            },
+            {
+              "value": "facebook.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "25",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "vercel.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "22",
+              "oneValue": "value"
+            },
+            {
+              "value": "3",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "in.search.yahoo.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "12",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "gemini.google.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "12",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "perplexity.ai",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "11",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "yahoo",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "10",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Unassigned",
+              "oneValue": "value"
+            },
+            {
+              "value": "chatgpt.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "10",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        }
+      ]
+    },
+    "userBehaviorExBotRegions": {
+      "countries": {
+        "dimensionHeaders": [
+          {
+            "name": "country"
+          }
+        ],
+        "metricHeaders": [
+          {
+            "name": "activeUsers",
+            "type": "TYPE_INTEGER"
+          },
+          {
+            "name": "sessions",
+            "type": "TYPE_INTEGER"
+          }
+        ],
+        "rows": [
+          {
+            "dimensionValues": [
+              {
+                "value": "United States",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "4279",
+                "oneValue": "value"
+              },
+              {
+                "value": "4633",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "India",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "164",
+                "oneValue": "value"
+              },
+              {
+                "value": "256",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Germany",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "150",
+                "oneValue": "value"
+              },
+              {
+                "value": "184",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "France",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "72",
+                "oneValue": "value"
+              },
+              {
+                "value": "100",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "United Kingdom",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "68",
+                "oneValue": "value"
+              },
+              {
+                "value": "93",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "(not set)",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "60",
+                "oneValue": "value"
+              },
+              {
+                "value": "60",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Canada",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "56",
+                "oneValue": "value"
+              },
+              {
+                "value": "74",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Netherlands",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "51",
+                "oneValue": "value"
+              },
+              {
+                "value": "62",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Brazil",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "48",
+                "oneValue": "value"
+              },
+              {
+                "value": "68",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Indonesia",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "45",
+                "oneValue": "value"
+              },
+              {
+                "value": "59",
+                "oneValue": "value"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "bing": {
+    "window": {
+      "startDate": "2025-05-06",
+      "endDate": "2026-05-06",
+      "days": 365
+    },
+    "siteUrl": "https://coffey.codes/",
+    "totals": {
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0
+    },
+    "trafficStats": [],
+    "topQueries": [],
+    "_note": "empty response"
+  },
+  "totals": {
+    "clicks": 1148,
+    "impressions": 292181,
+    "ctr": 0.0039290713632987775
+  },
+  "topPages": [
+    {
+      "keys": [
+        "https://coffey.codes/articles/building-location-based-features-using-expo-location"
+      ],
+      "clicks": 387,
+      "impressions": 149858,
+      "ctr": 0.0025824447143295653,
+      "position": 6.756022367841557
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/vibe-coding-building-an-app-entirely-with-ai-prompts"
+      ],
+      "clicks": 248,
+      "impressions": 9012,
+      "ctr": 0.027518863737239236,
+      "position": 8.473923657345761
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/slow-android-emulator-flutter-dev"
+      ],
+      "clicks": 236,
+      "impressions": 70981,
+      "ctr": 0.0033248334061227653,
+      "position": 5.842324002197771
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/managing-secrets-firebase-apphosting-yaml-nextjs"
+      ],
+      "clicks": 180,
+      "impressions": 43402,
+      "ctr": 0.004147274319155799,
+      "position": 7.460001843233031
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/react-19-features-and-design-patterns"
+      ],
+      "clicks": 52,
+      "impressions": 14933,
+      "ctr": 0.0034822205852809217,
+      "position": 8.550056920913413
+    },
+    {
+      "keys": [
+        "https://coffey.codes/Anthony%20Coffey%20-%20Resume.pdf"
+      ],
+      "clicks": 15,
+      "impressions": 465,
+      "ctr": 0.03225806451612903,
+      "position": 39.72043010752688
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/authorize-net-for-react-native-expo-sdk-49"
+      ],
+      "clicks": 15,
+      "impressions": 882,
+      "ctr": 0.017006802721088437,
+      "position": 11.487528344671201
+    },
+    {
+      "keys": [
+        "https://coffey.codes/"
+      ],
+      "clicks": 4,
+      "impressions": 310,
+      "ctr": 0.012903225806451613,
+      "position": 13.825806451612904
+    },
+    {
+      "keys": [
+        "https://coffey.codes/contact"
+      ],
+      "clicks": 4,
+      "impressions": 224,
+      "ctr": 0.017857142857142856,
+      "position": 26.379464285714285
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/setting-up-ci-cd-for-firebase-functions-using-github-actions"
+      ],
+      "clicks": 3,
+      "impressions": 594,
+      "ctr": 0.005050505050505051,
+      "position": 12.065656565656566
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/how-to-end-a-process-by-port-number"
+      ],
+      "clicks": 2,
+      "impressions": 706,
+      "ctr": 0.0028328611898017,
+      "position": 19.879603399433428
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/step-by-step-building-your-blog-with-next-js-and-mdx"
+      ],
+      "clicks": 1,
+      "impressions": 633,
+      "ctr": 0.001579778830963665,
+      "position": 17.50394944707741
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/tag/unit%20testing?"
+      ],
+      "clicks": 1,
+      "impressions": 9,
+      "ctr": 0.1111111111111111,
+      "position": 6.333333333333333
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles"
+      ],
+      "clicks": 0,
+      "impressions": 97,
+      "ctr": 0,
+      "position": 8.391752577319588
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/avoiding-unnecessary-re-renders-in-react-apps"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/building-an-mdx-powered-blog-using-app-router-next-js"
+      ],
+      "clicks": 0,
+      "impressions": 256,
+      "ctr": 0,
+      "position": 24.921875
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/building-interactive-3d-experiences-with-react-three-fiber"
+      ],
+      "clicks": 0,
+      "impressions": 34,
+      "ctr": 0,
+      "position": 9.764705882352942
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/categories"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/category/development"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/category/web%20development"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/essential-tips-for-effective-aws-iam-policy-management"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/how-to-deploy-a-flask-rest-api-on-google-cloud-run"
+      ],
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 6.153846153846154
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/preventing-unnecessary-re-renders-in-react-apps"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 36.333333333333336
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/react-19-features-and-design-patterns#actions-api"
+      ],
+      "clicks": 0,
+      "impressions": 711,
+      "ctr": 0,
+      "position": 6.022503516174402
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/react-19-features-and-design-patterns#document-metadata"
+      ],
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 4.764705882352941
+    }
+  ],
+  "topQueries": [
+    {
+      "keys": [
+        "flutter vibe coding"
+      ],
+      "clicks": 49,
+      "impressions": 1073,
+      "ctr": 0.045666356011183594,
+      "position": 8.387698042870458
+    },
+    {
+      "keys": [
+        "expo location"
+      ],
+      "clicks": 24,
+      "impressions": 9612,
+      "ctr": 0.0024968789013732834,
+      "position": 7.72929671244278
+    },
+    {
+      "keys": [
+        "vibe coding flutter"
+      ],
+      "clicks": 24,
+      "impressions": 647,
+      "ctr": 0.03709428129829984,
+      "position": 8.256568778979908
+    },
+    {
+      "keys": [
+        "vibe coding flutter app"
+      ],
+      "clicks": 15,
+      "impressions": 218,
+      "ctr": 0.06880733944954129,
+      "position": 7.389908256880734
+    },
+    {
+      "keys": [
+        "expo-location"
+      ],
+      "clicks": 10,
+      "impressions": 5256,
+      "ctr": 0.001902587519025875,
+      "position": 6.5932267884322675
+    },
+    {
+      "keys": [
+        "vibe code flutter app"
+      ],
+      "clicks": 9,
+      "impressions": 157,
+      "ctr": 0.05732484076433121,
+      "position": 7.547770700636943
+    },
+    {
+      "keys": [
+        "expo geofencing"
+      ],
+      "clicks": 7,
+      "impressions": 216,
+      "ctr": 0.032407407407407406,
+      "position": 7.583333333333333
+    },
+    {
+      "keys": [
+        "firebase apphosting:secrets:grantaccess"
+      ],
+      "clicks": 7,
+      "impressions": 386,
+      "ctr": 0.018134715025906734,
+      "position": 6.160621761658031
+    },
+    {
+      "keys": [
+        "firebase apphosting:secrets:set"
+      ],
+      "clicks": 6,
+      "impressions": 192,
+      "ctr": 0.03125,
+      "position": 5.447916666666667
+    },
+    {
+      "keys": [
+        "vibe code flutter"
+      ],
+      "clicks": 6,
+      "impressions": 144,
+      "ctr": 0.041666666666666664,
+      "position": 8.208333333333332
+    },
+    {
+      "keys": [
+        "expo location accuracy"
+      ],
+      "clicks": 5,
+      "impressions": 132,
+      "ctr": 0.03787878787878788,
+      "position": 5.613636363636363
+    },
+    {
+      "keys": [
+        "flutter vibe code"
+      ],
+      "clicks": 4,
+      "impressions": 53,
+      "ctr": 0.07547169811320754,
+      "position": 7.471698113207547
+    },
+    {
+      "keys": [
+        "expo geolocation"
+      ],
+      "clicks": 3,
+      "impressions": 494,
+      "ctr": 0.006072874493927126,
+      "position": 6.923076923076923
+    },
+    {
+      "keys": [
+        "expo location example"
+      ],
+      "clicks": 3,
+      "impressions": 47,
+      "ctr": 0.06382978723404255,
+      "position": 8.51063829787234
+    },
+    {
+      "keys": [
+        "react native expo location"
+      ],
+      "clicks": 3,
+      "impressions": 227,
+      "ctr": 0.013215859030837005,
+      "position": 5.066079295154185
+    },
+    {
+      "keys": [
+        "requestforegroundpermissionsasync"
+      ],
+      "clicks": 3,
+      "impressions": 222,
+      "ctr": 0.013513513513513514,
+      "position": 7.833333333333333
+    },
+    {
+      "keys": [
+        "android emulator slow"
+      ],
+      "clicks": 2,
+      "impressions": 386,
+      "ctr": 0.0051813471502590676,
+      "position": 7.383419689119171
+    },
+    {
+      "keys": [
+        "apphosting.yaml"
+      ],
+      "clicks": 2,
+      "impressions": 448,
+      "ctr": 0.004464285714285714,
+      "position": 8.453125
+    },
+    {
+      "keys": [
+        "expo gps"
+      ],
+      "clicks": 2,
+      "impressions": 255,
+      "ctr": 0.00784313725490196,
+      "position": 7.6117647058823525
+    },
+    {
+      "keys": [
+        "expo location api"
+      ],
+      "clicks": 2,
+      "impressions": 236,
+      "ctr": 0.00847457627118644,
+      "position": 5.008474576271187
+    },
+    {
+      "keys": [
+        "expo location permission"
+      ],
+      "clicks": 2,
+      "impressions": 56,
+      "ctr": 0.03571428571428571,
+      "position": 8.660714285714285
+    },
+    {
+      "keys": [
+        "expo location tracking"
+      ],
+      "clicks": 2,
+      "impressions": 33,
+      "ctr": 0.06060606060606061,
+      "position": 6.363636363636363
+    },
+    {
+      "keys": [
+        "firebase app hosting secrets"
+      ],
+      "clicks": 2,
+      "impressions": 204,
+      "ctr": 0.00980392156862745,
+      "position": 6.519607843137255
+    },
+    {
+      "keys": [
+        "flutter vibe coding platform"
+      ],
+      "clicks": 2,
+      "impressions": 31,
+      "ctr": 0.06451612903225806,
+      "position": 8.032258064516128
+    },
+    {
+      "keys": [
+        "location.watchpositionasync"
+      ],
+      "clicks": 2,
+      "impressions": 63,
+      "ctr": 0.031746031746031744,
+      "position": 6.666666666666667
+    },
+    {
+      "keys": [
+        "react 19 best practices"
+      ],
+      "clicks": 2,
+      "impressions": 71,
+      "ctr": 0.028169014084507043,
+      "position": 9.647887323943662
+    },
+    {
+      "keys": [
+        "vibe coding for flutter"
+      ],
+      "clicks": 2,
+      "impressions": 57,
+      "ctr": 0.03508771929824561,
+      "position": 8.491228070175438
+    },
+    {
+      "keys": [
+        "why android emulator is slow"
+      ],
+      "clicks": 2,
+      "impressions": 84,
+      "ctr": 0.023809523809523808,
+      "position": 4.666666666666666
+    },
+    {
+      "keys": [
+        "android emulator very slow"
+      ],
+      "clicks": 1,
+      "impressions": 134,
+      "ctr": 0.007462686567164179,
+      "position": 6.746268656716418
+    },
+    {
+      "keys": [
+        "apphosting.yaml firebase"
+      ],
+      "clicks": 1,
+      "impressions": 88,
+      "ctr": 0.011363636363636364,
+      "position": 8.420454545454547
+    },
+    {
+      "keys": [
+        "expo background location tracking"
+      ],
+      "clicks": 1,
+      "impressions": 105,
+      "ctr": 0.009523809523809525,
+      "position": 7.6761904761904765
+    },
+    {
+      "keys": [
+        "expo location documentation"
+      ],
+      "clicks": 1,
+      "impressions": 304,
+      "ctr": 0.003289473684210526,
+      "position": 5.384868421052632
+    },
+    {
+      "keys": [
+        "expo location geofencing"
+      ],
+      "clicks": 1,
+      "impressions": 61,
+      "ctr": 0.01639344262295082,
+      "position": 4.557377049180328
+    },
+    {
+      "keys": [
+        "expo location permissions"
+      ],
+      "clicks": 1,
+      "impressions": 209,
+      "ctr": 0.004784688995215311,
+      "position": 6.574162679425838
+    },
+    {
+      "keys": [
+        "expo location react native"
+      ],
+      "clicks": 1,
+      "impressions": 220,
+      "ctr": 0.004545454545454545,
+      "position": 5.177272727272728
+    },
+    {
+      "keys": [
+        "expo location services"
+      ],
+      "clicks": 1,
+      "impressions": 78,
+      "ctr": 0.01282051282051282,
+      "position": 4.589743589743589
+    },
+    {
+      "keys": [
+        "expo-location documentation"
+      ],
+      "clicks": 1,
+      "impressions": 339,
+      "ctr": 0.0029498525073746312,
+      "position": 4.775811209439528
+    },
+    {
+      "keys": [
+        "firebase app hosting environment variables"
+      ],
+      "clicks": 1,
+      "impressions": 211,
+      "ctr": 0.004739336492890996,
+      "position": 9.189573459715639
+    },
+    {
+      "keys": [
+        "location expo"
+      ],
+      "clicks": 1,
+      "impressions": 166,
+      "ctr": 0.006024096385542169,
+      "position": 8.650602409638555
+    },
+    {
+      "keys": [
+        "location.getcurrentpositionasync"
+      ],
+      "clicks": 1,
+      "impressions": 15,
+      "ctr": 0.06666666666666667,
+      "position": 9.133333333333333
+    },
+    {
+      "keys": [
+        "next_public_firebase_api_key"
+      ],
+      "clicks": 1,
+      "impressions": 345,
+      "ctr": 0.002898550724637681,
+      "position": 9.30144927536232
+    },
+    {
+      "keys": [
+        "react 19 design patterns and best practices"
+      ],
+      "clicks": 1,
+      "impressions": 13,
+      "ctr": 0.07692307692307693,
+      "position": 4.3076923076923075
+    },
+    {
+      "keys": [
+        "react 19 partial hydration"
+      ],
+      "clicks": 1,
+      "impressions": 82,
+      "ctr": 0.012195121951219513,
+      "position": 7.426829268292683
+    },
+    {
+      "keys": [
+        "vibe coding with flutter"
+      ],
+      "clicks": 1,
+      "impressions": 84,
+      "ctr": 0.011904761904761904,
+      "position": 7.928571428571429
+    },
+    {
+      "keys": [
+        "why is android emulator so slow"
+      ],
+      "clicks": 1,
+      "impressions": 111,
+      "ctr": 0.009009009009009009,
+      "position": 4.684684684684685
+    },
+    {
+      "keys": [
+        "\"$.location.coords\" audit logs geofence"
+      ],
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 8.2
+    },
+    {
+      "keys": [
+        "\"$.location.coords\" geofence"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "\"$.location.coords\" jsonpath example"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "\"a react element from an older version of react was rendered\""
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 10.083333333333334
+    },
+    {
+      "keys": [
+        "\"adb emu geo fix\""
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4
+    }
+  ],
+  "countries": [
+    {
+      "keys": [
+        "usa"
+      ],
+      "clicks": 183,
+      "impressions": 169004,
+      "ctr": 0.0010828146079382736,
+      "position": 6.878482166102577
+    },
+    {
+      "keys": [
+        "ind"
+      ],
+      "clicks": 85,
+      "impressions": 11685,
+      "ctr": 0.007274283269148481,
+      "position": 7.085665382969619
+    },
+    {
+      "keys": [
+        "deu"
+      ],
+      "clicks": 71,
+      "impressions": 4934,
+      "ctr": 0.014389947304418322,
+      "position": 6.618767734089988
+    },
+    {
+      "keys": [
+        "gbr"
+      ],
+      "clicks": 47,
+      "impressions": 11708,
+      "ctr": 0.004014349162965494,
+      "position": 5.81576699692518
+    },
+    {
+      "keys": [
+        "fra"
+      ],
+      "clicks": 43,
+      "impressions": 4034,
+      "ctr": 0.010659395141298959,
+      "position": 7.397372335151215
+    },
+    {
+      "keys": [
+        "can"
+      ],
+      "clicks": 35,
+      "impressions": 6775,
+      "ctr": 0.0051660516605166054,
+      "position": 7.258007380073801
+    },
+    {
+      "keys": [
+        "esp"
+      ],
+      "clicks": 35,
+      "impressions": 3232,
+      "ctr": 0.010829207920792078,
+      "position": 7.24845297029703
+    },
+    {
+      "keys": [
+        "bel"
+      ],
+      "clicks": 30,
+      "impressions": 1048,
+      "ctr": 0.02862595419847328,
+      "position": 6.430343511450381
+    },
+    {
+      "keys": [
+        "ita"
+      ],
+      "clicks": 27,
+      "impressions": 2647,
+      "ctr": 0.010200226671703816,
+      "position": 7.870419342652059
+    },
+    {
+      "keys": [
+        "idn"
+      ],
+      "clicks": 26,
+      "impressions": 2973,
+      "ctr": 0.008745375042045072,
+      "position": 6.358560376723848
+    },
+    {
+      "keys": [
+        "nld"
+      ],
+      "clicks": 24,
+      "impressions": 2292,
+      "ctr": 0.010471204188481676,
+      "position": 6.732984293193717
+    },
+    {
+      "keys": [
+        "bra"
+      ],
+      "clicks": 22,
+      "impressions": 6725,
+      "ctr": 0.0032713754646840148,
+      "position": 7.023048327137547
+    },
+    {
+      "keys": [
+        "aus"
+      ],
+      "clicks": 21,
+      "impressions": 2762,
+      "ctr": 0.007603186097031137,
+      "position": 7.189355539464157
+    },
+    {
+      "keys": [
+        "swe"
+      ],
+      "clicks": 21,
+      "impressions": 1480,
+      "ctr": 0.01418918918918919,
+      "position": 6.719594594594595
+    },
+    {
+      "keys": [
+        "kor"
+      ],
+      "clicks": 19,
+      "impressions": 2270,
+      "ctr": 0.008370044052863436,
+      "position": 7.640088105726872
+    }
+  ],
+  "devices": [
+    {
+      "keys": [
+        "DESKTOP"
+      ],
+      "clicks": 909,
+      "impressions": 260134,
+      "ctr": 0.00349435291042309,
+      "position": 7.189014123490201
+    },
+    {
+      "keys": [
+        "MOBILE"
+      ],
+      "clicks": 233,
+      "impressions": 27650,
+      "ctr": 0.008426763110307415,
+      "position": 4.778951175406871
+    },
+    {
+      "keys": [
+        "TABLET"
+      ],
+      "clicks": 6,
+      "impressions": 4397,
+      "ctr": 0.001364566750056857,
+      "position": 6.6561291789856725
+    }
+  ]
+}

--- a/docs/strategy/data/snapshot-2026-05-09.md
+++ b/docs/strategy/data/snapshot-2026-05-09.md
@@ -1,0 +1,158 @@
+---
+title: SEO snapshot — 2026-05-11
+tags: [seo, snapshot, gsc, ga4, bing, keywords]
+date: 2026-05-11
+window_start: 2025-05-06
+window_end: 2026-05-06
+---
+
+# SEO snapshot — 2026-05-11
+
+**Window:** 2025-05-06 → 2026-05-06 (365 days)  
+**Site:** `sc-domain:coffey.codes`  
+**Pulled:** 2026-05-11T21:55:51.378Z
+
+## Headline numbers
+
+| Source | Clicks | Impressions | CTR | Sessions |
+|---|---:|---:|---:|---:|
+| Google Search Console | 1,148 | 292,181 | 0.39% | — |
+| Bing Webmaster *(empty response)* | 0 | 0 | 0.00% | — |
+| GA4 (all channels) | — | — | — | 8,303 |
+| GA4 (excluding bot regions: China, Singapore) | — | — | — | 6,710 |
+
+## GSC — top pages
+
+| URL | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| /articles/building-location-based-features-using-expo-location | 387 | 149,858 | 0.26% | 6.8 |
+| /articles/vibe-coding-building-an-app-entirely-with-ai-prompts | 248 | 9,012 | 2.75% | 8.5 |
+| /articles/slow-android-emulator-flutter-dev | 236 | 70,981 | 0.33% | 5.8 |
+| /articles/managing-secrets-firebase-apphosting-yaml-nextjs | 180 | 43,402 | 0.41% | 7.5 |
+| /articles/react-19-features-and-design-patterns | 52 | 14,933 | 0.35% | 8.6 |
+| /Anthony%20Coffey%20-%20Resume.pdf | 15 | 465 | 3.23% | 39.7 |
+| /articles/authorize-net-for-react-native-expo-sdk-49 | 15 | 882 | 1.70% | 11.5 |
+| / | 4 | 310 | 1.29% | 13.8 |
+| /contact | 4 | 224 | 1.79% | 26.4 |
+| /articles/setting-up-ci-cd-for-firebase-functions-using-github-actions | 3 | 594 | 0.51% | 12.1 |
+| /articles/how-to-end-a-process-by-port-number | 2 | 706 | 0.28% | 19.9 |
+| /articles/step-by-step-building-your-blog-with-next-js-and-mdx | 1 | 633 | 0.16% | 17.5 |
+| /articles/tag/unit%20testing? | 1 | 9 | 11.11% | 6.3 |
+| /articles | 0 | 97 | 0.00% | 8.4 |
+| /articles/avoiding-unnecessary-re-renders-in-react-apps | 0 | 1 | 0.00% | 9.0 |
+
+## GSC — top queries
+
+| Query | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| flutter vibe coding | 49 | 1,073 | 4.57% | 8.4 |
+| expo location | 24 | 9,612 | 0.25% | 7.7 |
+| vibe coding flutter | 24 | 647 | 3.71% | 8.3 |
+| vibe coding flutter app | 15 | 218 | 6.88% | 7.4 |
+| expo-location | 10 | 5,256 | 0.19% | 6.6 |
+| vibe code flutter app | 9 | 157 | 5.73% | 7.5 |
+| expo geofencing | 7 | 216 | 3.24% | 7.6 |
+| firebase apphosting:secrets:grantaccess | 7 | 386 | 1.81% | 6.2 |
+| firebase apphosting:secrets:set | 6 | 192 | 3.13% | 5.4 |
+| vibe code flutter | 6 | 144 | 4.17% | 8.2 |
+| expo location accuracy | 5 | 132 | 3.79% | 5.6 |
+| flutter vibe code | 4 | 53 | 7.55% | 7.5 |
+| expo geolocation | 3 | 494 | 0.61% | 6.9 |
+| expo location example | 3 | 47 | 6.38% | 8.5 |
+| react native expo location | 3 | 227 | 1.32% | 5.1 |
+| requestforegroundpermissionsasync | 3 | 222 | 1.35% | 7.8 |
+| android emulator slow | 2 | 386 | 0.52% | 7.4 |
+| apphosting.yaml | 2 | 448 | 0.45% | 8.5 |
+| expo gps | 2 | 255 | 0.78% | 7.6 |
+| expo location api | 2 | 236 | 0.85% | 5.0 |
+| expo location permission | 2 | 56 | 3.57% | 8.7 |
+| expo location tracking | 2 | 33 | 6.06% | 6.4 |
+| firebase app hosting secrets | 2 | 204 | 0.98% | 6.5 |
+| flutter vibe coding platform | 2 | 31 | 6.45% | 8.0 |
+| location.watchpositionasync | 2 | 63 | 3.17% | 6.7 |
+| react 19 best practices | 2 | 71 | 2.82% | 9.6 |
+| vibe coding for flutter | 2 | 57 | 3.51% | 8.5 |
+| why android emulator is slow | 2 | 84 | 2.38% | 4.7 |
+| android emulator very slow | 1 | 134 | 0.75% | 6.7 |
+| apphosting.yaml firebase | 1 | 88 | 1.14% | 8.4 |
+
+## GSC — countries
+
+| Country | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| usa | 183 | 169,004 | 0.11% | 6.9 |
+| ind | 85 | 11,685 | 0.73% | 7.1 |
+| deu | 71 | 4,934 | 1.44% | 6.6 |
+| gbr | 47 | 11,708 | 0.40% | 5.8 |
+| fra | 43 | 4,034 | 1.07% | 7.4 |
+| can | 35 | 6,775 | 0.52% | 7.3 |
+| esp | 35 | 3,232 | 1.08% | 7.2 |
+| bel | 30 | 1,048 | 2.86% | 6.4 |
+| ita | 27 | 2,647 | 1.02% | 7.9 |
+| idn | 26 | 2,973 | 0.87% | 6.4 |
+
+## GSC — devices
+
+| Device | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| DESKTOP | 909 | 260,134 | 0.35% | 7.2 |
+| MOBILE | 233 | 27,650 | 0.84% | 4.8 |
+| TABLET | 6 | 4,397 | 0.14% | 6.7 |
+
+## GA4 — traffic sources
+
+| Channel | Source | Medium | Sessions | Conversions |
+|---|---|---|---:|---:|
+| Direct | (direct) | (none) | 6,076 | 61 |
+| Organic Search | google | organic | 1,545 | 7 |
+| Organic Search | bing | organic | 239 | 0 |
+| Unassigned | (not set) | (not set) | 111 | 5 |
+| Organic Search | duckduckgo | organic | 110 | 1 |
+| Referral | chatgpt.com | referral | 62 | 0 |
+| Organic Social | m.facebook.com | referral | 31 | 1 |
+| Referral | github.com | referral | 26 | 1 |
+| Organic Social | facebook.com | referral | 25 | 0 |
+| Referral | vercel.com | referral | 22 | 3 |
+
+### GA4 — traffic sources (bot regions excluded)
+
+| Channel | Source | Medium | Sessions | Conversions |
+|---|---|---|---:|---:|
+| Direct | (direct) | (none) | 4,566 | 59 |
+| Organic Search | google | organic | 1,525 | 6 |
+| Organic Search | bing | organic | 232 | 0 |
+| Organic Search | duckduckgo | organic | 110 | 1 |
+| Referral | chatgpt.com | referral | 62 | 0 |
+| Unassigned | (not set) | (not set) | 56 | 5 |
+| Organic Social | m.facebook.com | referral | 31 | 1 |
+| Referral | github.com | referral | 26 | 1 |
+| Organic Social | facebook.com | referral | 25 | 0 |
+| Referral | vercel.com | referral | 22 | 3 |
+
+## GA4 — organic landing pages
+
+| Page | Sessions | Bounce | Engaged | Avg dur |
+|---|---:|---:|---:|---:|
+| /articles/building-location-based-features-using-expo-location | 461 | 39.05% | 60.95% | 3m 5s |
+| /articles/vibe-coding-building-an-app-entirely-with-ai-prompts | 423 | 37.12% | 62.88% | 2m 7s |
+| (not set) | 335 | 98.51% | 1.49% | 4s |
+| /articles/slow-android-emulator-flutter-dev | 241 | 49.79% | 50.21% | 3m 9s |
+| /articles/managing-secrets-firebase-apphosting-yaml-nextjs | 221 | 36.20% | 63.80% | 3m 58s |
+| /articles/react-19-features-and-design-patterns | 76 | 53.95% | 46.05% | 2m 39s |
+| /articles/how-to-see-when-a-file-was-deleted-or-changed-with-git-log | 48 | 50.00% | 50.00% | 3m 2s |
+| / | 28 | 21.43% | 78.57% | 3m 48s |
+| /articles/preventing-unnecessary-re-renders-in-react-apps | 25 | 52.00% | 48.00% | 2m 56s |
+| /articles/authorize-net-for-react-native-expo-sdk-49 | 18 | 50.00% | 50.00% | 1m 5s |
+
+## GA4 — user behavior (devices)
+
+| Device | Active users | Sessions | Engagement |
+|---|---:|---:|---:|
+| desktop | 6,804 | 7,794 | 19.35% |
+| mobile | 499 | 593 | 44.69% |
+| tablet | 7 | 9 | 44.44% |
+
+## Notes
+
+- Bot regions excluded from `*ExBotRegions` slices: China, Singapore (per SPEC-018).
+- Full structured data: `snapshot-2026-05-11.json` next to this file.

--- a/docs/strategy/data/snapshot-2026-05-10.json
+++ b/docs/strategy/data/snapshot-2026-05-10.json
@@ -1,0 +1,3574 @@
+{
+  "window": {
+    "startDate": "2025-05-07",
+    "endDate": "2026-05-07",
+    "days": 365
+  },
+  "pulledAt": "2026-05-11T21:56:09.766Z",
+  "siteUrl": "sc-domain:coffey.codes",
+  "gsc": {
+    "window": {
+      "startDate": "2025-05-07",
+      "endDate": "2026-05-07",
+      "days": 365
+    },
+    "totals": {
+      "clicks": 1149,
+      "impressions": 293590,
+      "ctr": 0.003913621036138833
+    },
+    "topPages": [
+      {
+        "keys": [
+          "https://coffey.codes/articles/building-location-based-features-using-expo-location"
+        ],
+        "clicks": 388,
+        "impressions": 150793,
+        "ctr": 0.002573063736380336,
+        "position": 6.754783046958413
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/vibe-coding-building-an-app-entirely-with-ai-prompts"
+        ],
+        "clicks": 248,
+        "impressions": 9038,
+        "ctr": 0.02743969904846205,
+        "position": 8.468245186988272
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/slow-android-emulator-flutter-dev"
+        ],
+        "clicks": 236,
+        "impressions": 71150,
+        "ctr": 0.0033169360505973296,
+        "position": 5.845158116654955
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/managing-secrets-firebase-apphosting-yaml-nextjs"
+        ],
+        "clicks": 180,
+        "impressions": 43486,
+        "ctr": 0.004139263211148415,
+        "position": 7.463206549234236
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/react-19-features-and-design-patterns"
+        ],
+        "clicks": 52,
+        "impressions": 15131,
+        "ctr": 0.0034366532284713504,
+        "position": 8.612451259004693
+      },
+      {
+        "keys": [
+          "https://coffey.codes/Anthony%20Coffey%20-%20Resume.pdf"
+        ],
+        "clicks": 15,
+        "impressions": 464,
+        "ctr": 0.032327586206896554,
+        "position": 39.797413793103445
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/authorize-net-for-react-native-expo-sdk-49"
+        ],
+        "clicks": 15,
+        "impressions": 885,
+        "ctr": 0.01694915254237288,
+        "position": 11.483615819209039
+      },
+      {
+        "keys": [
+          "https://coffey.codes/"
+        ],
+        "clicks": 4,
+        "impressions": 311,
+        "ctr": 0.012861736334405145,
+        "position": 13.855305466237942
+      },
+      {
+        "keys": [
+          "https://coffey.codes/contact"
+        ],
+        "clicks": 4,
+        "impressions": 223,
+        "ctr": 0.017937219730941704,
+        "position": 26.30493273542601
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/setting-up-ci-cd-for-firebase-functions-using-github-actions"
+        ],
+        "clicks": 3,
+        "impressions": 594,
+        "ctr": 0.005050505050505051,
+        "position": 12.065656565656566
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/how-to-end-a-process-by-port-number"
+        ],
+        "clicks": 2,
+        "impressions": 706,
+        "ctr": 0.0028328611898017,
+        "position": 19.879603399433428
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/step-by-step-building-your-blog-with-next-js-and-mdx"
+        ],
+        "clicks": 1,
+        "impressions": 633,
+        "ctr": 0.001579778830963665,
+        "position": 17.50394944707741
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/tag/unit%20testing?"
+        ],
+        "clicks": 1,
+        "impressions": 9,
+        "ctr": 0.1111111111111111,
+        "position": 6.333333333333333
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles"
+        ],
+        "clicks": 0,
+        "impressions": 97,
+        "ctr": 0,
+        "position": 8.391752577319588
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/avoiding-unnecessary-re-renders-in-react-apps"
+        ],
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 9
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/building-an-mdx-powered-blog-using-app-router-next-js"
+        ],
+        "clicks": 0,
+        "impressions": 259,
+        "ctr": 0,
+        "position": 24.72200772200772
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/building-interactive-3d-experiences-with-react-three-fiber"
+        ],
+        "clicks": 0,
+        "impressions": 27,
+        "ctr": 0,
+        "position": 11.037037037037036
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/categories"
+        ],
+        "clicks": 0,
+        "impressions": 4,
+        "ctr": 0,
+        "position": 5
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/category/development"
+        ],
+        "clicks": 0,
+        "impressions": 2,
+        "ctr": 0,
+        "position": 10
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/category/web%20development"
+        ],
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 5
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/how-to-deploy-a-flask-rest-api-on-google-cloud-run"
+        ],
+        "clicks": 0,
+        "impressions": 13,
+        "ctr": 0,
+        "position": 6.153846153846154
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/preventing-unnecessary-re-renders-in-react-apps"
+        ],
+        "clicks": 0,
+        "impressions": 3,
+        "ctr": 0,
+        "position": 36.333333333333336
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/react-19-features-and-design-patterns#actions-api"
+        ],
+        "clicks": 0,
+        "impressions": 715,
+        "ctr": 0,
+        "position": 6.027972027972028
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/react-19-features-and-design-patterns#document-metadata"
+        ],
+        "clicks": 0,
+        "impressions": 17,
+        "ctr": 0,
+        "position": 4.764705882352941
+      },
+      {
+        "keys": [
+          "https://coffey.codes/articles/react-19-features-and-design-patterns#enhanced-server-components"
+        ],
+        "clicks": 0,
+        "impressions": 183,
+        "ctr": 0,
+        "position": 6.4316939890710385
+      }
+    ],
+    "topQueries": [
+      {
+        "keys": [
+          "flutter vibe coding"
+        ],
+        "clicks": 49,
+        "impressions": 1075,
+        "ctr": 0.045581395348837206,
+        "position": 8.377674418604652
+      },
+      {
+        "keys": [
+          "expo location"
+        ],
+        "clicks": 24,
+        "impressions": 9656,
+        "ctr": 0.0024855012427506215,
+        "position": 7.731048053024026
+      },
+      {
+        "keys": [
+          "vibe coding flutter"
+        ],
+        "clicks": 24,
+        "impressions": 648,
+        "ctr": 0.037037037037037035,
+        "position": 8.26388888888889
+      },
+      {
+        "keys": [
+          "vibe coding flutter app"
+        ],
+        "clicks": 15,
+        "impressions": 218,
+        "ctr": 0.06880733944954129,
+        "position": 7.389908256880734
+      },
+      {
+        "keys": [
+          "expo-location"
+        ],
+        "clicks": 10,
+        "impressions": 5285,
+        "ctr": 0.001892147587511826,
+        "position": 6.601135288552507
+      },
+      {
+        "keys": [
+          "vibe code flutter app"
+        ],
+        "clicks": 9,
+        "impressions": 157,
+        "ctr": 0.05732484076433121,
+        "position": 7.547770700636943
+      },
+      {
+        "keys": [
+          "expo geofencing"
+        ],
+        "clicks": 7,
+        "impressions": 216,
+        "ctr": 0.032407407407407406,
+        "position": 7.583333333333333
+      },
+      {
+        "keys": [
+          "firebase apphosting:secrets:grantaccess"
+        ],
+        "clicks": 7,
+        "impressions": 386,
+        "ctr": 0.018134715025906734,
+        "position": 6.160621761658031
+      },
+      {
+        "keys": [
+          "firebase apphosting:secrets:set"
+        ],
+        "clicks": 6,
+        "impressions": 192,
+        "ctr": 0.03125,
+        "position": 5.447916666666667
+      },
+      {
+        "keys": [
+          "vibe code flutter"
+        ],
+        "clicks": 6,
+        "impressions": 144,
+        "ctr": 0.041666666666666664,
+        "position": 8.208333333333332
+      },
+      {
+        "keys": [
+          "expo location accuracy"
+        ],
+        "clicks": 5,
+        "impressions": 132,
+        "ctr": 0.03787878787878788,
+        "position": 5.613636363636363
+      },
+      {
+        "keys": [
+          "flutter vibe code"
+        ],
+        "clicks": 4,
+        "impressions": 53,
+        "ctr": 0.07547169811320754,
+        "position": 7.471698113207547
+      },
+      {
+        "keys": [
+          "expo geolocation"
+        ],
+        "clicks": 3,
+        "impressions": 494,
+        "ctr": 0.006072874493927126,
+        "position": 6.923076923076923
+      },
+      {
+        "keys": [
+          "expo location example"
+        ],
+        "clicks": 3,
+        "impressions": 47,
+        "ctr": 0.06382978723404255,
+        "position": 8.51063829787234
+      },
+      {
+        "keys": [
+          "react native expo location"
+        ],
+        "clicks": 3,
+        "impressions": 228,
+        "ctr": 0.013157894736842105,
+        "position": 5.06140350877193
+      },
+      {
+        "keys": [
+          "requestforegroundpermissionsasync"
+        ],
+        "clicks": 3,
+        "impressions": 224,
+        "ctr": 0.013392857142857142,
+        "position": 7.825892857142857
+      },
+      {
+        "keys": [
+          "android emulator slow"
+        ],
+        "clicks": 2,
+        "impressions": 387,
+        "ctr": 0.00516795865633075,
+        "position": 7.390180878552972
+      },
+      {
+        "keys": [
+          "apphosting.yaml"
+        ],
+        "clicks": 2,
+        "impressions": 448,
+        "ctr": 0.004464285714285714,
+        "position": 8.453125
+      },
+      {
+        "keys": [
+          "expo gps"
+        ],
+        "clicks": 2,
+        "impressions": 258,
+        "ctr": 0.007751937984496124,
+        "position": 7.608527131782946
+      },
+      {
+        "keys": [
+          "expo location api"
+        ],
+        "clicks": 2,
+        "impressions": 237,
+        "ctr": 0.008438818565400843,
+        "position": 5.0042194092827
+      },
+      {
+        "keys": [
+          "expo location permission"
+        ],
+        "clicks": 2,
+        "impressions": 56,
+        "ctr": 0.03571428571428571,
+        "position": 8.660714285714285
+      },
+      {
+        "keys": [
+          "expo location tracking"
+        ],
+        "clicks": 2,
+        "impressions": 33,
+        "ctr": 0.06060606060606061,
+        "position": 6.363636363636363
+      },
+      {
+        "keys": [
+          "firebase app hosting secrets"
+        ],
+        "clicks": 2,
+        "impressions": 204,
+        "ctr": 0.00980392156862745,
+        "position": 6.519607843137255
+      },
+      {
+        "keys": [
+          "flutter vibe coding platform"
+        ],
+        "clicks": 2,
+        "impressions": 31,
+        "ctr": 0.06451612903225806,
+        "position": 8.032258064516128
+      },
+      {
+        "keys": [
+          "location.watchpositionasync"
+        ],
+        "clicks": 2,
+        "impressions": 63,
+        "ctr": 0.031746031746031744,
+        "position": 6.666666666666667
+      },
+      {
+        "keys": [
+          "react 19 best practices"
+        ],
+        "clicks": 2,
+        "impressions": 71,
+        "ctr": 0.028169014084507043,
+        "position": 9.647887323943662
+      },
+      {
+        "keys": [
+          "vibe coding for flutter"
+        ],
+        "clicks": 2,
+        "impressions": 57,
+        "ctr": 0.03508771929824561,
+        "position": 8.491228070175438
+      },
+      {
+        "keys": [
+          "why android emulator is slow"
+        ],
+        "clicks": 2,
+        "impressions": 84,
+        "ctr": 0.023809523809523808,
+        "position": 4.666666666666666
+      },
+      {
+        "keys": [
+          "android emulator very slow"
+        ],
+        "clicks": 1,
+        "impressions": 135,
+        "ctr": 0.007407407407407408,
+        "position": 6.762962962962963
+      },
+      {
+        "keys": [
+          "apphosting.yaml firebase"
+        ],
+        "clicks": 1,
+        "impressions": 88,
+        "ctr": 0.011363636363636364,
+        "position": 8.420454545454547
+      },
+      {
+        "keys": [
+          "expo background location tracking"
+        ],
+        "clicks": 1,
+        "impressions": 105,
+        "ctr": 0.009523809523809525,
+        "position": 7.6761904761904765
+      },
+      {
+        "keys": [
+          "expo location documentation"
+        ],
+        "clicks": 1,
+        "impressions": 304,
+        "ctr": 0.003289473684210526,
+        "position": 5.384868421052632
+      },
+      {
+        "keys": [
+          "expo location geofencing"
+        ],
+        "clicks": 1,
+        "impressions": 61,
+        "ctr": 0.01639344262295082,
+        "position": 4.557377049180328
+      },
+      {
+        "keys": [
+          "expo location permissions"
+        ],
+        "clicks": 1,
+        "impressions": 209,
+        "ctr": 0.004784688995215311,
+        "position": 6.574162679425838
+      },
+      {
+        "keys": [
+          "expo location react native"
+        ],
+        "clicks": 1,
+        "impressions": 223,
+        "ctr": 0.004484304932735426,
+        "position": 5.20627802690583
+      },
+      {
+        "keys": [
+          "expo location services"
+        ],
+        "clicks": 1,
+        "impressions": 78,
+        "ctr": 0.01282051282051282,
+        "position": 4.589743589743589
+      },
+      {
+        "keys": [
+          "expo-location documentation"
+        ],
+        "clicks": 1,
+        "impressions": 339,
+        "ctr": 0.0029498525073746312,
+        "position": 4.775811209439528
+      },
+      {
+        "keys": [
+          "firebase app hosting environment variables"
+        ],
+        "clicks": 1,
+        "impressions": 211,
+        "ctr": 0.004739336492890996,
+        "position": 9.189573459715639
+      },
+      {
+        "keys": [
+          "location expo"
+        ],
+        "clicks": 1,
+        "impressions": 166,
+        "ctr": 0.006024096385542169,
+        "position": 8.650602409638555
+      },
+      {
+        "keys": [
+          "location.getcurrentpositionasync"
+        ],
+        "clicks": 1,
+        "impressions": 15,
+        "ctr": 0.06666666666666667,
+        "position": 9.133333333333333
+      },
+      {
+        "keys": [
+          "next_public_firebase_api_key"
+        ],
+        "clicks": 1,
+        "impressions": 345,
+        "ctr": 0.002898550724637681,
+        "position": 9.30144927536232
+      },
+      {
+        "keys": [
+          "react 19 design patterns and best practices"
+        ],
+        "clicks": 1,
+        "impressions": 13,
+        "ctr": 0.07692307692307693,
+        "position": 4.3076923076923075
+      },
+      {
+        "keys": [
+          "react 19 partial hydration"
+        ],
+        "clicks": 1,
+        "impressions": 82,
+        "ctr": 0.012195121951219513,
+        "position": 7.426829268292683
+      },
+      {
+        "keys": [
+          "vibe coding with flutter"
+        ],
+        "clicks": 1,
+        "impressions": 84,
+        "ctr": 0.011904761904761904,
+        "position": 7.928571428571429
+      },
+      {
+        "keys": [
+          "why is android emulator so slow"
+        ],
+        "clicks": 1,
+        "impressions": 112,
+        "ctr": 0.008928571428571428,
+        "position": 4.714285714285714
+      },
+      {
+        "keys": [
+          "\"$.location.coords\" audit logs geofence"
+        ],
+        "clicks": 0,
+        "impressions": 10,
+        "ctr": 0,
+        "position": 8.2
+      },
+      {
+        "keys": [
+          "\"$.location.coords\" geofence"
+        ],
+        "clicks": 0,
+        "impressions": 3,
+        "ctr": 0,
+        "position": 8
+      },
+      {
+        "keys": [
+          "\"$.location.coords\" jsonpath example"
+        ],
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 10
+      },
+      {
+        "keys": [
+          "\"a react element from an older version of react was rendered\""
+        ],
+        "clicks": 0,
+        "impressions": 12,
+        "ctr": 0,
+        "position": 10.083333333333334
+      },
+      {
+        "keys": [
+          "\"adb emu geo fix\""
+        ],
+        "clicks": 0,
+        "impressions": 2,
+        "ctr": 0,
+        "position": 4
+      }
+    ],
+    "countries": [
+      {
+        "keys": [
+          "usa"
+        ],
+        "clicks": 183,
+        "impressions": 169819,
+        "ctr": 0.0010776179343889671,
+        "position": 6.877887633303694
+      },
+      {
+        "keys": [
+          "ind"
+        ],
+        "clicks": 85,
+        "impressions": 11741,
+        "ctr": 0.007239587769355251,
+        "position": 7.095988416659569
+      },
+      {
+        "keys": [
+          "deu"
+        ],
+        "clicks": 71,
+        "impressions": 4946,
+        "ctr": 0.014355034371209057,
+        "position": 6.6164577436312175
+      },
+      {
+        "keys": [
+          "gbr"
+        ],
+        "clicks": 47,
+        "impressions": 11724,
+        "ctr": 0.004008870692596383,
+        "position": 5.817809621289662
+      },
+      {
+        "keys": [
+          "fra"
+        ],
+        "clicks": 43,
+        "impressions": 4060,
+        "ctr": 0.010591133004926109,
+        "position": 7.396305418719212
+      },
+      {
+        "keys": [
+          "can"
+        ],
+        "clicks": 35,
+        "impressions": 6793,
+        "ctr": 0.005152362726335934,
+        "position": 7.253201825408508
+      },
+      {
+        "keys": [
+          "esp"
+        ],
+        "clicks": 35,
+        "impressions": 3249,
+        "ctr": 0.01077254539858418,
+        "position": 7.243767313019391
+      },
+      {
+        "keys": [
+          "bel"
+        ],
+        "clicks": 30,
+        "impressions": 1048,
+        "ctr": 0.02862595419847328,
+        "position": 6.430343511450381
+      },
+      {
+        "keys": [
+          "ita"
+        ],
+        "clicks": 27,
+        "impressions": 2662,
+        "ctr": 0.0101427498121713,
+        "position": 7.858377160030052
+      },
+      {
+        "keys": [
+          "idn"
+        ],
+        "clicks": 26,
+        "impressions": 2984,
+        "ctr": 0.00871313672922252,
+        "position": 6.360254691689008
+      },
+      {
+        "keys": [
+          "nld"
+        ],
+        "clicks": 24,
+        "impressions": 2309,
+        "ctr": 0.01039411000433088,
+        "position": 6.733650931139021
+      },
+      {
+        "keys": [
+          "bra"
+        ],
+        "clicks": 22,
+        "impressions": 6753,
+        "ctr": 0.003257811343106767,
+        "position": 7.03731674811195
+      },
+      {
+        "keys": [
+          "aus"
+        ],
+        "clicks": 21,
+        "impressions": 2783,
+        "ctr": 0.007545813869924541,
+        "position": 7.1875673733381245
+      },
+      {
+        "keys": [
+          "swe"
+        ],
+        "clicks": 21,
+        "impressions": 1483,
+        "ctr": 0.014160485502360081,
+        "position": 6.712070128118678
+      },
+      {
+        "keys": [
+          "kor"
+        ],
+        "clicks": 19,
+        "impressions": 2273,
+        "ctr": 0.008358996920369555,
+        "position": 7.65068191816982
+      }
+    ],
+    "devices": [
+      {
+        "keys": [
+          "DESKTOP"
+        ],
+        "clicks": 910,
+        "impressions": 261510,
+        "ctr": 0.0034797904477840234,
+        "position": 7.1920461932622075
+      },
+      {
+        "keys": [
+          "MOBILE"
+        ],
+        "clicks": 233,
+        "impressions": 27682,
+        "ctr": 0.00841702189148183,
+        "position": 4.780326565999566
+      },
+      {
+        "keys": [
+          "TABLET"
+        ],
+        "clicks": 6,
+        "impressions": 4398,
+        "ctr": 0.001364256480218281,
+        "position": 6.655070486584811
+      }
+    ]
+  },
+  "ga4": {
+    "window": {
+      "startDate": "2025-05-07",
+      "endDate": "2026-05-07",
+      "days": 365
+    },
+    "propertyId": "416080229",
+    "botRegionsExcluded": [
+      "China",
+      "Singapore"
+    ],
+    "trafficSources": {
+      "dimensionHeaders": [
+        {
+          "name": "sessionDefaultChannelGroup"
+        },
+        {
+          "name": "sessionSource"
+        },
+        {
+          "name": "sessionMedium"
+        }
+      ],
+      "metricHeaders": [
+        {
+          "name": "sessions",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "conversions",
+          "type": "TYPE_FLOAT"
+        }
+      ],
+      "rows": [
+        {
+          "dimensionValues": [
+            {
+              "value": "Direct",
+              "oneValue": "value"
+            },
+            {
+              "value": "(direct)",
+              "oneValue": "value"
+            },
+            {
+              "value": "(none)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "6084",
+              "oneValue": "value"
+            },
+            {
+              "value": "62",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "google",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "1544",
+              "oneValue": "value"
+            },
+            {
+              "value": "7",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "bing",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "240",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Unassigned",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "111",
+              "oneValue": "value"
+            },
+            {
+              "value": "5",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "duckduckgo",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "110",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "chatgpt.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "62",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Social",
+              "oneValue": "value"
+            },
+            {
+              "value": "m.facebook.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "31",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "github.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "27",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Social",
+              "oneValue": "value"
+            },
+            {
+              "value": "facebook.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "25",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "vercel.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "24",
+              "oneValue": "value"
+            },
+            {
+              "value": "3",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "in.search.yahoo.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "12",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "gemini.google.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "12",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "perplexity.ai",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "11",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Unassigned",
+              "oneValue": "value"
+            },
+            {
+              "value": "chatgpt.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "11",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "yahoo",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "10",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        }
+      ]
+    },
+    "organicLandingPages": {
+      "dimensionHeaders": [
+        {
+          "name": "landingPagePlusQueryString"
+        }
+      ],
+      "metricHeaders": [
+        {
+          "name": "sessions",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "bounceRate",
+          "type": "TYPE_FLOAT"
+        },
+        {
+          "name": "conversions",
+          "type": "TYPE_FLOAT"
+        },
+        {
+          "name": "engagementRate",
+          "type": "TYPE_FLOAT"
+        },
+        {
+          "name": "averageSessionDuration",
+          "type": "TYPE_SECONDS"
+        }
+      ],
+      "rows": [
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/building-location-based-features-using-expo-location",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "461",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.39045553145336226",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.6095444685466378",
+              "oneValue": "value"
+            },
+            {
+              "value": "185.37360236442515",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/vibe-coding-building-an-app-entirely-with-ai-prompts",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "422",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.36966824644549762",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.63033175355450233",
+              "oneValue": "value"
+            },
+            {
+              "value": "127.52180770853082",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "335",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.9850746268656716",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.014925373134328358",
+              "oneValue": "value"
+            },
+            {
+              "value": "4.422159095522388",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/slow-android-emulator-flutter-dev",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "242",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.49586776859504134",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.50413223140495866",
+              "oneValue": "value"
+            },
+            {
+              "value": "188.29133713636364",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/managing-secrets-firebase-apphosting-yaml-nextjs",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "221",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.36199095022624433",
+              "oneValue": "value"
+            },
+            {
+              "value": "2",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.63800904977375561",
+              "oneValue": "value"
+            },
+            {
+              "value": "237.69706467420812",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/react-19-features-and-design-patterns",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "76",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.53947368421052633",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.46052631578947367",
+              "oneValue": "value"
+            },
+            {
+              "value": "159.01837968421052",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/how-to-see-when-a-file-was-deleted-or-changed-with-git-log",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "49",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.51020408163265307",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.48979591836734693",
+              "oneValue": "value"
+            },
+            {
+              "value": "177.9064298367347",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "28",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.21428571428571427",
+              "oneValue": "value"
+            },
+            {
+              "value": "4",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.7857142857142857",
+              "oneValue": "value"
+            },
+            {
+              "value": "228.43832785714287",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/preventing-unnecessary-re-renders-in-react-apps",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "25",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.52",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.48",
+              "oneValue": "value"
+            },
+            {
+              "value": "175.66383539999998",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/authorize-net-for-react-native-expo-sdk-49",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "18",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.5",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.5",
+              "oneValue": "value"
+            },
+            {
+              "value": "64.892102888888886",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/setting-up-ci-cd-for-firebase-functions-using-github-actions",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "17",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.29411764705882354",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.70588235294117652",
+              "oneValue": "value"
+            },
+            {
+              "value": "64.067072058823541",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/building-interactive-3d-experiences-with-react-three-fiber",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "9",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.22222222222222221",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.77777777777777779",
+              "oneValue": "value"
+            },
+            {
+              "value": "139.87847633333334",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/contact",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "7",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.14285714285714285",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.8571428571428571",
+              "oneValue": "value"
+            },
+            {
+              "value": "270.49053214285715",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/how-to-end-a-process-by-port-number",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "6",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.5",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.5",
+              "oneValue": "value"
+            },
+            {
+              "value": "362.753571",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "/articles/micro-frontends-architecture-benefits-challenges-best-practices",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "4",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.75",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            },
+            {
+              "value": "0.25",
+              "oneValue": "value"
+            },
+            {
+              "value": "37.08032775",
+              "oneValue": "value"
+            }
+          ]
+        }
+      ]
+    },
+    "userBehavior": {
+      "devices": {
+        "dimensionHeaders": [
+          {
+            "name": "deviceCategory"
+          }
+        ],
+        "metricHeaders": [
+          {
+            "name": "activeUsers",
+            "type": "TYPE_INTEGER"
+          },
+          {
+            "name": "sessions",
+            "type": "TYPE_INTEGER"
+          },
+          {
+            "name": "engagementRate",
+            "type": "TYPE_FLOAT"
+          }
+        ],
+        "rows": [
+          {
+            "dimensionValues": [
+              {
+                "value": "desktop",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "6812",
+                "oneValue": "value"
+              },
+              {
+                "value": "7805",
+                "oneValue": "value"
+              },
+              {
+                "value": "0.19359385009609226",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "mobile",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "499",
+                "oneValue": "value"
+              },
+              {
+                "value": "593",
+                "oneValue": "value"
+              },
+              {
+                "value": "0.44688026981450252",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "tablet",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "7",
+                "oneValue": "value"
+              },
+              {
+                "value": "9",
+                "oneValue": "value"
+              },
+              {
+                "value": "0.44444444444444442",
+                "oneValue": "value"
+              }
+            ]
+          }
+        ]
+      },
+      "countries": {
+        "dimensionHeaders": [
+          {
+            "name": "country"
+          }
+        ],
+        "metricHeaders": [
+          {
+            "name": "activeUsers",
+            "type": "TYPE_INTEGER"
+          },
+          {
+            "name": "sessions",
+            "type": "TYPE_INTEGER"
+          }
+        ],
+        "rows": [
+          {
+            "dimensionValues": [
+              {
+                "value": "United States",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "4279",
+                "oneValue": "value"
+              },
+              {
+                "value": "4637",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "China",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "957",
+                "oneValue": "value"
+              },
+              {
+                "value": "965",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Singapore",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "743",
+                "oneValue": "value"
+              },
+              {
+                "value": "744",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "India",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "165",
+                "oneValue": "value"
+              },
+              {
+                "value": "257",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Germany",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "150",
+                "oneValue": "value"
+              },
+              {
+                "value": "184",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "France",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "72",
+                "oneValue": "value"
+              },
+              {
+                "value": "100",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "United Kingdom",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "68",
+                "oneValue": "value"
+              },
+              {
+                "value": "93",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "(not set)",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "60",
+                "oneValue": "value"
+              },
+              {
+                "value": "60",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Canada",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "56",
+                "oneValue": "value"
+              },
+              {
+                "value": "74",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Netherlands",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "50",
+                "oneValue": "value"
+              },
+              {
+                "value": "61",
+                "oneValue": "value"
+              }
+            ]
+          }
+        ]
+      },
+      "engagement": {
+        "dimensionHeaders": [],
+        "metricHeaders": [
+          {
+            "name": "averageSessionDuration",
+            "type": "TYPE_SECONDS"
+          },
+          {
+            "name": "engagementRate",
+            "type": "TYPE_FLOAT"
+          }
+        ],
+        "rows": [
+          {
+            "dimensionValues": [],
+            "metricValues": [
+              {
+                "value": "62.909885892674211",
+                "oneValue": "value"
+              },
+              {
+                "value": "0.21191185229303156",
+                "oneValue": "value"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "trafficSourcesExBotRegions": {
+      "dimensionHeaders": [
+        {
+          "name": "sessionDefaultChannelGroup"
+        },
+        {
+          "name": "sessionSource"
+        },
+        {
+          "name": "sessionMedium"
+        }
+      ],
+      "metricHeaders": [
+        {
+          "name": "sessions",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "conversions",
+          "type": "TYPE_FLOAT"
+        }
+      ],
+      "rows": [
+        {
+          "dimensionValues": [
+            {
+              "value": "Direct",
+              "oneValue": "value"
+            },
+            {
+              "value": "(direct)",
+              "oneValue": "value"
+            },
+            {
+              "value": "(none)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "4569",
+              "oneValue": "value"
+            },
+            {
+              "value": "60",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "google",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "1524",
+              "oneValue": "value"
+            },
+            {
+              "value": "6",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "bing",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "233",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "duckduckgo",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "110",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "chatgpt.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "62",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Unassigned",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "56",
+              "oneValue": "value"
+            },
+            {
+              "value": "5",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Social",
+              "oneValue": "value"
+            },
+            {
+              "value": "m.facebook.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "31",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "github.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "27",
+              "oneValue": "value"
+            },
+            {
+              "value": "1",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Social",
+              "oneValue": "value"
+            },
+            {
+              "value": "facebook.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "25",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "vercel.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "24",
+              "oneValue": "value"
+            },
+            {
+              "value": "3",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "in.search.yahoo.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "12",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "gemini.google.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "12",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Referral",
+              "oneValue": "value"
+            },
+            {
+              "value": "perplexity.ai",
+              "oneValue": "value"
+            },
+            {
+              "value": "referral",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "11",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Organic Search",
+              "oneValue": "value"
+            },
+            {
+              "value": "yahoo",
+              "oneValue": "value"
+            },
+            {
+              "value": "organic",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "10",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "Unassigned",
+              "oneValue": "value"
+            },
+            {
+              "value": "chatgpt.com",
+              "oneValue": "value"
+            },
+            {
+              "value": "(not set)",
+              "oneValue": "value"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "10",
+              "oneValue": "value"
+            },
+            {
+              "value": "0",
+              "oneValue": "value"
+            }
+          ]
+        }
+      ]
+    },
+    "userBehaviorExBotRegions": {
+      "countries": {
+        "dimensionHeaders": [
+          {
+            "name": "country"
+          }
+        ],
+        "metricHeaders": [
+          {
+            "name": "activeUsers",
+            "type": "TYPE_INTEGER"
+          },
+          {
+            "name": "sessions",
+            "type": "TYPE_INTEGER"
+          }
+        ],
+        "rows": [
+          {
+            "dimensionValues": [
+              {
+                "value": "United States",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "4279",
+                "oneValue": "value"
+              },
+              {
+                "value": "4637",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "India",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "165",
+                "oneValue": "value"
+              },
+              {
+                "value": "257",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Germany",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "150",
+                "oneValue": "value"
+              },
+              {
+                "value": "184",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "France",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "72",
+                "oneValue": "value"
+              },
+              {
+                "value": "100",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "United Kingdom",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "68",
+                "oneValue": "value"
+              },
+              {
+                "value": "93",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "(not set)",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "60",
+                "oneValue": "value"
+              },
+              {
+                "value": "60",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Canada",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "56",
+                "oneValue": "value"
+              },
+              {
+                "value": "74",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Netherlands",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "50",
+                "oneValue": "value"
+              },
+              {
+                "value": "61",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Brazil",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "48",
+                "oneValue": "value"
+              },
+              {
+                "value": "68",
+                "oneValue": "value"
+              }
+            ]
+          },
+          {
+            "dimensionValues": [
+              {
+                "value": "Indonesia",
+                "oneValue": "value"
+              }
+            ],
+            "metricValues": [
+              {
+                "value": "45",
+                "oneValue": "value"
+              },
+              {
+                "value": "59",
+                "oneValue": "value"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "bing": {
+    "window": {
+      "startDate": "2025-05-07",
+      "endDate": "2026-05-07",
+      "days": 365
+    },
+    "siteUrl": "https://coffey.codes/",
+    "totals": {
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0
+    },
+    "trafficStats": [],
+    "topQueries": [],
+    "_note": "empty response"
+  },
+  "totals": {
+    "clicks": 1149,
+    "impressions": 293590,
+    "ctr": 0.003913621036138833
+  },
+  "topPages": [
+    {
+      "keys": [
+        "https://coffey.codes/articles/building-location-based-features-using-expo-location"
+      ],
+      "clicks": 388,
+      "impressions": 150793,
+      "ctr": 0.002573063736380336,
+      "position": 6.754783046958413
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/vibe-coding-building-an-app-entirely-with-ai-prompts"
+      ],
+      "clicks": 248,
+      "impressions": 9038,
+      "ctr": 0.02743969904846205,
+      "position": 8.468245186988272
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/slow-android-emulator-flutter-dev"
+      ],
+      "clicks": 236,
+      "impressions": 71150,
+      "ctr": 0.0033169360505973296,
+      "position": 5.845158116654955
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/managing-secrets-firebase-apphosting-yaml-nextjs"
+      ],
+      "clicks": 180,
+      "impressions": 43486,
+      "ctr": 0.004139263211148415,
+      "position": 7.463206549234236
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/react-19-features-and-design-patterns"
+      ],
+      "clicks": 52,
+      "impressions": 15131,
+      "ctr": 0.0034366532284713504,
+      "position": 8.612451259004693
+    },
+    {
+      "keys": [
+        "https://coffey.codes/Anthony%20Coffey%20-%20Resume.pdf"
+      ],
+      "clicks": 15,
+      "impressions": 464,
+      "ctr": 0.032327586206896554,
+      "position": 39.797413793103445
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/authorize-net-for-react-native-expo-sdk-49"
+      ],
+      "clicks": 15,
+      "impressions": 885,
+      "ctr": 0.01694915254237288,
+      "position": 11.483615819209039
+    },
+    {
+      "keys": [
+        "https://coffey.codes/"
+      ],
+      "clicks": 4,
+      "impressions": 311,
+      "ctr": 0.012861736334405145,
+      "position": 13.855305466237942
+    },
+    {
+      "keys": [
+        "https://coffey.codes/contact"
+      ],
+      "clicks": 4,
+      "impressions": 223,
+      "ctr": 0.017937219730941704,
+      "position": 26.30493273542601
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/setting-up-ci-cd-for-firebase-functions-using-github-actions"
+      ],
+      "clicks": 3,
+      "impressions": 594,
+      "ctr": 0.005050505050505051,
+      "position": 12.065656565656566
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/how-to-end-a-process-by-port-number"
+      ],
+      "clicks": 2,
+      "impressions": 706,
+      "ctr": 0.0028328611898017,
+      "position": 19.879603399433428
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/step-by-step-building-your-blog-with-next-js-and-mdx"
+      ],
+      "clicks": 1,
+      "impressions": 633,
+      "ctr": 0.001579778830963665,
+      "position": 17.50394944707741
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/tag/unit%20testing?"
+      ],
+      "clicks": 1,
+      "impressions": 9,
+      "ctr": 0.1111111111111111,
+      "position": 6.333333333333333
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles"
+      ],
+      "clicks": 0,
+      "impressions": 97,
+      "ctr": 0,
+      "position": 8.391752577319588
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/avoiding-unnecessary-re-renders-in-react-apps"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/building-an-mdx-powered-blog-using-app-router-next-js"
+      ],
+      "clicks": 0,
+      "impressions": 259,
+      "ctr": 0,
+      "position": 24.72200772200772
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/building-interactive-3d-experiences-with-react-three-fiber"
+      ],
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 11.037037037037036
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/categories"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/category/development"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/category/web%20development"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/how-to-deploy-a-flask-rest-api-on-google-cloud-run"
+      ],
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 6.153846153846154
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/preventing-unnecessary-re-renders-in-react-apps"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 36.333333333333336
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/react-19-features-and-design-patterns#actions-api"
+      ],
+      "clicks": 0,
+      "impressions": 715,
+      "ctr": 0,
+      "position": 6.027972027972028
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/react-19-features-and-design-patterns#document-metadata"
+      ],
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 4.764705882352941
+    },
+    {
+      "keys": [
+        "https://coffey.codes/articles/react-19-features-and-design-patterns#enhanced-server-components"
+      ],
+      "clicks": 0,
+      "impressions": 183,
+      "ctr": 0,
+      "position": 6.4316939890710385
+    }
+  ],
+  "topQueries": [
+    {
+      "keys": [
+        "flutter vibe coding"
+      ],
+      "clicks": 49,
+      "impressions": 1075,
+      "ctr": 0.045581395348837206,
+      "position": 8.377674418604652
+    },
+    {
+      "keys": [
+        "expo location"
+      ],
+      "clicks": 24,
+      "impressions": 9656,
+      "ctr": 0.0024855012427506215,
+      "position": 7.731048053024026
+    },
+    {
+      "keys": [
+        "vibe coding flutter"
+      ],
+      "clicks": 24,
+      "impressions": 648,
+      "ctr": 0.037037037037037035,
+      "position": 8.26388888888889
+    },
+    {
+      "keys": [
+        "vibe coding flutter app"
+      ],
+      "clicks": 15,
+      "impressions": 218,
+      "ctr": 0.06880733944954129,
+      "position": 7.389908256880734
+    },
+    {
+      "keys": [
+        "expo-location"
+      ],
+      "clicks": 10,
+      "impressions": 5285,
+      "ctr": 0.001892147587511826,
+      "position": 6.601135288552507
+    },
+    {
+      "keys": [
+        "vibe code flutter app"
+      ],
+      "clicks": 9,
+      "impressions": 157,
+      "ctr": 0.05732484076433121,
+      "position": 7.547770700636943
+    },
+    {
+      "keys": [
+        "expo geofencing"
+      ],
+      "clicks": 7,
+      "impressions": 216,
+      "ctr": 0.032407407407407406,
+      "position": 7.583333333333333
+    },
+    {
+      "keys": [
+        "firebase apphosting:secrets:grantaccess"
+      ],
+      "clicks": 7,
+      "impressions": 386,
+      "ctr": 0.018134715025906734,
+      "position": 6.160621761658031
+    },
+    {
+      "keys": [
+        "firebase apphosting:secrets:set"
+      ],
+      "clicks": 6,
+      "impressions": 192,
+      "ctr": 0.03125,
+      "position": 5.447916666666667
+    },
+    {
+      "keys": [
+        "vibe code flutter"
+      ],
+      "clicks": 6,
+      "impressions": 144,
+      "ctr": 0.041666666666666664,
+      "position": 8.208333333333332
+    },
+    {
+      "keys": [
+        "expo location accuracy"
+      ],
+      "clicks": 5,
+      "impressions": 132,
+      "ctr": 0.03787878787878788,
+      "position": 5.613636363636363
+    },
+    {
+      "keys": [
+        "flutter vibe code"
+      ],
+      "clicks": 4,
+      "impressions": 53,
+      "ctr": 0.07547169811320754,
+      "position": 7.471698113207547
+    },
+    {
+      "keys": [
+        "expo geolocation"
+      ],
+      "clicks": 3,
+      "impressions": 494,
+      "ctr": 0.006072874493927126,
+      "position": 6.923076923076923
+    },
+    {
+      "keys": [
+        "expo location example"
+      ],
+      "clicks": 3,
+      "impressions": 47,
+      "ctr": 0.06382978723404255,
+      "position": 8.51063829787234
+    },
+    {
+      "keys": [
+        "react native expo location"
+      ],
+      "clicks": 3,
+      "impressions": 228,
+      "ctr": 0.013157894736842105,
+      "position": 5.06140350877193
+    },
+    {
+      "keys": [
+        "requestforegroundpermissionsasync"
+      ],
+      "clicks": 3,
+      "impressions": 224,
+      "ctr": 0.013392857142857142,
+      "position": 7.825892857142857
+    },
+    {
+      "keys": [
+        "android emulator slow"
+      ],
+      "clicks": 2,
+      "impressions": 387,
+      "ctr": 0.00516795865633075,
+      "position": 7.390180878552972
+    },
+    {
+      "keys": [
+        "apphosting.yaml"
+      ],
+      "clicks": 2,
+      "impressions": 448,
+      "ctr": 0.004464285714285714,
+      "position": 8.453125
+    },
+    {
+      "keys": [
+        "expo gps"
+      ],
+      "clicks": 2,
+      "impressions": 258,
+      "ctr": 0.007751937984496124,
+      "position": 7.608527131782946
+    },
+    {
+      "keys": [
+        "expo location api"
+      ],
+      "clicks": 2,
+      "impressions": 237,
+      "ctr": 0.008438818565400843,
+      "position": 5.0042194092827
+    },
+    {
+      "keys": [
+        "expo location permission"
+      ],
+      "clicks": 2,
+      "impressions": 56,
+      "ctr": 0.03571428571428571,
+      "position": 8.660714285714285
+    },
+    {
+      "keys": [
+        "expo location tracking"
+      ],
+      "clicks": 2,
+      "impressions": 33,
+      "ctr": 0.06060606060606061,
+      "position": 6.363636363636363
+    },
+    {
+      "keys": [
+        "firebase app hosting secrets"
+      ],
+      "clicks": 2,
+      "impressions": 204,
+      "ctr": 0.00980392156862745,
+      "position": 6.519607843137255
+    },
+    {
+      "keys": [
+        "flutter vibe coding platform"
+      ],
+      "clicks": 2,
+      "impressions": 31,
+      "ctr": 0.06451612903225806,
+      "position": 8.032258064516128
+    },
+    {
+      "keys": [
+        "location.watchpositionasync"
+      ],
+      "clicks": 2,
+      "impressions": 63,
+      "ctr": 0.031746031746031744,
+      "position": 6.666666666666667
+    },
+    {
+      "keys": [
+        "react 19 best practices"
+      ],
+      "clicks": 2,
+      "impressions": 71,
+      "ctr": 0.028169014084507043,
+      "position": 9.647887323943662
+    },
+    {
+      "keys": [
+        "vibe coding for flutter"
+      ],
+      "clicks": 2,
+      "impressions": 57,
+      "ctr": 0.03508771929824561,
+      "position": 8.491228070175438
+    },
+    {
+      "keys": [
+        "why android emulator is slow"
+      ],
+      "clicks": 2,
+      "impressions": 84,
+      "ctr": 0.023809523809523808,
+      "position": 4.666666666666666
+    },
+    {
+      "keys": [
+        "android emulator very slow"
+      ],
+      "clicks": 1,
+      "impressions": 135,
+      "ctr": 0.007407407407407408,
+      "position": 6.762962962962963
+    },
+    {
+      "keys": [
+        "apphosting.yaml firebase"
+      ],
+      "clicks": 1,
+      "impressions": 88,
+      "ctr": 0.011363636363636364,
+      "position": 8.420454545454547
+    },
+    {
+      "keys": [
+        "expo background location tracking"
+      ],
+      "clicks": 1,
+      "impressions": 105,
+      "ctr": 0.009523809523809525,
+      "position": 7.6761904761904765
+    },
+    {
+      "keys": [
+        "expo location documentation"
+      ],
+      "clicks": 1,
+      "impressions": 304,
+      "ctr": 0.003289473684210526,
+      "position": 5.384868421052632
+    },
+    {
+      "keys": [
+        "expo location geofencing"
+      ],
+      "clicks": 1,
+      "impressions": 61,
+      "ctr": 0.01639344262295082,
+      "position": 4.557377049180328
+    },
+    {
+      "keys": [
+        "expo location permissions"
+      ],
+      "clicks": 1,
+      "impressions": 209,
+      "ctr": 0.004784688995215311,
+      "position": 6.574162679425838
+    },
+    {
+      "keys": [
+        "expo location react native"
+      ],
+      "clicks": 1,
+      "impressions": 223,
+      "ctr": 0.004484304932735426,
+      "position": 5.20627802690583
+    },
+    {
+      "keys": [
+        "expo location services"
+      ],
+      "clicks": 1,
+      "impressions": 78,
+      "ctr": 0.01282051282051282,
+      "position": 4.589743589743589
+    },
+    {
+      "keys": [
+        "expo-location documentation"
+      ],
+      "clicks": 1,
+      "impressions": 339,
+      "ctr": 0.0029498525073746312,
+      "position": 4.775811209439528
+    },
+    {
+      "keys": [
+        "firebase app hosting environment variables"
+      ],
+      "clicks": 1,
+      "impressions": 211,
+      "ctr": 0.004739336492890996,
+      "position": 9.189573459715639
+    },
+    {
+      "keys": [
+        "location expo"
+      ],
+      "clicks": 1,
+      "impressions": 166,
+      "ctr": 0.006024096385542169,
+      "position": 8.650602409638555
+    },
+    {
+      "keys": [
+        "location.getcurrentpositionasync"
+      ],
+      "clicks": 1,
+      "impressions": 15,
+      "ctr": 0.06666666666666667,
+      "position": 9.133333333333333
+    },
+    {
+      "keys": [
+        "next_public_firebase_api_key"
+      ],
+      "clicks": 1,
+      "impressions": 345,
+      "ctr": 0.002898550724637681,
+      "position": 9.30144927536232
+    },
+    {
+      "keys": [
+        "react 19 design patterns and best practices"
+      ],
+      "clicks": 1,
+      "impressions": 13,
+      "ctr": 0.07692307692307693,
+      "position": 4.3076923076923075
+    },
+    {
+      "keys": [
+        "react 19 partial hydration"
+      ],
+      "clicks": 1,
+      "impressions": 82,
+      "ctr": 0.012195121951219513,
+      "position": 7.426829268292683
+    },
+    {
+      "keys": [
+        "vibe coding with flutter"
+      ],
+      "clicks": 1,
+      "impressions": 84,
+      "ctr": 0.011904761904761904,
+      "position": 7.928571428571429
+    },
+    {
+      "keys": [
+        "why is android emulator so slow"
+      ],
+      "clicks": 1,
+      "impressions": 112,
+      "ctr": 0.008928571428571428,
+      "position": 4.714285714285714
+    },
+    {
+      "keys": [
+        "\"$.location.coords\" audit logs geofence"
+      ],
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 8.2
+    },
+    {
+      "keys": [
+        "\"$.location.coords\" geofence"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "\"$.location.coords\" jsonpath example"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "\"a react element from an older version of react was rendered\""
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 10.083333333333334
+    },
+    {
+      "keys": [
+        "\"adb emu geo fix\""
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4
+    }
+  ],
+  "countries": [
+    {
+      "keys": [
+        "usa"
+      ],
+      "clicks": 183,
+      "impressions": 169819,
+      "ctr": 0.0010776179343889671,
+      "position": 6.877887633303694
+    },
+    {
+      "keys": [
+        "ind"
+      ],
+      "clicks": 85,
+      "impressions": 11741,
+      "ctr": 0.007239587769355251,
+      "position": 7.095988416659569
+    },
+    {
+      "keys": [
+        "deu"
+      ],
+      "clicks": 71,
+      "impressions": 4946,
+      "ctr": 0.014355034371209057,
+      "position": 6.6164577436312175
+    },
+    {
+      "keys": [
+        "gbr"
+      ],
+      "clicks": 47,
+      "impressions": 11724,
+      "ctr": 0.004008870692596383,
+      "position": 5.817809621289662
+    },
+    {
+      "keys": [
+        "fra"
+      ],
+      "clicks": 43,
+      "impressions": 4060,
+      "ctr": 0.010591133004926109,
+      "position": 7.396305418719212
+    },
+    {
+      "keys": [
+        "can"
+      ],
+      "clicks": 35,
+      "impressions": 6793,
+      "ctr": 0.005152362726335934,
+      "position": 7.253201825408508
+    },
+    {
+      "keys": [
+        "esp"
+      ],
+      "clicks": 35,
+      "impressions": 3249,
+      "ctr": 0.01077254539858418,
+      "position": 7.243767313019391
+    },
+    {
+      "keys": [
+        "bel"
+      ],
+      "clicks": 30,
+      "impressions": 1048,
+      "ctr": 0.02862595419847328,
+      "position": 6.430343511450381
+    },
+    {
+      "keys": [
+        "ita"
+      ],
+      "clicks": 27,
+      "impressions": 2662,
+      "ctr": 0.0101427498121713,
+      "position": 7.858377160030052
+    },
+    {
+      "keys": [
+        "idn"
+      ],
+      "clicks": 26,
+      "impressions": 2984,
+      "ctr": 0.00871313672922252,
+      "position": 6.360254691689008
+    },
+    {
+      "keys": [
+        "nld"
+      ],
+      "clicks": 24,
+      "impressions": 2309,
+      "ctr": 0.01039411000433088,
+      "position": 6.733650931139021
+    },
+    {
+      "keys": [
+        "bra"
+      ],
+      "clicks": 22,
+      "impressions": 6753,
+      "ctr": 0.003257811343106767,
+      "position": 7.03731674811195
+    },
+    {
+      "keys": [
+        "aus"
+      ],
+      "clicks": 21,
+      "impressions": 2783,
+      "ctr": 0.007545813869924541,
+      "position": 7.1875673733381245
+    },
+    {
+      "keys": [
+        "swe"
+      ],
+      "clicks": 21,
+      "impressions": 1483,
+      "ctr": 0.014160485502360081,
+      "position": 6.712070128118678
+    },
+    {
+      "keys": [
+        "kor"
+      ],
+      "clicks": 19,
+      "impressions": 2273,
+      "ctr": 0.008358996920369555,
+      "position": 7.65068191816982
+    }
+  ],
+  "devices": [
+    {
+      "keys": [
+        "DESKTOP"
+      ],
+      "clicks": 910,
+      "impressions": 261510,
+      "ctr": 0.0034797904477840234,
+      "position": 7.1920461932622075
+    },
+    {
+      "keys": [
+        "MOBILE"
+      ],
+      "clicks": 233,
+      "impressions": 27682,
+      "ctr": 0.00841702189148183,
+      "position": 4.780326565999566
+    },
+    {
+      "keys": [
+        "TABLET"
+      ],
+      "clicks": 6,
+      "impressions": 4398,
+      "ctr": 0.001364256480218281,
+      "position": 6.655070486584811
+    }
+  ]
+}

--- a/docs/strategy/data/snapshot-2026-05-10.md
+++ b/docs/strategy/data/snapshot-2026-05-10.md
@@ -1,0 +1,158 @@
+---
+title: SEO snapshot — 2026-05-11
+tags: [seo, snapshot, gsc, ga4, bing, keywords]
+date: 2026-05-11
+window_start: 2025-05-07
+window_end: 2026-05-07
+---
+
+# SEO snapshot — 2026-05-11
+
+**Window:** 2025-05-07 → 2026-05-07 (365 days)  
+**Site:** `sc-domain:coffey.codes`  
+**Pulled:** 2026-05-11T21:56:09.766Z
+
+## Headline numbers
+
+| Source | Clicks | Impressions | CTR | Sessions |
+|---|---:|---:|---:|---:|
+| Google Search Console | 1,149 | 293,590 | 0.39% | — |
+| Bing Webmaster *(empty response)* | 0 | 0 | 0.00% | — |
+| GA4 (all channels) | — | — | — | 8,314 |
+| GA4 (excluding bot regions: China, Singapore) | — | — | — | 6,716 |
+
+## GSC — top pages
+
+| URL | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| /articles/building-location-based-features-using-expo-location | 388 | 150,793 | 0.26% | 6.8 |
+| /articles/vibe-coding-building-an-app-entirely-with-ai-prompts | 248 | 9,038 | 2.74% | 8.5 |
+| /articles/slow-android-emulator-flutter-dev | 236 | 71,150 | 0.33% | 5.8 |
+| /articles/managing-secrets-firebase-apphosting-yaml-nextjs | 180 | 43,486 | 0.41% | 7.5 |
+| /articles/react-19-features-and-design-patterns | 52 | 15,131 | 0.34% | 8.6 |
+| /Anthony%20Coffey%20-%20Resume.pdf | 15 | 464 | 3.23% | 39.8 |
+| /articles/authorize-net-for-react-native-expo-sdk-49 | 15 | 885 | 1.69% | 11.5 |
+| / | 4 | 311 | 1.29% | 13.9 |
+| /contact | 4 | 223 | 1.79% | 26.3 |
+| /articles/setting-up-ci-cd-for-firebase-functions-using-github-actions | 3 | 594 | 0.51% | 12.1 |
+| /articles/how-to-end-a-process-by-port-number | 2 | 706 | 0.28% | 19.9 |
+| /articles/step-by-step-building-your-blog-with-next-js-and-mdx | 1 | 633 | 0.16% | 17.5 |
+| /articles/tag/unit%20testing? | 1 | 9 | 11.11% | 6.3 |
+| /articles | 0 | 97 | 0.00% | 8.4 |
+| /articles/avoiding-unnecessary-re-renders-in-react-apps | 0 | 1 | 0.00% | 9.0 |
+
+## GSC — top queries
+
+| Query | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| flutter vibe coding | 49 | 1,075 | 4.56% | 8.4 |
+| expo location | 24 | 9,656 | 0.25% | 7.7 |
+| vibe coding flutter | 24 | 648 | 3.70% | 8.3 |
+| vibe coding flutter app | 15 | 218 | 6.88% | 7.4 |
+| expo-location | 10 | 5,285 | 0.19% | 6.6 |
+| vibe code flutter app | 9 | 157 | 5.73% | 7.5 |
+| expo geofencing | 7 | 216 | 3.24% | 7.6 |
+| firebase apphosting:secrets:grantaccess | 7 | 386 | 1.81% | 6.2 |
+| firebase apphosting:secrets:set | 6 | 192 | 3.13% | 5.4 |
+| vibe code flutter | 6 | 144 | 4.17% | 8.2 |
+| expo location accuracy | 5 | 132 | 3.79% | 5.6 |
+| flutter vibe code | 4 | 53 | 7.55% | 7.5 |
+| expo geolocation | 3 | 494 | 0.61% | 6.9 |
+| expo location example | 3 | 47 | 6.38% | 8.5 |
+| react native expo location | 3 | 228 | 1.32% | 5.1 |
+| requestforegroundpermissionsasync | 3 | 224 | 1.34% | 7.8 |
+| android emulator slow | 2 | 387 | 0.52% | 7.4 |
+| apphosting.yaml | 2 | 448 | 0.45% | 8.5 |
+| expo gps | 2 | 258 | 0.78% | 7.6 |
+| expo location api | 2 | 237 | 0.84% | 5.0 |
+| expo location permission | 2 | 56 | 3.57% | 8.7 |
+| expo location tracking | 2 | 33 | 6.06% | 6.4 |
+| firebase app hosting secrets | 2 | 204 | 0.98% | 6.5 |
+| flutter vibe coding platform | 2 | 31 | 6.45% | 8.0 |
+| location.watchpositionasync | 2 | 63 | 3.17% | 6.7 |
+| react 19 best practices | 2 | 71 | 2.82% | 9.6 |
+| vibe coding for flutter | 2 | 57 | 3.51% | 8.5 |
+| why android emulator is slow | 2 | 84 | 2.38% | 4.7 |
+| android emulator very slow | 1 | 135 | 0.74% | 6.8 |
+| apphosting.yaml firebase | 1 | 88 | 1.14% | 8.4 |
+
+## GSC — countries
+
+| Country | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| usa | 183 | 169,819 | 0.11% | 6.9 |
+| ind | 85 | 11,741 | 0.72% | 7.1 |
+| deu | 71 | 4,946 | 1.44% | 6.6 |
+| gbr | 47 | 11,724 | 0.40% | 5.8 |
+| fra | 43 | 4,060 | 1.06% | 7.4 |
+| can | 35 | 6,793 | 0.52% | 7.3 |
+| esp | 35 | 3,249 | 1.08% | 7.2 |
+| bel | 30 | 1,048 | 2.86% | 6.4 |
+| ita | 27 | 2,662 | 1.01% | 7.9 |
+| idn | 26 | 2,984 | 0.87% | 6.4 |
+
+## GSC — devices
+
+| Device | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| DESKTOP | 910 | 261,510 | 0.35% | 7.2 |
+| MOBILE | 233 | 27,682 | 0.84% | 4.8 |
+| TABLET | 6 | 4,398 | 0.14% | 6.7 |
+
+## GA4 — traffic sources
+
+| Channel | Source | Medium | Sessions | Conversions |
+|---|---|---|---:|---:|
+| Direct | (direct) | (none) | 6,084 | 62 |
+| Organic Search | google | organic | 1,544 | 7 |
+| Organic Search | bing | organic | 240 | 0 |
+| Unassigned | (not set) | (not set) | 111 | 5 |
+| Organic Search | duckduckgo | organic | 110 | 1 |
+| Referral | chatgpt.com | referral | 62 | 0 |
+| Organic Social | m.facebook.com | referral | 31 | 1 |
+| Referral | github.com | referral | 27 | 1 |
+| Organic Social | facebook.com | referral | 25 | 0 |
+| Referral | vercel.com | referral | 24 | 3 |
+
+### GA4 — traffic sources (bot regions excluded)
+
+| Channel | Source | Medium | Sessions | Conversions |
+|---|---|---|---:|---:|
+| Direct | (direct) | (none) | 4,569 | 60 |
+| Organic Search | google | organic | 1,524 | 6 |
+| Organic Search | bing | organic | 233 | 0 |
+| Organic Search | duckduckgo | organic | 110 | 1 |
+| Referral | chatgpt.com | referral | 62 | 0 |
+| Unassigned | (not set) | (not set) | 56 | 5 |
+| Organic Social | m.facebook.com | referral | 31 | 1 |
+| Referral | github.com | referral | 27 | 1 |
+| Organic Social | facebook.com | referral | 25 | 0 |
+| Referral | vercel.com | referral | 24 | 3 |
+
+## GA4 — organic landing pages
+
+| Page | Sessions | Bounce | Engaged | Avg dur |
+|---|---:|---:|---:|---:|
+| /articles/building-location-based-features-using-expo-location | 461 | 39.05% | 60.95% | 3m 5s |
+| /articles/vibe-coding-building-an-app-entirely-with-ai-prompts | 422 | 36.97% | 63.03% | 2m 8s |
+| (not set) | 335 | 98.51% | 1.49% | 4s |
+| /articles/slow-android-emulator-flutter-dev | 242 | 49.59% | 50.41% | 3m 8s |
+| /articles/managing-secrets-firebase-apphosting-yaml-nextjs | 221 | 36.20% | 63.80% | 3m 58s |
+| /articles/react-19-features-and-design-patterns | 76 | 53.95% | 46.05% | 2m 39s |
+| /articles/how-to-see-when-a-file-was-deleted-or-changed-with-git-log | 49 | 51.02% | 48.98% | 2m 58s |
+| / | 28 | 21.43% | 78.57% | 3m 48s |
+| /articles/preventing-unnecessary-re-renders-in-react-apps | 25 | 52.00% | 48.00% | 2m 56s |
+| /articles/authorize-net-for-react-native-expo-sdk-49 | 18 | 50.00% | 50.00% | 1m 5s |
+
+## GA4 — user behavior (devices)
+
+| Device | Active users | Sessions | Engagement |
+|---|---:|---:|---:|
+| desktop | 6,812 | 7,805 | 19.36% |
+| mobile | 499 | 593 | 44.69% |
+| tablet | 7 | 9 | 44.44% |
+
+## Notes
+
+- Bot regions excluded from `*ExBotRegions` slices: China, Singapore (per SPEC-018).
+- Full structured data: `snapshot-2026-05-11.json` next to this file.

--- a/docs/strategy/data/snapshot-2026-05-11.json
+++ b/docs/strategy/data/snapshot-2026-05-11.json
@@ -4,7 +4,7 @@
     "endDate": "2026-05-08",
     "days": 365
   },
-  "pulledAt": "2026-05-11T06:15:28.869Z",
+  "pulledAt": "2026-05-11T21:56:24.911Z",
   "siteUrl": "sc-domain:coffey.codes",
   "gsc": {
     "window": {

--- a/docs/strategy/data/snapshot-2026-05-11.md
+++ b/docs/strategy/data/snapshot-2026-05-11.md
@@ -10,7 +10,7 @@ window_end: 2026-05-08
 
 **Window:** 2025-05-08 → 2026-05-08 (365 days)  
 **Site:** `sc-domain:coffey.codes`  
-**Pulled:** 2026-05-11T06:15:28.869Z
+**Pulled:** 2026-05-11T21:56:24.911Z
 
 ## Headline numbers
 

--- a/scripts/seo-snapshot.mjs
+++ b/scripts/seo-snapshot.mjs
@@ -59,6 +59,11 @@
  * Optional CLI flags:
  *   --engines=gsc,bing,ga4,keywords   Default: all configured engines
  *   --window=180                       Default: 365 (days)
+ *   --asof=YYYY-MM-DD                  Anchor "today" to a past date.
+ *                                      Drives both the output filename and
+ *                                      the GSC window. Useful for filling
+ *                                      a few consecutive snapshots in a
+ *                                      single sitting.
  *   --dry-run                          Print what would be pulled; don't call APIs
  *
  * Optional env vars (also read from .env.local / .env):
@@ -111,7 +116,7 @@ const BING_SITE_URL = SITE_URL.startsWith('sc-domain:')
 // ── CLI args ─────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const out = { engines: null, window: null, dryRun: false };
+  const out = { engines: null, window: null, dryRun: false, asof: null };
   for (const arg of argv) {
     if (arg.startsWith('--engines=')) {
       out.engines = arg
@@ -123,6 +128,21 @@ function parseArgs(argv) {
       out.window = Number(arg.slice('--window='.length));
     } else if (arg === '--dry-run') {
       out.dryRun = true;
+    } else if (arg.startsWith('--asof=')) {
+      // Anchor the snapshot's "today" to a fixed date (YYYY-MM-DD).
+      // Drives both the output filename and the GSC window. Useful for
+      // backfilling a few consecutive snapshots from one machine, or for
+      // reproducing a past pull. The date is interpreted as UTC midnight.
+      const value = arg.slice('--asof='.length);
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        throw new Error(
+          `--asof must be in YYYY-MM-DD form, got: ${value}`,
+        );
+      }
+      out.asof = new Date(`${value}T00:00:00.000Z`);
+      if (Number.isNaN(out.asof.getTime())) {
+        throw new Error(`--asof is not a valid date: ${value}`);
+      }
     }
   }
   return out;
@@ -501,7 +521,10 @@ function enrichGscWithKeywords(gsc, keywords) {
 // ── Orchestrator ─────────────────────────────────────────────────────
 
 async function main() {
-  const now = new Date();
+  // `--asof` lets the caller anchor "today" to a past date, which drives
+  // both the snapshot filename and the GSC window. Without it the script
+  // uses the system clock.
+  const now = args.asof ?? new Date();
   // GSC has a ~3-day lag for `final` data; back off the end date.
   const endDate = ymd(new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000));
   const startDate = ymd(


### PR DESCRIPTION
## Summary

Adds a `--asof=YYYY-MM-DD` flag to `scripts/seo-snapshot.mjs` so the script can backfill a few consecutive snapshots from one machine in one sitting, without time-traveling the OS clock. Then uses it to fill three snapshots: 2026-05-09, 2026-05-10, and 2026-05-11.

The three-day backfill doubles as a test drive of the latest snapshot pipeline. All three pulls used the same code path with only the `--asof` value changing.

### Real cross-snapshot delta now in git

```
node scripts/seo-snapshot-diff.mjs \
  docs/strategy/data/snapshot-2026-05-09.json \
  docs/strategy/data/snapshot-2026-05-11.json
```

Produces:
- GSC totals: +4 clicks, +2,815 impressions, flat CTR
- GA4 sessions: +15 (+6 ex bot regions)
- Top page deltas: +3 to `building-location-based-features-using-expo-location`, +1 to `slow-android-emulator-flutter-dev`
- Bing: 0 → 0 (still empty, as expected; site was added 2026-05-10)

### Snapshot totals at each anchor

| Anchor | GSC window | Clicks | Impressions | CTR | GA4 sessions |
| --- | --- | --- | --- | --- | --- |
| 2026-05-09 | 2025-05-06 → 2026-05-06 | 1,148 | 292,181 | 0.39% | 8,303 |
| 2026-05-10 | 2025-05-07 → 2026-05-07 | 1,149 | 293,590 | 0.39% | 8,314 |
| 2026-05-11 | 2025-05-08 → 2026-05-08 | 1,152 | 294,996 | 0.39% | 8,318 |

Each window slides forward one day, so the slight totals drift comes from the oldest day rolling off the window while the newest GSC-final day rolls on.

### What's in the PR

1. `feat(snapshot): add --asof flag` — script + agent brief + setup guide updated
2. `data(seo): backfill 2026-05-09 snapshot`
3. `data(seo): backfill 2026-05-10 snapshot`
4. `data(seo): refresh 2026-05-11 snapshot` (replaces the existing same-day snapshot)

`--asof` defaults to unset; without it the script behaves exactly as before.

Keywords engine still skipped on `CUSTOMER_NOT_ENABLED` (Google Ads billing).

## Test plan

- [ ] CI green (ESLint, Vitest, TypeScript, Playwright)
- [ ] `node scripts/seo-snapshot.mjs --asof=2026-05-09 --dry-run` prints the plan
- [ ] Manual: rerun any of the three pulls to verify reproducibility against a fixed `--asof`

🤖 Generated with [Claude Code](https://claude.com/claude-code)