### PR TITLE
feat(periscope): port snapshot command + GSC/GA4/Bing engines [SPEC-023]

### DIFF
--- a/tooling/periscope/package-lock.json
+++ b/tooling/periscope/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonycoffey/periscope",
-      "version": "0.1.0-alpha.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@google-analytics/data": "^5.2.2",

--- a/tooling/periscope/package.json
+++ b/tooling/periscope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "SEO data tooling: pull GSC/GA4/Bing/Ads snapshots, diff them, run keyword research. A unified CLI over a set of project-configurable engines.",
   "type": "module",
   "license": "MIT",

--- a/tooling/periscope/src/cli.ts
+++ b/tooling/periscope/src/cli.ts
@@ -7,6 +7,7 @@
  */
 
 import { Command } from 'commander';
+import { runSnapshot } from './commands/snapshot.js';
 
 const program = new Command();
 
@@ -36,8 +37,19 @@ Examples:
   $ periscope snapshot --window=180 --asof=2026-05-09
 `,
   )
-  .action(async () => {
-    notImplemented('snapshot');
+  .action(async (opts: {
+    engines?: string;
+    window?: string;
+    asof?: string;
+    dryRun?: boolean;
+    config?: string;
+  }) => {
+    await runSnapshot({
+      engines: opts.engines,
+      window: opts.window,
+      asof: opts.asof,
+      dryRun: opts.dryRun,
+    });
   });
 
 // ---------------------------------------------------------------------------

--- a/tooling/periscope/src/commands/snapshot.ts
+++ b/tooling/periscope/src/commands/snapshot.ts
@@ -1,0 +1,314 @@
+/**
+ * `periscope snapshot` command.
+ *
+ * Orchestrates GSC, GA4, and Bing engine pulls, composes them into a
+ * single SnapshotEnvelope, and writes the JSON + Markdown pair to
+ * outputDir/snapshot-<date>.{json,md}.
+ *
+ * The keywords engine (Google Ads Planner enrichment) is wired through
+ * but no-ops in this version -- it lands with the rest of the keyword
+ * research tooling. When that ships, this orchestrator gets the
+ * gsc.topQueries → keywords enrichment step plugged back in.
+ *
+ * Configuration comes from env vars at this stage (commit 5 introduces
+ * a real periscope.config.ts loader that this command will prefer).
+ */
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { loadGoogleCredentials } from '../lib/auth.js';
+import { renderSnapshotMarkdown } from '../lib/markdown.js';
+import {
+  writeSnapshotJson,
+  writeSnapshotMarkdown,
+} from '../lib/snapshot-store.js';
+import { pullBing } from '../engines/bing.js';
+import { pullGa4 } from '../engines/ga4.js';
+import { pullGsc } from '../engines/gsc.js';
+import type {
+  EngineName,
+  SnapshotEnvelope,
+} from '../types/snapshot.js';
+
+export interface SnapshotCommandOptions {
+  engines?: string;
+  window?: string;
+  asof?: string;
+  dryRun?: boolean;
+  /** Project root override. Defaults to process.cwd(). */
+  repoRoot?: string;
+}
+
+/** Engines this command currently knows how to run. */
+const SUPPORTED_ENGINES = new Set<EngineName>(['gsc', 'ga4', 'bing', 'keywords']);
+
+/** Default bot-region exclusion list per SPEC-018. */
+const DEFAULT_BOT_REGIONS = ['China', 'Singapore'];
+
+/** GSC has a ~3-day lag for `final` data; back off the end date by this many days. */
+const GSC_LAG_DAYS = 3;
+
+function ymd(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function parseAsof(value: string | undefined): Date | null {
+  if (!value) return null;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`--asof must be in YYYY-MM-DD form, got: ${value}`);
+  }
+  const d = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`--asof is not a valid date: ${value}`);
+  }
+  return d;
+}
+
+function parseEngines(value: string | undefined): EngineName[] | null {
+  if (!value) return null;
+  const requested = value
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean) as EngineName[];
+  for (const e of requested) {
+    if (!SUPPORTED_ENGINES.has(e)) {
+      throw new Error(
+        `Unknown engine: ${e}. Supported: ${[...SUPPORTED_ENGINES].join(', ')}`,
+      );
+    }
+  }
+  return requested;
+}
+
+function shouldRun(engine: EngineName, selected: EngineName[] | null): boolean {
+  return selected === null || selected.includes(engine);
+}
+
+/** Auto-load .env then .env.local. Node 22+ ships process.loadEnvFile. */
+function loadDotenv(repoRoot: string): void {
+  if (typeof process.loadEnvFile !== 'function') return;
+  for (const name of ['.env', '.env.local']) {
+    const f = path.join(repoRoot, name);
+    if (existsSync(f)) {
+      try {
+        process.loadEnvFile(f);
+      } catch {
+        // Tolerate malformed env files -- engine-level checks will surface
+        // missing values with their own clear errors.
+      }
+    }
+  }
+}
+
+export async function runSnapshot(
+  options: SnapshotCommandOptions,
+): Promise<void> {
+  const repoRoot = options.repoRoot ?? process.cwd();
+  loadDotenv(repoRoot);
+
+  const selected = parseEngines(options.engines);
+  const windowDays = Number(
+    options.window ?? process.env.SNAPSHOT_WINDOW ?? 365,
+  );
+  if (!Number.isFinite(windowDays) || windowDays < 1) {
+    throw new Error(`--window must be a positive integer, got: ${options.window}`);
+  }
+
+  const asof = parseAsof(options.asof);
+  const now = asof ?? new Date();
+
+  const endDate = ymd(new Date(now.getTime() - GSC_LAG_DAYS * 24 * 60 * 60 * 1000));
+  const startDate = ymd(
+    new Date(now.getTime() - (windowDays + GSC_LAG_DAYS) * 24 * 60 * 60 * 1000),
+  );
+
+  const siteUrl = process.env.GSC_SITE_URL;
+  if (!siteUrl) {
+    throw new Error(
+      'GSC_SITE_URL is required. Set it in .env (e.g. GSC_SITE_URL=sc-domain:example.com).',
+    );
+  }
+  const outputDir = path.resolve(
+    repoRoot,
+    process.env.OUTPUT_DIR ?? path.join('docs', 'strategy', 'data'),
+  );
+
+  // Bing requires the full URL form, not sc-domain:
+  const bingSiteUrl = siteUrl.startsWith('sc-domain:')
+    ? `https://${siteUrl.slice('sc-domain:'.length)}/`
+    : siteUrl;
+
+  const googleCreds = loadGoogleCredentials(repoRoot);
+  const ga4PropertyId = process.env.GA4_PROPERTY_ID;
+  const bingApiKey = process.env.BING_WEBMASTER_API_KEY;
+
+  // ── Plan ──────────────────────────────────────────────────────────────
+  type EnginePlan = { name: EngineName; run: () => Promise<unknown> };
+  const planned: EnginePlan[] = [];
+
+  if (shouldRun('gsc', selected)) {
+    if (googleCreds) {
+      planned.push({
+        name: 'gsc',
+        run: () =>
+          pullGsc({
+            siteUrl,
+            startDate,
+            endDate,
+            windowDays,
+            credentials: googleCreds,
+          }),
+      });
+    } else {
+      process.stderr.write(
+        '[snapshot] gsc: skipped (no Google service account credentials configured)\n',
+      );
+    }
+  }
+
+  if (shouldRun('ga4', selected)) {
+    if (googleCreds && ga4PropertyId) {
+      planned.push({
+        name: 'ga4',
+        run: () =>
+          pullGa4({
+            propertyId: ga4PropertyId,
+            startDate,
+            endDate,
+            windowDays,
+            credentials: googleCreds,
+            botRegions: DEFAULT_BOT_REGIONS,
+          }),
+      });
+    } else if (!googleCreds) {
+      process.stderr.write(
+        '[snapshot] ga4: skipped (no Google service account credentials configured)\n',
+      );
+    } else {
+      process.stderr.write('[snapshot] ga4: skipped (GA4_PROPERTY_ID not set)\n');
+    }
+  }
+
+  if (shouldRun('bing', selected)) {
+    if (bingApiKey) {
+      planned.push({
+        name: 'bing',
+        run: () =>
+          pullBing({
+            siteUrl: bingSiteUrl,
+            apiKey: bingApiKey,
+            startDate,
+            endDate,
+            windowDays,
+          }),
+      });
+    } else {
+      process.stderr.write(
+        '[snapshot] bing: skipped (BING_WEBMASTER_API_KEY not set)\n',
+      );
+    }
+  }
+
+  // Keywords engine lands in a follow-up commit. Surface a clear "not yet
+  // available" message instead of silently skipping so users running the
+  // pre-port script don't mistake parity for completeness.
+  if (shouldRun('keywords', selected) && selected?.includes('keywords')) {
+    process.stderr.write(
+      '[snapshot] keywords: skipped (Google Ads engine not yet ported; see SPEC-023)\n',
+    );
+  }
+
+  if (planned.length === 0) {
+    throw new Error(
+      'No engines configured. Set at least one of GSC_SERVICE_ACCOUNT_*, GA4_PROPERTY_ID, BING_WEBMASTER_API_KEY.',
+    );
+  }
+
+  if (options.dryRun) {
+    process.stdout.write(
+      `[dry-run] Would pull from ${planned.map((p) => p.name).join(', ')} for window ${startDate} to ${endDate}\n`,
+    );
+    return;
+  }
+
+  // ── Pull ──────────────────────────────────────────────────────────────
+  const results = await Promise.allSettled(
+    planned.map(async (p) => ({ name: p.name, data: await p.run() })),
+  );
+
+  const snapshot: SnapshotEnvelope = {
+    window: { startDate, endDate, days: windowDays },
+    pulledAt: new Date().toISOString(),
+    siteUrl,
+  };
+
+  for (const r of results) {
+    if (r.status === 'fulfilled') {
+      const { name, data } = r.value;
+      // The types narrowing on a discriminated union of engine outputs
+      // would be heavy here; the wire shape is fully described in the
+      // SnapshotEnvelope so a single indexed assignment is fine.
+      (snapshot as unknown as Record<string, unknown>)[name] = data;
+    } else {
+      const reason = r.reason as Error | undefined;
+      process.stderr.write(
+        `[snapshot] engine pull failed: ${reason?.message ?? r.reason}\n`,
+      );
+    }
+  }
+
+  // Backwards-compat: surface GSC top-level fields at envelope level so
+  // SPEC-016-era consumers (and the diff command, until it's ported) keep
+  // working.
+  if (snapshot.gsc) {
+    snapshot.totals = snapshot.gsc.totals;
+    snapshot.topPages = snapshot.gsc.topPages;
+    snapshot.topQueries = snapshot.gsc.topQueries;
+    snapshot.countries = snapshot.gsc.countries;
+    snapshot.devices = snapshot.gsc.devices;
+  }
+
+  // Empty-result guard: if every engine failed, don't overwrite any
+  // existing snapshot file with the bare envelope.
+  const snapshotIndexed = snapshot as unknown as Record<string, unknown>;
+  const enginesWithData = (['gsc', 'ga4', 'bing', 'keywords'] as EngineName[]).filter(
+    (k) => snapshotIndexed[k],
+  );
+  if (enginesWithData.length === 0) {
+    process.stderr.write(
+      '[snapshot] no engines returned data; not overwriting any existing snapshot file\n',
+    );
+    process.exit(1);
+  }
+
+  // ── Write ─────────────────────────────────────────────────────────────
+  const jsonPath = await writeSnapshotJson(outputDir, snapshot, now);
+  const markdown = renderSnapshotMarkdown(snapshot);
+  const mdPath = await writeSnapshotMarkdown(outputDir, markdown, now);
+
+  process.stdout.write(
+    `Wrote ${jsonPath}  (engines: ${enginesWithData.join(', ')})\n`,
+  );
+  process.stdout.write(`Wrote ${mdPath}\n`);
+
+  if (snapshot.gsc) {
+    const { clicks, impressions, ctr } = snapshot.gsc.totals;
+    process.stdout.write(
+      `GSC window: ${startDate} to ${endDate}  Clicks: ${clicks}  Impressions: ${impressions}  CTR: ${(ctr * 100).toFixed(2)}%\n`,
+    );
+  }
+  if (snapshot.ga4) {
+    const totalSessions = (snapshot.ga4.trafficSources.rows ?? []).reduce(
+      (sum, row) => sum + Number(row.metricValues?.[0]?.value ?? 0),
+      0,
+    );
+    process.stdout.write(`GA4 sessions: ${totalSessions}\n`);
+  }
+  if (snapshot.bing) {
+    const note = snapshot.bing._note ? `  (${snapshot.bing._note})` : '';
+    process.stdout.write(
+      `Bing clicks: ${snapshot.bing.totals.clicks}  Impressions: ${snapshot.bing.totals.impressions}${note}\n`,
+    );
+  }
+}

