### PR TITLE
ci(periscope): land publish workflow on main [SPEC-023]

### DIFF
--- a/.github/workflows/periscope-publish.yml
+++ b/.github/workflows/periscope-publish.yml
@@ -63,8 +63,23 @@ jobs:
           echo "dist/ contents:"
           ls -la dist/
 
+      - name: Determine npm dist-tag
+        id: disttag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          # Prerelease versions (containing a hyphen) get the channel name
+          # as their dist-tag so they never become `latest`. Stable versions
+          # get `latest`.
+          if [[ "$VERSION" == *-* ]]; then
+            CHANNEL=$(echo "$VERSION" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+-([a-z]+).*$/\1/')
+            echo "tag=$CHANNEL" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Publishing $VERSION with dist-tag ${CHANNEL:-latest}"
+
       - name: Publish to GitHub Packages
-        run: npm publish
+        run: npm publish --tag ${{ steps.disttag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/periscope-publish.yml
+++ b/.github/workflows/periscope-publish.yml
@@ -1,0 +1,80 @@
+name: Publish @anthonycoffey/periscope
+
+on:
+  # Trigger via tag push: `git tag periscope-v0.1.0 && git push origin periscope-v0.1.0`
+  push:
+    tags:
+      - 'periscope-v*'
+  # Manual trigger from the Actions UI; picks up whatever version is in
+  # tooling/periscope/package.json on the selected branch. Use this for
+  # alpha/beta publishes during Phase A while we iterate fast.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to publish from'
+        required: true
+        default: 'feature/periscope-tool-suite'
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tooling/periscope
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@anthonycoffey'
+          cache: 'npm'
+          cache-dependency-path: tooling/periscope/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify dist exists
+        run: |
+          test -f dist/cli.js || (echo "dist/cli.js missing after build" && exit 1)
+          test -f dist/index.js || (echo "dist/index.js missing after build" && exit 1)
+          test -f dist/cli.d.ts || (echo "dist/cli.d.ts missing after build" && exit 1)
+          echo "dist/ contents:"
+          ls -la dist/
+
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "### Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Package: \`@anthonycoffey/periscope\`" >> $GITHUB_STEP_SUMMARY
+          VERSION=$(node -p "require('./package.json').version")
+          echo "- Version: \`$VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Registry: \`https://npm.pkg.github.com\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "View at: https://github.com/anthonycoffey/coffey.codes/pkgs/npm/periscope" >> $GITHUB_STEP_SUMMARY

--- a/tooling/periscope/README.md
+++ b/tooling/periscope/README.md
@@ -21,7 +21,7 @@ Look at the SERPs from a hidden vantage. Your repo is the vantage. The SERPs are
 
 Once parity against coffey.codes is proven, Phases B (extract to own repo) and C (publish to GitHub Packages) follow under their own SPECs.
 
-## Install (during Phase A)
+## Install (from source, during Phase A)
 
 ```bash
 cd tooling/periscope
@@ -30,6 +30,43 @@ npm run build
 ```
 
 The CLI is available at `tooling/periscope/dist/cli.js`. The coffey.codes root `package.json` has `seo:*` npm scripts that delegate to it.
+
+## Install (from GitHub Packages)
+
+The package publishes to [GitHub Packages](https://github.com/anthonycoffey/coffey.codes/pkgs/npm/periscope) under the `@anthonycoffey` scope. Visibility is **private**, so consumers need a Personal Access Token with `read:packages` scope.
+
+### One-time setup in a consuming project
+
+1. Create a PAT at https://github.com/settings/tokens with the `read:packages` scope. Copy the token.
+2. Add an `.npmrc` to the consuming project root (and to `.gitignore` — never commit the token):
+
+   ```ini
+   @anthonycoffey:registry=https://npm.pkg.github.com
+   //npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN}
+   ```
+
+3. Set the env var: `export GITHUB_PACKAGES_TOKEN=<your-pat>` (or use a `.env` file your shell loads).
+
+### Install
+
+```bash
+npm install @anthonycoffey/periscope
+```
+
+### Verify
+
+```bash
+npx periscope --help
+```
+
+## Publishing new versions
+
+Two ways, both via the [periscope-publish workflow](../../.github/workflows/periscope-publish.yml):
+
+1. **Manual (during Phase A iteration).** GitHub UI: Actions → "Publish @anthonycoffey/periscope" → Run workflow → pick the branch.
+2. **Tag-based (releases).** Bump version in `tooling/periscope/package.json`, commit, then `git tag periscope-v0.1.0 && git push origin periscope-v0.1.0`. Workflow runs, publishes, summary in the Actions run.
+
+The workflow uses `GITHUB_TOKEN` (auto-granted `packages:write` via `permissions:` in the workflow). No PATs needed for publishing.
 
 ## Config
 

--- a/tooling/periscope/package-lock.json
+++ b/tooling/periscope/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "0.0.0-dev",
+  "version": "0.1.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonycoffey/periscope",
-      "version": "0.0.0-dev",
+      "version": "0.1.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@google-analytics/data": "^5.2.2",

--- a/tooling/periscope/package.json
+++ b/tooling/periscope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "SEO data tooling: pull GSC/GA4/Bing/Ads snapshots, diff them, run keyword research. A unified CLI over a set of project-configurable engines.",
   "type": "module",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "node": ">=22.0.0"
   },
   "bin": {
-    "periscope": "./dist/cli.js"
+    "periscope": "dist/cli.js"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/tooling/periscope/package.json
+++ b/tooling/periscope/package.json
@@ -1,11 +1,23 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "0.0.0-dev",
+  "version": "0.1.0-alpha.1",
   "description": "SEO data tooling: pull GSC/GA4/Bing/Ads snapshots, diff them, run keyword research. A unified CLI over a set of project-configurable engines.",
-  "private": true,
   "type": "module",
   "license": "MIT",
   "author": "Anthony Coffey <coffey.j.anthony@gmail.com>",
+  "homepage": "https://github.com/anthonycoffey/coffey.codes/tree/main/tooling/periscope",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/anthonycoffey/coffey.codes.git",
+    "directory": "tooling/periscope"
+  },
+  "bugs": {
+    "url": "https://github.com/anthonycoffey/coffey.codes/issues"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
   "engines": {
     "node": ">=22.0.0"
   },


### PR DESCRIPTION
## Summary

Brings the two publish-workflow commits onto main. They were on the feature branch for PR #193 but landed after the merge captured the diff, so main is currently missing them. Without this, future periscope publishes can only run from the (now-orphan) feature branch.

The cherry-picked commits:

- \`b49848c ci(periscope): wire GitHub Packages publish workflow\` — adds \`.github/workflows/periscope-publish.yml\`, removes \`private: true\`, adds \`publishConfig\`, bumps version to \`0.1.0-alpha.1\`, README install-from-GH-Packages section.
- \`c5e1640 fix(periscope): unblock first publish\` — adds \`--tag <channel>\` for prerelease publishes, fixes the bin path warning, bumps to \`0.1.0-alpha.2\`.

Both already proven by the actual publish: \`@anthonycoffey/periscope@0.1.0-alpha.2\` is live on GitHub Packages (workflow ran from the feature branch tag).

## Why now

You added \`.npmrc\` to root gitignore in commit \`bb37c18\`, signaling intent to wire coffey.codes as a consumer. For that to keep working long-term — and for new versions to publish — the workflow file needs to live on main.

## Test plan

- [x] Cherry-pick applied cleanly (no conflicts)
- [x] \`diff --stat\` matches the original commits (4 files, 150 insertions, 6 deletions)
- [ ] CI passes (TypeScript, ESLint, Vitest, Vercel)
- [ ] After merge: optional manual \`workflow_dispatch\` from main to confirm the workflow runs from there (would publish \`0.1.0-alpha.3\` if you bump the version first; otherwise it'll fail on duplicate version, which is fine — proves the workflow is wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)