### PR TITLE
feat(seo): wire coffey.codes to @anthonycoffey/periscope [SPEC-023]

### DIFF
--- a/.npmrc.example
+++ b/.npmrc.example
@@ -1,0 +1,15 @@
+# Template for the gitignored .npmrc.
+# Copy this file to .npmrc, then either:
+#   (a) set GITHUB_PACKAGES_TOKEN in your shell env (recommended), OR
+#   (b) replace ${GITHUB_PACKAGES_TOKEN} with a literal ghp_... token
+#
+# The token only needs the `read:packages` scope. Create at:
+#   https://github.com/settings/tokens
+#
+# Why this file exists: @anthonycoffey/periscope (SEO tooling) lives on
+# GitHub Packages, not npm.com. Both lines below are required:
+#   - the scope mapping directs `@anthonycoffey/*` lookups at GH Packages
+#   - the authToken line provides the read credential
+
+@anthonycoffey:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,41 @@ npm run test:e2e       # Playwright e2e tests (requires dev server)
 npm run typecheck      # tsc --noEmit
 ```
 
+SEO tooling (via `@anthonycoffey/periscope` from GitHub Packages, see Setup below):
+
+```bash
+npm run seo:snapshot         # Pull multi-engine snapshot
+npm run seo:diff             # Diff two snapshot JSONs
+npm run seo:audit-articles   # Flag article keyword fit
+npm run seo:discover-topics  # Editorial backlog from Ads + GSC
+npm run seo:validate-lps     # Validate LP keyword targets
+npm run seo:probe -- <url>   # One-shot competitor URL probe
+```
+
 Vitest + Testing Library is configured for unit/component tests; Playwright lives in `e2e/` for end-to-end. TDD (RED → GREEN → REFACTOR) is the expected workflow for new features — see `docs/documentation/development-standards.md`.
+
+## Periscope (SEO tooling) setup
+
+The `seo:*` scripts call `@anthonycoffey/periscope`, a private package on GitHub Packages. One-time setup per machine:
+
+1. Generate a PAT at https://github.com/settings/tokens with **only** the `read:packages` scope. Copy the `ghp_...` value.
+2. Set the env var so npm can read it:
+   - PowerShell (persistent): `setx GITHUB_PACKAGES_TOKEN "ghp_yourTokenHere"` (open a new terminal after)
+   - Or inline for a single session: `$env:GITHUB_PACKAGES_TOKEN = "ghp_yourTokenHere"`
+3. Copy the template to a gitignored `.npmrc`:
+   ```bash
+   cp .npmrc.example .npmrc
+   ```
+4. Install the package:
+   ```bash
+   npm install @anthonycoffey/periscope --save-dev
+   ```
+5. Verify:
+   ```bash
+   npx periscope --help
+   ```
+
+Periscope is currently in Phase A (scaffolding only) — the commands respond but exit with "not yet implemented" until SPEC-023 commits 2-9 land and a new version is published.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,14 @@
     "test:e2e": "playwright test",
     "typecheck": "tsc --noEmit",
     "analyze": "cross-env ANALYZE=true next build",
-    "thumbnail:youtube": "node scripts/youtube-thumbnail.mjs"
+    "thumbnail:youtube": "node scripts/youtube-thumbnail.mjs",
+    "seo": "periscope",
+    "seo:snapshot": "periscope snapshot",
+    "seo:diff": "periscope diff",
+    "seo:audit-articles": "periscope audit articles",
+    "seo:discover-topics": "periscope discover topics",
+    "seo:validate-lps": "periscope validate lps",
+    "seo:probe": "periscope probe"
   },
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
## Summary

Wires coffey.codes as a consumer of the published `@anthonycoffey/periscope` package on GitHub Packages.

Three additions:
- `.npmrc.example` — template for the gitignored `.npmrc` with scope mapping + env-var auth
- `package.json` — seven `seo:*` scripts pointing at the installed `periscope` bin
- `CLAUDE.md` — one-time setup steps and command reference

## Why the package isn't added to devDependencies

Deliberately leaving `@anthonycoffey/periscope` out of `devDependencies` here. Reasons:

1. **CI doesn't have the auth token.** Adding the dep would require a `GITHUB_PACKAGES_TOKEN` repo secret + workflow tweaks to write `.npmrc` before `npm ci`. That's a separate concern worth its own PR if/when periscope becomes critical to CI.
2. **Lockfile generation needs the install.** Adding the dep without running install leaves the lockfile out of sync; CI's `npm ci` would break immediately.

The user runs install once locally after setting up `GITHUB_PACKAGES_TOKEN`. The lockfile gets the entry then.

## One-time setup steps (documented in CLAUDE.md)

```powershell
# 1. Create PAT at https://github.com/settings/tokens with read:packages scope
# 2. Set env var (persistent)
setx GITHUB_PACKAGES_TOKEN "ghp_yourTokenHere"
# 3. Open a new terminal, then:
cp .npmrc.example .npmrc
npm install @anthonycoffey/periscope --save-dev
npx periscope --help
```

## Stacks on PR #194

This PR depends on PR #194's workflow being on main to be useful (future periscope versions need a place to publish from). Both can merge independently though — this PR just wires the consumer side, doesn't require any specific periscope version to exist beyond what's already published (`0.1.0-alpha.2`).

## Test plan

- [ ] CI passes (ESLint, TypeScript, Vitest, Vercel — none of which touch `seo:*` scripts)
- [ ] After merge, the documented setup steps work end-to-end on a clean machine
- [ ] `npm run seo:snapshot -- --dry-run` exits 2 with "not yet implemented" — confirms wiring works, just no functionality yet (scaffolding phase)
- [ ] `npx periscope --help` lists six subcommands

## What's NOT in this PR

- `periscope.config.ts` at the root — defers to SPEC-023 commit 5 (config loader doesn't exist yet)
- Old `scripts/seo-*.mjs` and `scripts/keyword-*.mjs` — they stay until SPEC-023 commit 8's parity validation deletes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)