--- a/tooling/periscope/src/engines/bing.ts
+++ b/tooling/periscope/src/engines/bing.ts
@@ -1,0 +1,87 @@
+/**
+ * Bing Webmaster Tools engine.
+ *
+ * Calls the JSON REST surface at https://ssl.bing.com/webmaster/api.svc/json/
+ * with the API key as a query parameter. Two calls, parallel:
+ *   - GetRankAndTrafficStats — daily clicks/impressions/position
+ *   - GetQueryStats          — top queries with avg position
+ *
+ * Bing requires the full URL form (https://example.com/), not GSC's
+ * sc-domain: form. The caller converts.
+ */
+
+import type {
+  BingEngineData,
+  BingQueryRow,
+  BingTrafficRow,
+  SnapshotWindow,
+} from '../types/snapshot.js';
+
+export interface PullBingOptions {
+  /** Full URL form: `https://example.com/`. */
+  siteUrl: string;
+  apiKey: string;
+  startDate: string;
+  endDate: string;
+  windowDays: number;
+}
+
+async function callBing<T>(
+  endpoint: string,
+  params: Record<string, string>,
+): Promise<T[]> {
+  const url = new URL(`https://ssl.bing.com/webmaster/api.svc/json/${endpoint}`);
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  const resp = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    throw new Error(
+      `Bing API ${endpoint} failed: HTTP ${resp.status} ${resp.statusText}, body: ${body.slice(0, 200)}`,
+    );
+  }
+  const json = (await resp.json()) as { d?: T[] };
+  return json.d ?? [];
+}
+
+export async function pullBing({
+  siteUrl,
+  apiKey,
+  startDate,
+  endDate,
+  windowDays,
+}: PullBingOptions): Promise<BingEngineData> {
+  const baseParams = { apikey: apiKey, siteUrl };
+
+  const [trafficStats, queryStats] = await Promise.all([
+    callBing<BingTrafficRow>('GetRankAndTrafficStats', baseParams),
+    callBing<BingQueryRow>('GetQueryStats', baseParams),
+  ]);
+
+  const aggregated = trafficStats.reduce<{ clicks: number; impressions: number }>(
+    (acc, row) => ({
+      clicks: acc.clicks + Number(row.Clicks ?? 0),
+      impressions: acc.impressions + Number(row.Impressions ?? 0),
+    }),
+    { clicks: 0, impressions: 0 },
+  );
+  const ctr =
+    aggregated.impressions > 0
+      ? aggregated.clicks / aggregated.impressions
+      : 0;
+
+  const isEmpty = trafficStats.length === 0 && queryStats.length === 0;
+  const window: SnapshotWindow = { startDate, endDate, days: windowDays };
+
+  return {
+    window,
+    siteUrl,
+    totals: { ...aggregated, ctr },
+    trafficStats,
+    topQueries: queryStats,
+    ...(isEmpty && { _note: 'empty response' }),
+  };
+}

--- a/tooling/periscope/src/engines/ga4.ts
+++ b/tooling/periscope/src/engines/ga4.ts
@@ -1,0 +1,207 @@
+/**
+ * GA4 (Google Analytics Data API) engine.
+ *
+ * Pulls seven parallel reports:
+ *   - trafficSources (channel/source/medium)
+ *   - organicLandingPages (organic-search filtered, with engagement metrics)
+ *   - userBehavior by device
+ *   - userBehavior by country
+ *   - engagement totals
+ *   - trafficSources excluding bot regions
+ *   - userBehavior by country excluding bot regions
+ *
+ * The bot-region exclusion is per SPEC-018; the list of bot regions comes
+ * in via config (default: ['China', 'Singapore']).
+ */
+
+import { BetaAnalyticsDataClient, protos } from '@google-analytics/data';
+
+import type {
+  Ga4EngineData,
+  Ga4Section,
+  SnapshotWindow,
+} from '../types/snapshot.js';
+import type { GoogleServiceAccountCredentials } from '../lib/auth.js';
+
+type RunReportRequest = protos.google.analytics.data.v1beta.IRunReportRequest;
+type RunReportResponse = protos.google.analytics.data.v1beta.IRunReportResponse;
+type IDimensionFilter = protos.google.analytics.data.v1beta.IFilterExpression;
+
+export interface PullGa4Options {
+  propertyId: string;
+  startDate: string;
+  endDate: string;
+  windowDays: number;
+  credentials: GoogleServiceAccountCredentials;
+  botRegions: string[];
+}
+
+/**
+ * Spec for a single GA4 report. We compose these into requests and then
+ * possibly re-issue them with an added bot-region filter for the
+ * "*ExBotRegions" slices.
+ */
+type ReportSpec = Omit<RunReportRequest, 'property' | 'dateRanges'>;
+
+function normalizeSection(resp: RunReportResponse): Ga4Section {
+  return {
+    dimensionHeaders: (resp.dimensionHeaders ?? []).map((h) => ({
+      name: h.name ?? '',
+    })),
+    metricHeaders: (resp.metricHeaders ?? []).map((h) => ({
+      name: h.name ?? '',
+      type: h.type ? String(h.type) : undefined,
+    })),
+    rows: (resp.rows ?? []).map((row) => ({
+      dimensionValues: (row.dimensionValues ?? []).map((v) => ({
+        value: v.value ?? undefined,
+      })),
+      metricValues: (row.metricValues ?? []).map((v) => ({
+        value: v.value ?? undefined,
+      })),
+    })),
+  };
+}
+
+export async function pullGa4({
+  propertyId,
+  startDate,
+  endDate,
+  windowDays,
+  credentials,
+  botRegions,
+}: PullGa4Options): Promise<Ga4EngineData> {
+  if (!propertyId) {
+    throw new Error('GA4_PROPERTY_ID is required for GA4 puller');
+  }
+  const property = `properties/${propertyId}`;
+
+  const ga4 = new BetaAnalyticsDataClient({ credentials });
+
+  const excludeBotRegions: IDimensionFilter = {
+    notExpression: {
+      filter: {
+        fieldName: 'country',
+        inListFilter: { values: botRegions },
+      },
+    },
+  };
+
+  const runReport = async (spec: ReportSpec): Promise<Ga4Section> => {
+    const [resp] = await ga4.runReport({
+      property,
+      dateRanges: [{ startDate, endDate }],
+      ...spec,
+    });
+    return normalizeSection(resp);
+  };
+
+  const trafficSourcesSpec: ReportSpec = {
+    dimensions: [
+      { name: 'sessionDefaultChannelGroup' },
+      { name: 'sessionSource' },
+      { name: 'sessionMedium' },
+    ],
+    metrics: [{ name: 'sessions' }, { name: 'conversions' }],
+    orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
+    limit: 15,
+  };
+
+  const organicLandingPagesSpec: ReportSpec = {
+    dimensions: [{ name: 'landingPagePlusQueryString' }],
+    metrics: [
+      { name: 'sessions' },
+      { name: 'bounceRate' },
+      { name: 'conversions' },
+      { name: 'engagementRate' },
+      { name: 'averageSessionDuration' },
+    ],
+    dimensionFilter: {
+      filter: {
+        fieldName: 'sessionDefaultChannelGroup',
+        stringFilter: { matchType: 'EXACT', value: 'Organic Search' },
+      },
+    },
+    orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
+    limit: 15,
+  };
+
+  const userBehaviorByDeviceSpec: ReportSpec = {
+    dimensions: [{ name: 'deviceCategory' }],
+    metrics: [
+      { name: 'activeUsers' },
+      { name: 'sessions' },
+      { name: 'engagementRate' },
+    ],
+  };
+
+  const userBehaviorByCountrySpec: ReportSpec = {
+    dimensions: [{ name: 'country' }],
+    metrics: [{ name: 'activeUsers' }, { name: 'sessions' }],
+    orderBys: [{ metric: { metricName: 'activeUsers' }, desc: true }],
+    limit: 10,
+  };
+
+  const engagementSpec: ReportSpec = {
+    metrics: [
+      { name: 'averageSessionDuration' },
+      { name: 'engagementRate' },
+    ],
+  };
+
+  /**
+   * Compose a bot-region-excluded variant of a spec by anding the
+   * existing dimension filter (if any) with the exclude filter. The
+   * structure mirrors what the .mjs script produced for SPEC-018 parity.
+   */
+  const withBotFilter = (spec: ReportSpec): ReportSpec => {
+    if (spec.dimensionFilter) {
+      return {
+        ...spec,
+        dimensionFilter: {
+          andGroup: {
+            expressions: [spec.dimensionFilter, excludeBotRegions],
+          },
+        },
+      };
+    }
+    return { ...spec, dimensionFilter: excludeBotRegions };
+  };
+
+  const [
+    trafficSources,
+    organicLandingPages,
+    userBehaviorByDevice,
+    userBehaviorByCountry,
+    engagement,
+    trafficSourcesExBotRegions,
+    userBehaviorByCountryExBotRegions,
+  ] = await Promise.all([
+    runReport(trafficSourcesSpec),
+    runReport(organicLandingPagesSpec),
+    runReport(userBehaviorByDeviceSpec),
+    runReport(userBehaviorByCountrySpec),
+    runReport(engagementSpec),
+    runReport(withBotFilter(trafficSourcesSpec)),
+    runReport(withBotFilter(userBehaviorByCountrySpec)),
+  ]);
+
+  const window: SnapshotWindow = { startDate, endDate, days: windowDays };
+
+  return {
+    window,
+    propertyId,
+    botRegionsExcluded: botRegions,
+    trafficSources,
+    organicLandingPages,
+    userBehavior: {
+      devices: userBehaviorByDevice,
+      countries: userBehaviorByCountry,
+      engagement,
+    },
+    trafficSourcesExBotRegions,
+    userBehaviorExBotRegions: {
+      countries: userBehaviorByCountryExBotRegions,
+    },
+  };
+}

--- a/tooling/periscope/src/engines/gsc.ts
+++ b/tooling/periscope/src/engines/gsc.ts
@@ -1,0 +1,111 @@
+/**
+ * Google Search Console engine.
+ *
+ * Pulls four parallel breakdowns from the Search Console API:
+ *   - by page (top 25)
+ *   - by query (top 50)
+ *   - by country (top 15)
+ *   - by device (no limit; only ~3 buckets)
+ *
+ * Returns the raw API rows. The orchestrator does the keyword-engine
+ * enrichment join on `topQueries` after this returns.
+ */
+
+import { google } from 'googleapis';
+
+import { buildGoogleAuth } from '../lib/auth.js';
+import type {
+  GscEngineData,
+  GscRow,
+  GscTopQueryRow,
+} from '../types/snapshot.js';
+import type { GoogleServiceAccountCredentials } from '../lib/auth.js';
+
+const GSC_SCOPES = ['https://www.googleapis.com/auth/webmasters.readonly'];
+
+export interface PullGscOptions {
+  siteUrl: string;
+  startDate: string; // YYYY-MM-DD
+  endDate: string; // YYYY-MM-DD
+  windowDays: number;
+  credentials: GoogleServiceAccountCredentials;
+}
+
+interface GscRequestBody {
+  startDate: string;
+  endDate: string;
+  dimensions: string[];
+  rowLimit?: number;
+  dataState?: 'final' | 'all';
+}
+
+/**
+ * Pull a full GSC snapshot section. All four sub-queries run in parallel;
+ * totals are derived from the by-device rows (smallest accurate aggregate).
+ */
+export async function pullGsc({
+  siteUrl,
+  startDate,
+  endDate,
+  windowDays,
+  credentials,
+}: PullGscOptions): Promise<GscEngineData> {
+  const auth = buildGoogleAuth(credentials, GSC_SCOPES);
+  const client = google.searchconsole({ version: 'v1', auth });
+
+  const query = async (params: GscRequestBody): Promise<GscRow[]> => {
+    const { data } = await client.searchanalytics.query({
+      siteUrl,
+      requestBody: params,
+    });
+    return (data.rows ?? []) as GscRow[];
+  };
+
+  const [byPage, byQuery, byCountry, byDevice] = await Promise.all([
+    query({
+      startDate,
+      endDate,
+      dimensions: ['page'],
+      rowLimit: 25,
+      dataState: 'final',
+    }),
+    query({
+      startDate,
+      endDate,
+      dimensions: ['query'],
+      rowLimit: 50,
+      dataState: 'final',
+    }),
+    query({
+      startDate,
+      endDate,
+      dimensions: ['country'],
+      rowLimit: 15,
+      dataState: 'final',
+    }),
+    query({
+      startDate,
+      endDate,
+      dimensions: ['device'],
+      dataState: 'final',
+    }),
+  ]);
+
+  const totals = byDevice.reduce(
+    (acc, row) => ({
+      clicks: acc.clicks + (row.clicks ?? 0),
+      impressions: acc.impressions + (row.impressions ?? 0),
+    }),
+    { clicks: 0, impressions: 0 },
+  );
+  const ctr = totals.impressions > 0 ? totals.clicks / totals.impressions : 0;
+
+  return {
+    window: { startDate, endDate, days: windowDays },
+    totals: { ...totals, ctr },
+    topPages: byPage,
+    topQueries: byQuery as GscTopQueryRow[],
+    countries: byCountry,
+    devices: byDevice,
+  };
+}

--- a/tooling/periscope/src/lib/auth.ts
+++ b/tooling/periscope/src/lib/auth.ts
@@ -1,0 +1,150 @@
+/**
+ * Google service-account JWT auth.
+ *
+ * One service account fronts Google Search Console, GA4, and the Google
+ * Ads API. Each consumer picks its scopes; this module mints and caches
+ * the access token plus the Ads-specific identifiers.
+ *
+ * Credentials come from one of two env vars (in priority order):
+ *   - GSC_SERVICE_ACCOUNT_KEY_PATH: absolute or repo-relative path to a JSON key
+ *   - GSC_SERVICE_ACCOUNT_JSON: the JSON key inline (for CI)
+ *
+ * Returns null when not configured. Callers should treat that as a
+ * normal "skip this engine" signal, not an error.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { google } from 'googleapis';
+
+const ADS_SCOPE = 'https://www.googleapis.com/auth/adwords';
+
+export interface GoogleServiceAccountCredentials {
+  type: 'service_account';
+  client_email: string;
+  private_key: string;
+  // ...other fields present in the JSON key file but unused here
+  [key: string]: unknown;
+}
+
+export interface GoogleAdsAuth {
+  accessToken: string;
+  expiresAt: number;
+  customerId: string;
+  loginCustomerId: string;
+  devToken: string;
+}
+
+/**
+ * Load the Google service-account credentials from env. Returns null
+ * when neither env var is set or the key file is missing.
+ */
+export function loadGoogleCredentials(
+  repoRoot: string,
+): GoogleServiceAccountCredentials | null {
+  const keyPath = process.env.GSC_SERVICE_ACCOUNT_KEY_PATH;
+  const inlineJson = process.env.GSC_SERVICE_ACCOUNT_JSON;
+
+  if (keyPath) {
+    const resolved = path.isAbsolute(keyPath)
+      ? keyPath
+      : path.resolve(repoRoot, keyPath);
+    if (!existsSync(resolved)) {
+      throw new Error(
+        `GSC_SERVICE_ACCOUNT_KEY_PATH points to a file that does not exist: ${resolved}`,
+      );
+    }
+    return JSON.parse(
+      readFileSync(resolved, 'utf-8'),
+    ) as GoogleServiceAccountCredentials;
+  }
+
+  if (inlineJson) {
+    return JSON.parse(inlineJson) as GoogleServiceAccountCredentials;
+  }
+
+  return null;
+}
+
+/**
+ * Returns true when all four Ads env vars + service-account credentials
+ * are present. Used as a precondition before any Ads API call.
+ */
+export function adsConfigured(repoRoot: string): boolean {
+  return !!(
+    process.env.GOOGLE_ADS_DEVELOPER_TOKEN &&
+    process.env.GOOGLE_ADS_CUSTOMER_ID &&
+    process.env.GOOGLE_ADS_LOGIN_CUSTOMER_ID &&
+    loadGoogleCredentials(repoRoot)
+  );
+}
+
+// Module-level cache: service-account tokens are good for 1h; refresh
+// 10m early. Sharing across calls in a single CLI run avoids the
+// re-mint roundtrip per request.
+let cachedAuth: GoogleAdsAuth | null = null;
+
+/**
+ * Mint (or return cached) Google Ads auth. Customer IDs are normalized
+ * to digits-only so users can paste them with or without dashes.
+ */
+export async function getAdsAuth(repoRoot: string): Promise<GoogleAdsAuth | null> {
+  if (!adsConfigured(repoRoot)) return null;
+  if (cachedAuth && cachedAuth.expiresAt > Date.now() + 60_000) {
+    return cachedAuth;
+  }
+
+  const credentials = loadGoogleCredentials(repoRoot);
+  if (!credentials) return null;
+
+  const auth = new google.auth.GoogleAuth({
+    credentials,
+    scopes: [ADS_SCOPE],
+  });
+  const client = await auth.getClient();
+  const tokenResp = await client.getAccessToken();
+  if (!tokenResp.token) {
+    throw new Error('Google Ads auth: failed to mint an access token');
+  }
+
+  const stripDashes = (s: string | undefined): string =>
+    String(s ?? '').replace(/\D/g, '');
+
+  cachedAuth = {
+    accessToken: tokenResp.token,
+    expiresAt: Date.now() + 50 * 60_000,
+    customerId: stripDashes(process.env.GOOGLE_ADS_CUSTOMER_ID),
+    loginCustomerId: stripDashes(process.env.GOOGLE_ADS_LOGIN_CUSTOMER_ID),
+    devToken: process.env.GOOGLE_ADS_DEVELOPER_TOKEN ?? '',
+  };
+  return cachedAuth;
+}
+
+/**
+ * Headers Google Ads expects on every REST call. Pulled out so engine
+ * implementations don't need to know the wire format.
+ */
+export function adsHeaders(auth: GoogleAdsAuth): Record<string, string> {
+  return {
+    Authorization: `Bearer ${auth.accessToken}`,
+    'developer-token': auth.devToken,
+    'login-customer-id': auth.loginCustomerId,
+    'Content-Type': 'application/json',
+  };
+}
+
+/**
+ * Build a GoogleAuth instance for non-Ads APIs (GSC, GA4). Each caller
+ * passes its own scope list.
+ */
+export function buildGoogleAuth(
+  credentials: GoogleServiceAccountCredentials,
+  scopes: string[],
+): InstanceType<typeof google.auth.GoogleAuth> {
+  return new google.auth.GoogleAuth({ credentials, scopes });
+}
+
+/** Reset the cached token. Used by tests; not exported via the public API. */
+export function _resetAdsAuthCache(): void {
+  cachedAuth = null;
+}

--- a/tooling/periscope/src/lib/bucket.ts
+++ b/tooling/periscope/src/lib/bucket.ts
@@ -1,0 +1,36 @@
+/**
+ * Google Ads volume bucket helpers.
+ *
+ * Accounts without spend history return bucketed volumes only.
+ * Accounts with spend get precise integers; we still bucket them for
+ * comparison consistency across snapshots.
+ */
+
+import type { VolumeBucket } from '../types/snapshot.js';
+
+export const BUCKET_ORDER: VolumeBucket[] = [
+  '<100',
+  '100-1K',
+  '1K-10K',
+  '10K-100K',
+  '100K+',
+];
+
+/** Position in BUCKET_ORDER (0..4). -1 for unknown labels. */
+export function bucketRank(label: string | null | undefined): number {
+  if (!label) return -1;
+  return BUCKET_ORDER.indexOf(label as VolumeBucket);
+}
+
+/**
+ * Derive a bucket label from an average-monthly-searches number.
+ * Returns '<100' for null/0 so the result is always a valid label.
+ */
+export function bucketLabel(avgMonthly: number | string | null | undefined): VolumeBucket {
+  const n = Number(avgMonthly ?? 0);
+  if (!n || n < 100) return '<100';
+  if (n < 1000) return '100-1K';
+  if (n < 10000) return '1K-10K';
+  if (n < 100000) return '10K-100K';
+  return '100K+';
+}

--- a/tooling/periscope/src/lib/markdown.ts
+++ b/tooling/periscope/src/lib/markdown.ts
@@ -1,0 +1,343 @@
+/**
+ * Snapshot Markdown renderer.
+ *
+ * Ported from scripts/lib/snapshot-markdown.mjs. Pairs with the JSON
+ * snapshot: the JSON is the source of truth, the Markdown is the
+ * human/AI skim. Section structure and column ordering match the .mjs
+ * version byte-for-byte (SPEC-023 parity).
+ */
+
+import type {
+  BingEngineData,
+  Ga4Section,
+  GscRow,
+  SnapshotEnvelope,
+} from '../types/snapshot.js';
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+const fmtInt = (n: unknown): string =>
+  Number.isFinite(Number(n))
+    ? Math.round(Number(n)).toLocaleString('en-US')
+    : '—';
+
+const fmtPct = (n: unknown, d = 2): string =>
+  Number.isFinite(Number(n)) ? (Number(n) * 100).toFixed(d) + '%' : '—';
+
+const fmtPos = (n: unknown): string =>
+  Number.isFinite(Number(n)) ? Number(n).toFixed(1) : '—';
+
+const fmtNum = (n: unknown, d = 2): string =>
+  Number.isFinite(Number(n)) ? Number(n).toFixed(d) : '—';
+
+function fmtDuration(seconds: unknown): string {
+  if (!Number.isFinite(Number(seconds))) return '—';
+  const s = Math.round(Number(seconds));
+  const m = Math.floor(s / 60);
+  return m > 0 ? `${m}m ${s % 60}s` : `${s}s`;
+}
+
+function shortenUrl(u: string | undefined): string {
+  if (!u) return '';
+  return (
+    u
+      .replace(/^https?:\/\/[^/]+/, '')
+      .replace(/^\/+$/, '/') || '/'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GA4 row zipping
+// ---------------------------------------------------------------------------
+
+/**
+ * GA4 returns parallel arrays for dimensions and metrics; this zips them
+ * into a plain object keyed by header name for easier downstream access.
+ */
+function ga4Rows(section: Ga4Section | undefined): Record<string, string>[] {
+  if (!section?.rows?.length) return [];
+  const dimNames = (section.dimensionHeaders ?? []).map((h) => h.name);
+  const metNames = (section.metricHeaders ?? []).map((h) => h.name);
+  return section.rows.map((row) => {
+    const o: Record<string, string> = {};
+    (row.dimensionValues ?? []).forEach((v, i) => {
+      const key = dimNames[i] ?? `dim${i}`;
+      o[key] = v.value ?? '';
+    });
+    (row.metricValues ?? []).forEach((v, i) => {
+      const key = metNames[i] ?? `met${i}`;
+      o[key] = v.value ?? '';
+    });
+    return o;
+  });
+}
+
+function ga4TotalSessions(section: Ga4Section | undefined): number {
+  const rows = ga4Rows(section);
+  return rows.reduce((sum, r) => sum + (Number(r.sessions) || 0), 0);
+}
+
+// ---------------------------------------------------------------------------
+// GSC table renderers
+// ---------------------------------------------------------------------------
+
+function renderGscTopPages(rows: GscRow[] | undefined, limit = 15): string {
+  if (!rows?.length) return '_(no GSC top-pages data)_';
+  const head = '| URL | Clicks | Impr | CTR | Pos |\n|---|---:|---:|---:|---:|';
+  const body = rows.slice(0, limit).map((r) => {
+    const url = shortenUrl(r.keys?.[0] ?? '');
+    return `| ${url} | ${fmtInt(r.clicks)} | ${fmtInt(r.impressions)} | ${fmtPct(r.ctr)} | ${fmtPos(r.position)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+function renderGscTopQueries(rows: GscRow[] | undefined, limit = 30): string {
+  if (!rows?.length) return '_(no GSC top-queries data)_';
+  const head = '| Query | Clicks | Impr | CTR | Pos |\n|---|---:|---:|---:|---:|';
+  const body = rows.slice(0, limit).map((r) => {
+    const q = (r.keys?.[0] ?? '').replace(/\|/g, '\\|');
+    return `| ${q} | ${fmtInt(r.clicks)} | ${fmtInt(r.impressions)} | ${fmtPct(r.ctr)} | ${fmtPos(r.position)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+function renderGscBreakdown(
+  rows: GscRow[] | undefined,
+  label: string,
+  limit = 10,
+): string {
+  if (!rows?.length) return `_(no ${label} data)_`;
+  const head = `| ${label} | Clicks | Impr | CTR | Pos |\n|---|---:|---:|---:|---:|`;
+  const body = rows.slice(0, limit).map((r) => {
+    return `| ${r.keys?.[0] ?? '?'} | ${fmtInt(r.clicks)} | ${fmtInt(r.impressions)} | ${fmtPct(r.ctr)} | ${fmtPos(r.position)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// GA4 table renderers
+// ---------------------------------------------------------------------------
+
+function renderGa4TrafficSources(
+  section: Ga4Section | undefined,
+  limit = 10,
+): string {
+  const rows = ga4Rows(section);
+  if (!rows.length) return '_(no GA4 traffic-sources data)_';
+  rows.sort((a, b) => Number(b.sessions) - Number(a.sessions));
+  const head =
+    '| Channel | Source | Medium | Sessions | Conversions |\n|---|---|---|---:|---:|';
+  const body = rows.slice(0, limit).map((r) => {
+    return `| ${r.sessionDefaultChannelGroup ?? '?'} | ${r.sessionSource ?? '?'} | ${r.sessionMedium ?? '?'} | ${fmtInt(r.sessions)} | ${fmtNum(r.conversions, 0)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+function renderGa4LandingPages(
+  section: Ga4Section | undefined,
+  limit = 10,
+): string {
+  const rows = ga4Rows(section);
+  if (!rows.length) return '_(no GA4 organic-landing-pages data)_';
+  rows.sort((a, b) => Number(b.sessions) - Number(a.sessions));
+  const head =
+    '| Page | Sessions | Bounce | Engaged | Avg dur |\n|---|---:|---:|---:|---:|';
+  const body = rows.slice(0, limit).map((r) => {
+    return `| ${shortenUrl(r.landingPagePlusQueryString)} | ${fmtInt(r.sessions)} | ${fmtPct(r.bounceRate)} | ${fmtPct(r.engagementRate)} | ${fmtDuration(r.averageSessionDuration)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+function renderGa4UserBehavior(
+  userBehavior:
+    | { devices: Ga4Section; countries?: Ga4Section; engagement?: Ga4Section }
+    | undefined,
+): string {
+  const rows = ga4Rows(userBehavior?.devices);
+  if (!rows.length) return '_(no GA4 user-behavior data)_';
+  const head =
+    '| Device | Active users | Sessions | Engagement |\n|---|---:|---:|---:|';
+  const body = rows.map((r) => {
+    return `| ${r.deviceCategory ?? '?'} | ${fmtInt(r.activeUsers)} | ${fmtInt(r.sessions)} | ${fmtPct(r.engagementRate)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Bing helper: reuse GSC top-queries shape since Bing's API rows have
+// the same field names when we treat them as `keys: [Query]`-style rows.
+// The actual port renders Bing rows directly without the keys[] shim.
+// ---------------------------------------------------------------------------
+
+function renderBingTopQueries(
+  rows: BingEngineData['topQueries'] | undefined,
+  limit = 15,
+): string {
+  if (!rows?.length) return '_(no Bing top-queries data)_';
+  const head = '| Query | Clicks | Impr |\n|---|---:|---:|';
+  const body = rows.slice(0, limit).map((r) => {
+    const q = String(r.Query ?? '').replace(/\|/g, '\\|');
+    return `| ${q} | ${fmtInt(r.Clicks)} | ${fmtInt(r.Impressions)} |`;
+  });
+  return [head, ...body].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Public entry: full snapshot → markdown
+// ---------------------------------------------------------------------------
+
+export function renderSnapshotMarkdown(snapshot: SnapshotEnvelope): string {
+  const date =
+    (snapshot.pulledAt ?? '').slice(0, 10) ||
+    new Date().toISOString().slice(0, 10);
+  const win = snapshot.window ?? snapshot.gsc?.window;
+
+  const lines: string[] = [];
+
+  lines.push(
+    '---',
+    `title: SEO snapshot — ${date}`,
+    `tags: [seo, snapshot, gsc, ga4, bing, keywords]`,
+    `date: ${date}`,
+    `window_start: ${win?.startDate ?? ''}`,
+    `window_end: ${win?.endDate ?? ''}`,
+    '---',
+    '',
+    `# SEO snapshot — ${date}`,
+    '',
+    `**Window:** ${win?.startDate ?? '?'} → ${win?.endDate ?? '?'} (${win?.days ?? '?'} days)  `,
+    `**Site:** \`${snapshot.siteUrl ?? '?'}\`  `,
+    `**Pulled:** ${snapshot.pulledAt ?? '?'}`,
+    '',
+  );
+
+  // Headline numbers
+  lines.push('## Headline numbers', '');
+  const headRows: string[] = [];
+  if (snapshot.gsc?.totals) {
+    headRows.push(
+      `| Google Search Console | ${fmtInt(snapshot.gsc.totals.clicks)} | ${fmtInt(snapshot.gsc.totals.impressions)} | ${fmtPct(snapshot.gsc.totals.ctr)} | — |`,
+    );
+  }
+  if (snapshot.bing?.totals) {
+    const note = snapshot.bing._note ? ` *(${snapshot.bing._note})*` : '';
+    headRows.push(
+      `| Bing Webmaster${note} | ${fmtInt(snapshot.bing.totals.clicks)} | ${fmtInt(snapshot.bing.totals.impressions)} | ${fmtPct(snapshot.bing.totals.ctr)} | — |`,
+    );
+  }
+  if (snapshot.ga4?.trafficSources) {
+    const total = ga4TotalSessions(snapshot.ga4.trafficSources);
+    headRows.push(`| GA4 (all channels) | — | — | — | ${fmtInt(total)} |`);
+  }
+  if (snapshot.ga4?.trafficSourcesExBotRegions) {
+    const total = ga4TotalSessions(snapshot.ga4.trafficSourcesExBotRegions);
+    const regions = (snapshot.ga4.botRegionsExcluded ?? []).join(', ') || '—';
+    headRows.push(
+      `| GA4 (excluding bot regions: ${regions}) | — | — | — | ${fmtInt(total)} |`,
+    );
+  }
+  if (headRows.length) {
+    lines.push(
+      '| Source | Clicks | Impressions | CTR | Sessions |',
+      '|---|---:|---:|---:|---:|',
+      ...headRows,
+      '',
+    );
+  } else {
+    lines.push('_(no engines returned headline data)_', '');
+  }
+
+  // GSC
+  if (snapshot.gsc) {
+    lines.push(
+      '## GSC — top pages',
+      '',
+      renderGscTopPages(snapshot.gsc.topPages),
+      '',
+    );
+    lines.push(
+      '## GSC — top queries',
+      '',
+      renderGscTopQueries(snapshot.gsc.topQueries),
+      '',
+    );
+    lines.push(
+      '## GSC — countries',
+      '',
+      renderGscBreakdown(snapshot.gsc.countries, 'Country'),
+      '',
+    );
+    lines.push(
+      '## GSC — devices',
+      '',
+      renderGscBreakdown(snapshot.gsc.devices, 'Device', 5),
+      '',
+    );
+  }
+
+  // GA4
+  if (snapshot.ga4) {
+    lines.push(
+      '## GA4 — traffic sources',
+      '',
+      renderGa4TrafficSources(snapshot.ga4.trafficSources),
+      '',
+    );
+    if (snapshot.ga4.trafficSourcesExBotRegions) {
+      lines.push(
+        '### GA4 — traffic sources (bot regions excluded)',
+        '',
+        renderGa4TrafficSources(snapshot.ga4.trafficSourcesExBotRegions),
+        '',
+      );
+    }
+    lines.push(
+      '## GA4 — organic landing pages',
+      '',
+      renderGa4LandingPages(snapshot.ga4.organicLandingPages),
+      '',
+    );
+    lines.push(
+      '## GA4 — user behavior (devices)',
+      '',
+      renderGa4UserBehavior(snapshot.ga4.userBehavior),
+      '',
+    );
+  }
+
+  // Bing detail (only when there's something useful)
+  if (
+    snapshot.bing &&
+    (snapshot.bing.topQueries?.length || snapshot.bing.trafficStats?.length)
+  ) {
+    lines.push('## Bing — top queries', '');
+    lines.push(renderBingTopQueries(snapshot.bing.topQueries, 15));
+    lines.push('');
+  }
+
+  // Keywords (Google Ads Planner) summary
+  if (snapshot.keywords) {
+    const k = snapshot.keywords;
+    lines.push(
+      '## Keywords (Google Ads Planner)',
+      '',
+      `- Historical metrics returned: **${fmtInt(k.historicalMetrics?.length ?? 0)}**`,
+      `- Keyword ideas returned: **${fmtInt(k.ideas?.length ?? 0)}**`,
+      '',
+    );
+  }
+
+  // Notes
+  lines.push('## Notes', '');
+  if (snapshot.ga4?.botRegionsExcluded?.length) {
+    lines.push(
+      `- Bot regions excluded from \`*ExBotRegions\` slices: ${snapshot.ga4.botRegionsExcluded.join(', ')} (per SPEC-018).`,
+    );
+  }
+  lines.push(`- Full structured data: \`snapshot-${date}.json\` next to this file.`);
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/tooling/periscope/src/lib/snapshot-store.ts
+++ b/tooling/periscope/src/lib/snapshot-store.ts
@@ -1,0 +1,89 @@
+/**
+ * Snapshot file I/O.
+ *
+ * Reads and writes the per-engine JSON snapshots that live in the
+ * project's configured outputDir (default: docs/strategy/data/).
+ *
+ * File naming convention: `snapshot-YYYY-MM-DD.json` plus a companion
+ * `snapshot-YYYY-MM-DD.md`. Same date stem for both formats.
+ */
+
+import { promises as fs } from 'node:fs';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import type { SnapshotEnvelope } from '../types/snapshot.js';
+
+export interface StoredSnapshot extends SnapshotEnvelope {
+  /** Filename of the source on disk; added when loading from disk. */
+  _sourceFile?: string;
+}
+
+/**
+ * Find the most-recent snapshot in `outputDir`. Returns null when the
+ * directory does not exist or contains no `snapshot-*.json` files.
+ */
+export async function loadLatestSnapshot(
+  outputDir: string,
+): Promise<StoredSnapshot | null> {
+  if (!existsSync(outputDir)) return null;
+
+  const files = (await fs.readdir(outputDir))
+    .filter((f) => /^snapshot-\d{4}-\d{2}-\d{2}\.json$/.test(f))
+    .sort();
+
+  if (files.length === 0) return null;
+
+  const latest = files[files.length - 1];
+  if (!latest) return null;
+
+  const raw = await fs.readFile(path.join(outputDir, latest), 'utf-8');
+  const data = JSON.parse(raw) as SnapshotEnvelope;
+  return { ...data, _sourceFile: latest };
+}
+
+/** Return true if a snapshot's `pulledAt` is older than `days` days. */
+export function isSnapshotStale(
+  snapshot: SnapshotEnvelope | null | undefined,
+  days = 30,
+): boolean {
+  if (!snapshot?.pulledAt) return true;
+  const pulledAt = new Date(snapshot.pulledAt).getTime();
+  if (Number.isNaN(pulledAt)) return true;
+  const ageMs = Date.now() - pulledAt;
+  return ageMs > days * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Write a snapshot JSON to disk. Creates `outputDir` if missing.
+ * Returns the absolute path written.
+ */
+export async function writeSnapshotJson(
+  outputDir: string,
+  envelope: SnapshotEnvelope,
+  asof: Date = new Date(),
+): Promise<string> {
+  await fs.mkdir(outputDir, { recursive: true });
+  const date = asof.toISOString().slice(0, 10);
+  const filename = `snapshot-${date}.json`;
+  const filePath = path.join(outputDir, filename);
+  await fs.writeFile(filePath, JSON.stringify(envelope, null, 2) + '\n', 'utf-8');
+  return filePath;
+}
+
+/**
+ * Write a snapshot's Markdown companion next to its JSON. Same date
+ * stem, `.md` extension. Returns the absolute path written.
+ */
+export async function writeSnapshotMarkdown(
+  outputDir: string,
+  markdown: string,
+  asof: Date = new Date(),
+): Promise<string> {
+  await fs.mkdir(outputDir, { recursive: true });
+  const date = asof.toISOString().slice(0, 10);
+  const filename = `snapshot-${date}.md`;
+  const filePath = path.join(outputDir, filename);
+  await fs.writeFile(filePath, markdown, 'utf-8');
+  return filePath;
+}

--- a/tooling/periscope/src/types/snapshot.ts
+++ b/tooling/periscope/src/types/snapshot.ts
@@ -1,155 +1,245 @@
 /**
  * Snapshot JSON contract.
  *
- * Captures the shape that `scripts/seo-snapshot.mjs` produces today. Made
- * explicit here so engine implementations and the markdown renderer agree
- * on the wire format. Byte-level structural parity is a SPEC-023 must-have.
+ * These types describe the exact wire format that lives on disk in
+ * `outputDir/snapshot-<YYYY-MM-DD>.json`. SPEC-023 requires byte-level
+ * structural parity with the snapshots `scripts/seo-snapshot.mjs`
+ * produced before the port, so the shapes here mirror raw API
+ * responses rather than imposing a normalized layer on top.
+ *
+ * A normalized read API can sit on top of these in `src/lib/` later,
+ * but the JSON file itself stays raw.
  */
 
-/** Volume bucket labels returned by Google Ads keyword planner. */
-export type VolumeBucket = '<100' | '100-1K' | '1K-10K' | '10K-100K' | '100K+';
-
-/** Competition label returned by Google Ads keyword planner. */
-export type Competition = 'LOW' | 'MEDIUM' | 'HIGH';
-
 // ---------------------------------------------------------------------------
-// GSC
+// Shared
 // ---------------------------------------------------------------------------
 
-export interface GscTopQuery {
-  query: string;
-  clicks: number;
-  impressions: number;
-  ctr: number;
-  position: number;
-  /** Filled by the `keywords` engine in the post-pull enrichment pass. */
-  volumeBucket?: VolumeBucket;
-  competition?: Competition;
-  competitionIndex?: number;
-  cpcRangeMicros?: { low: number; high: number };
-  _keywordsMatch?: boolean;
+export interface SnapshotWindow {
+  startDate: string; // YYYY-MM-DD
+  endDate: string; // YYYY-MM-DD
+  days: number;
 }
 
-export interface GscTopPage {
-  page: string;
+/** Google Ads bucket label produced by lib/bucket.ts:bucketLabel. */
+export type VolumeBucket = '<100' | '100-1K' | '1K-10K' | '10K-100K' | '100K+';
+
+/** Google Ads competition tier. */
+export type Competition = 'LOW' | 'MEDIUM' | 'HIGH' | 'UNSPECIFIED';
+
+// ---------------------------------------------------------------------------
+// GSC (Google Search Console)
+//
+// The Search Console API returns rows like { keys, clicks, impressions, ctr,
+// position }. `topQueries` rows are joined in-place with Google Ads keyword
+// metrics by the orchestrator, so they carry optional enrichment fields.
+// ---------------------------------------------------------------------------
+
+export interface GscRow {
+  keys?: string[];
   clicks: number;
   impressions: number;
   ctr: number;
   position: number;
+}
+
+export interface GscTopQueryRow extends GscRow {
+  /** Set when Ads keyword metrics found a match for the query. */
+  volumeBucket?: VolumeBucket;
+  volumeAvgMonthly?: number | null;
+  competition?: Competition | null;
+  competitionIndex?: number | null;
+  /** [low, high] micros from Google Ads, or null when unavailable. */
+  cpcRangeMicros?: [number | null, number | null];
+  /** Set ONLY when the lookup did NOT find a match. */
+  _keywordsMatch?: false;
 }
 
 export interface GscEngineData {
-  topQueries: GscTopQuery[];
-  topPages: GscTopPage[];
+  window: SnapshotWindow;
   totals: {
     clicks: number;
     impressions: number;
     ctr: number;
-    position: number;
   };
+  topPages: GscRow[];
+  topQueries: GscTopQueryRow[];
+  countries: GscRow[];
+  devices: GscRow[];
 }
 
 // ---------------------------------------------------------------------------
-// GA4
+// GA4 (Google Analytics Data API)
+//
+// The Data API returns sections with parallel arrays: dimensionHeaders,
+// metricHeaders, and rows where each row has dimensionValues + metricValues
+// in the same order as the headers. We store the raw shape; the markdown
+// renderer and any audit consumers zip the arrays.
 // ---------------------------------------------------------------------------
 
-export interface Ga4TrafficSource {
-  source: string;
-  medium: string;
-  sessions: number;
-  engagedSessions: number;
-  conversions: number;
+export interface Ga4HeaderName {
+  name: string;
+  type?: string;
+}
+
+export interface Ga4DimensionValue {
+  value?: string;
+}
+
+export interface Ga4MetricValue {
+  value?: string;
+}
+
+export interface Ga4Row {
+  dimensionValues?: Ga4DimensionValue[];
+  metricValues?: Ga4MetricValue[];
+}
+
+export interface Ga4Section {
+  dimensionHeaders: Ga4HeaderName[];
+  metricHeaders: Ga4HeaderName[];
+  rows: Ga4Row[];
 }
 
 export interface Ga4EngineData {
-  totals: {
-    sessions: number;
-    users: number;
-    engagedSessions: number;
-    averageSessionDuration: number;
-    screenPageViews: number;
+  window: SnapshotWindow;
+  propertyId: string;
+  botRegionsExcluded: string[];
+  trafficSources: Ga4Section;
+  organicLandingPages: Ga4Section;
+  userBehavior: {
+    devices: Ga4Section;
+    countries: Ga4Section;
+    engagement: Ga4Section;
   };
-  trafficSources: Ga4TrafficSource[];
-  /** Same shape as `trafficSources`, but with bot-region rows excluded. */
-  trafficSourcesExBotRegions: Ga4TrafficSource[];
-  topCountries: { country: string; sessions: number }[];
-  topPages: { page: string; sessions: number; views: number }[];
+  trafficSourcesExBotRegions: Ga4Section;
+  userBehaviorExBotRegions: {
+    countries: Ga4Section;
+  };
 }
 
 // ---------------------------------------------------------------------------
 // Bing Webmaster Tools
+//
+// The Bing API returns daily rank/traffic stats and query stats as the `.d`
+// array. We store those raw. Dates come as the literal `/Date(...)/` string
+// format -- consumers parse them on demand.
 // ---------------------------------------------------------------------------
+
+export interface BingTrafficRow {
+  Date?: string;
+  Clicks?: number;
+  Impressions?: number;
+  AvgClickPosition?: number;
+  AvgImpressionPosition?: number;
+  [key: string]: unknown;
+}
+
+export interface BingQueryRow {
+  Query?: string;
+  Clicks?: number;
+  Impressions?: number;
+  AvgClickPosition?: number;
+  AvgImpressionPosition?: number;
+  [key: string]: unknown;
+}
 
 export interface BingEngineData {
-  topQueries: { query: string; clicks: number; impressions: number; position: number }[];
-  topPages: { page: string; clicks: number; impressions: number }[];
-  totals: { clicks: number; impressions: number };
+  window: SnapshotWindow;
+  siteUrl: string;
+  totals: {
+    clicks: number;
+    impressions: number;
+    ctr: number;
+  };
+  trafficStats: BingTrafficRow[];
+  topQueries: BingQueryRow[];
+  /** Set to "empty response" when Bing returned no data (new property warm-up). */
+  _note?: string;
 }
 
 // ---------------------------------------------------------------------------
-// Keywords (Google Ads Keyword Planner enrichment)
+// Keywords (Google Ads Keyword Planner)
+//
+// Normalized rows produced by lib/google-ads helpers. These ARE shaped by us
+// since the raw Ads REST surface is awkward; the normalization is stable and
+// already part of the parity contract.
 // ---------------------------------------------------------------------------
 
-export interface KeywordHistoricalMetric {
+export interface KeywordMetricRow {
   keyword: string;
+  volumeAvgMonthly: number | null;
   volumeBucket: VolumeBucket | null;
   competition: Competition | null;
   competitionIndex: number | null;
-  cpcRangeMicros: { low: number; high: number } | null;
+  cpcLowMicros: number | null;
+  cpcHighMicros: number | null;
+  monthlySearchVolumes: unknown[];
 }
 
-export interface KeywordIdea {
-  keyword: string;
-  volumeBucket: VolumeBucket | null;
-  competition: Competition | null;
-  competitionIndex: number | null;
-  cpcRangeMicros: { low: number; high: number } | null;
+export interface KeywordIdeaRow extends KeywordMetricRow {
+  closeVariants?: string[];
 }
 
 export interface KeywordsEngineData {
-  historicalMetrics: KeywordHistoricalMetric[];
-  ideas: KeywordIdea[];
+  geo: 'US' | string;
+  language: 'en' | string;
+  seedCount: number;
+  historicalMetrics: KeywordMetricRow[];
+  ideas: KeywordIdeaRow[];
 }
 
 // ---------------------------------------------------------------------------
-// Ahrefs (SPEC-022, stub for now)
+// Ahrefs (SPEC-022 stub, kept for the future engine slot)
 // ---------------------------------------------------------------------------
 
 export interface AhrefsEngineData {
   target: string;
   fetchedAt: string;
-  domainRating: { current: number; history: { date: string; value: number }[] };
-  refdomains: { total: number; newInWindow: number; lostInWindow: number };
-  organicKeywords: {
+  domainRating?: { current: number; history: { date: string; value: number }[] };
+  refdomains?: { total: number; newInWindow: number; lostInWindow: number };
+  organicKeywords?: {
     keyword: string;
     position: number;
     traffic: number;
     url: string;
   }[];
-  topPages: { url: string; organicTraffic: number; topKeyword: string }[];
-  backlinksStats: { total: number; doFollow: number; fromUniqueDomains: number };
-  topBacklinks: {
+  topPages?: { url: string; organicTraffic: number; topKeyword: string }[];
+  backlinksStats?: { total: number; doFollow: number; fromUniqueDomains: number };
+  topBacklinks?: {
     sourceUrl: string;
     targetUrl: string;
     sourceUrlRating: number;
     anchor: string;
   }[];
-  _meta: { creditsUsed: number; window: number };
+  _meta?: { creditsUsed: number; window: number };
 }
 
 // ---------------------------------------------------------------------------
 // Snapshot envelope
+//
+// The top-level shape on disk. `gsc` data is duplicated at the envelope
+// level (`totals`, `topPages`, etc.) for SPEC-016-era backwards compat;
+// new readers should prefer the `gsc.*` nested fields.
 // ---------------------------------------------------------------------------
 
 export interface SnapshotEnvelope {
+  window: SnapshotWindow;
+  pulledAt: string; // ISO 8601
   siteUrl: string;
-  pulledAt: string;
-  window: { startDate: string; endDate: string; days: number };
   gsc?: GscEngineData;
   ga4?: Ga4EngineData;
   bing?: BingEngineData;
   keywords?: KeywordsEngineData;
   ahrefs?: AhrefsEngineData;
+  // ── Backwards-compat: duplicates of `gsc.*` at the envelope level.
+  // Old SPEC-016 consumers read these directly. Engines do NOT populate
+  // these -- the orchestrator copies them after the GSC pull lands.
+  totals?: GscEngineData['totals'];
+  topPages?: GscEngineData['topPages'];
+  topQueries?: GscEngineData['topQueries'];
+  countries?: GscEngineData['countries'];
+  devices?: GscEngineData['devices'];
 }
 
 export type EngineName = 'gsc' | 'ga4' | 'bing' | 'keywords' | 'ahrefs';


### PR DESCRIPTION
## Summary

Phase A commit 2 from SPEC-023. Ports `scripts/seo-snapshot.mjs` and `scripts/lib/{google-ads,snapshot-markdown}.mjs` into the typed periscope package. The `periscope snapshot` command is now functional end-to-end (modulo the keywords engine, which lands with the keyword research commands).

## What landed

Five commits, each builds cleanly:

| Commit | Scope |
| --- | --- |
| `44d65df` | Port google auth, bucket, snapshot-store libs |
| `04c4a27` | Align snapshot types with actual wire format, port markdown renderer |
| `afe6845` | Port GSC, GA4, Bing engines |
| `052ac84` | Wire snapshot command end-to-end |
| `f41d52c` | Bump to `0.1.0-alpha.3` |

## Type contract correction

The `src/types/snapshot.ts` from PR #193 didn't match the actual on-disk shape (it was a normalized version I'd prefer). SPEC-023 §3 requires byte-level parity with the .mjs snapshots, so types are now rewritten to mirror raw GSC/GA4/Bing API responses + the SPEC-016 backwards-compat duplicates at the envelope level. Caught early — before the engines were built against the wrong shape.

## Project-agnostic shape

Each engine takes its config explicitly (`siteUrl`, `propertyId`, `apiKey`, `botRegions`) rather than reading env vars. The orchestrator command reads env vars and threads them through. Commit 5 will replace env vars with a `periscope.config.ts` loader, but the engines themselves are already multi-project ready.

## Verification

- `npm run typecheck` clean
- `npm run build` produces `dist/cli.js` with engines bundled (sourcemap ~65 KB, up from 6 KB)
- `npm test` passes (1/1, the existing smoke test)
- `node dist/cli.js --help` lists all six subcommands

## What's NOT in this PR

- **Keywords engine** (Google Ads Planner enrichment). Lands with the keyword research commands (`audit articles`, `discover topics`, `validate lps`, `probe <url>`) in the next PR. When `--engines=keywords` is requested today, the command emits a clear "not yet ported" stderr message rather than silently skipping.
- **Diff command**. Separate PR.
- **Config loader**. SPEC-023 commit 5. Still env-var driven at this stage.
- **Unit tests** for the new code. SPEC-023 commit 7.
- **Parity validation against live coffey.codes data**. SPEC-023 commit 8 (requires running both old + new with real credentials and diffing output).

## After merge

To publish `0.1.0-alpha.3`:

```bash
git tag periscope-v0.1.0-alpha.3
git push origin periscope-v0.1.0-alpha.3
# workflow runs; package available within ~30s
```

Then on your end:

```bash
npm update @anthonycoffey/periscope
npx periscope snapshot --dry-run
# real run:
npx periscope snapshot --engines=gsc,ga4,bing --window=180
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)