### PR TITLE
feat(periscope): add doctor diagnostic command, ship 0.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ npm run seo:audit-articles   # Flag article keyword fit
 npm run seo:discover-topics  # Editorial backlog from Ads + GSC
 npm run seo:validate-lps     # Validate LP keyword targets
 npm run seo:probe -- <url>   # One-shot competitor URL probe
+npm run seo:doctor           # Diagnose engine credentials and access
 ```
 
 Vitest + Testing Library is configured for unit/component tests; Playwright lives in `e2e/` for end-to-end. TDD (RED → GREEN → REFACTOR) is the expected workflow for new features — see `docs/documentation/development-standards.md`.

--- a/docs/documentation/guides/seo-snapshot-setup.md
+++ b/docs/documentation/guides/seo-snapshot-setup.md
@@ -217,6 +217,7 @@ GA4 captures both raw `trafficSources` and a `trafficSourcesExBotRegions` varian
 | Google Ads `INVALID_CUSTOMER_ID` | Customer ID is wrong account | The scripts now strip dashes automatically; if you still see this, recheck the ID at the top right of the Ads UI |
 | Google Ads `CUSTOMER_NOT_ENABLED` | Ads account hasn't completed billing setup | Set billing country and add a payment method in Ads UI → Tools → Billing → Summary (no charge for Keyword Planner use) |
 | Google Ads HTTP 404 with HTML error page | API version in the engine is sunset | Bump `API_VERSION` constant in `tooling/periscope/src/engines/ads.ts`, build, publish a new periscope version, `npm update`. Google deprecates versions ~3 months after release; the engine uses v21 as of 2026-05-11 |
+| Google Ads `USER_PERMISSION_DENIED` (or any auth/access uncertainty) | Service account not added to the target customer, or `LOGIN_CUSTOMER_ID` ≠ the Manager account where the developer token lives | Run `npm run seo:doctor -- ads`. It lists which customer IDs the service account can see and names exactly which env id is misaligned. |
 | Keyword research scripts return zero ideas | URL probe: target URL is not indexed by Google. Other scripts: seed terms are too generic/specific | Adjust the seed or pick a different URL |
 | `[snapshot] no engines returned data; not overwriting any existing snapshot file` | Every engine failed; protective guard fired | Investigate the specific engine errors; existing snapshot file is unchanged |
 

--- a/docs/documentation/guides/seo-tooling-inventory.md
+++ b/docs/documentation/guides/seo-tooling-inventory.md
@@ -15,8 +15,9 @@ All SEO work runs through `@anthonycoffey/periscope`, a TypeScript package on Gi
 | Data collection | Pulls from four engines into dated JSON + Markdown snapshots | `periscope snapshot` (cmd: `src/commands/snapshot.ts`) |
 | Diffing | Reports deltas between any two snapshots | `periscope diff` (cmd: `src/commands/diff.ts`) |
 | Keyword research | Four targeted commands that consume snapshots + Google Ads API | `periscope audit/discover/validate/probe` |
+| Diagnostics | Credential and access checks per engine | `periscope doctor [engine]` (cmd: `src/commands/doctor.ts`, modules: `src/diagnostics/*.ts`) |
 | Engines | One module per upstream API | `src/engines/{gsc,ga4,bing,ads}.ts` |
-| Shared library | Auth, bucket math, markdown render, config loader, frontmatter parser, ANSI colors, snapshot store | `src/lib/*.ts` |
+| Shared library | Auth, bucket math, markdown render, config loader, frontmatter parser, ANSI colors, snapshot store, diagnostics types | `src/lib/*.ts` |
 | Config | Project-specific paths + ids | `periscope.config.mjs` at the consumer repo root |
 | Output | Snapshots, diffs, and reports | `docs/strategy/data/` (committed to git) |
 
@@ -90,6 +91,23 @@ One-shot competitor URL probe. Single positional arg, top 30 keyword ideas to st
 ```bash
 npm run seo:probe -- https://competitor.com/their-post
 ```
+
+## Diagnostics
+
+### `periscope doctor [engine]`
+
+Runs credential + access checks against the engines periscope talks to. Currently the **Ads** engine is the only one with a diagnostic module (others land as needs surface).
+
+```bash
+npm run seo:doctor              # all available checks (currently just ads)
+npm run seo:doctor -- ads       # just the Ads check
+```
+
+The Ads diagnostic walks the same auth path the `keywords` engine uses (service-account JWT mint), calls Google Ads' `listAccessibleCustomers` (the cheapest probe — does not need `login-customer-id`), and compares the returned customer IDs to `GOOGLE_ADS_CUSTOMER_ID` + `GOOGLE_ADS_LOGIN_CUSTOMER_ID`. Names the gap when one of them is not in the accessible list.
+
+Never prints the developer token, access token, or service-account private key. Prints `client_email` and customer IDs (not secret). Exits 0 on success, 1 on failure, 2 on unknown engine.
+
+Diagnostic modules live in `src/diagnostics/`; each exports a `diagnose<Engine>()` returning a `DiagnosticReport` (`src/lib/diagnostics.ts`). Add a new engine by writing the diagnostic module and registering it in `AVAILABLE_DIAGNOSTICS` in `src/commands/doctor.ts`.
 
 ## Engines
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "seo:audit-articles": "periscope audit articles",
     "seo:discover-topics": "periscope discover topics",
     "seo:validate-lps": "periscope validate lps",
-    "seo:probe": "periscope probe"
+    "seo:probe": "periscope probe",
+    "seo:doctor": "periscope doctor"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/tooling/periscope/README.md
+++ b/tooling/periscope/README.md
@@ -14,12 +14,13 @@ Look at the SERPs from a hidden vantage. Your repo is the vantage. The SERPs are
 | `periscope discover topics` | Seed Ads with categories + top GSC queries to surface editorial backlog |
 | `periscope validate lps` | Validate `/lp/*` pages: `UNDER_INVESTED` / `WELL_TARGETED` / `OVER_AMBITIOUS` verdicts |
 | `periscope probe <url>` | One-shot competitor URL probe; top 30 keyword ideas to stdout |
+| `periscope doctor [engine]` | Diagnose engine credentials and access (currently: `ads`) |
 
 ## Status
 
-**Phase A, in development.** This package lives inside `coffey.codes` at `tooling/periscope/` and ports the existing `scripts/seo-*.mjs` + `scripts/keyword-*.mjs` files into a typed, unified, config-driven package. Driven by [SPEC-023](../../docs/specs/active/SPEC-023-periscope-tool-suite.md).
+Phase A is complete. The package ships every capability the legacy `scripts/seo-*.mjs` + `scripts/keyword-*.mjs` files provided, plus a config layer, types, tests, and the `doctor` diagnostic command. Driven by [SPEC-023](../../docs/specs/active/SPEC-023-periscope-tool-suite.md).
 
-Once parity against coffey.codes is proven, Phases B (extract to own repo) and C (publish to GitHub Packages) follow under their own SPECs.
+Phases B (extract to own repo) and C (further publish workflow polish) are future work tracked under their own specs.
 
 ## Install (from source, during Phase A)
 

--- a/tooling/periscope/package-lock.json
+++ b/tooling/periscope/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonycoffey/periscope",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@google-analytics/data": "^5.2.2",

--- a/tooling/periscope/package.json
+++ b/tooling/periscope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SEO data tooling: pull GSC/GA4/Bing/Ads snapshots, diff them, run keyword research. A unified CLI over a set of project-configurable engines.",
   "type": "module",
   "license": "MIT",

--- a/tooling/periscope/src/cli.ts
+++ b/tooling/periscope/src/cli.ts
@@ -11,6 +11,7 @@ import { Command } from 'commander';
 import { runAuditArticles } from './commands/audit-articles.js';
 import { runDiff } from './commands/diff.js';
 import { runDiscoverTopics } from './commands/discover-topics.js';
+import { runDoctor } from './commands/doctor.js';
 import { runProbe } from './commands/probe.js';
 import { runSnapshot } from './commands/snapshot.js';
 import { runValidateLps } from './commands/validate-lps.js';
@@ -160,6 +161,25 @@ Examples:
   )
   .action(async (url: string) => {
     await runProbe({ url });
+  });
+
+// ---------------------------------------------------------------------------
+// doctor
+// ---------------------------------------------------------------------------
+
+program
+  .command('doctor [engine]')
+  .description('Diagnose engine credentials and access. Currently: ads (alias: keywords).')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ periscope doctor              # run all available checks
+  $ periscope doctor ads          # check Google Ads access specifically
+`,
+  )
+  .action(async (engine: string | undefined) => {
+    await runDoctor({ engine });
   });
 
 // ---------------------------------------------------------------------------

--- a/tooling/periscope/src/commands/doctor.ts
+++ b/tooling/periscope/src/commands/doctor.ts
@@ -1,0 +1,128 @@
+/**
+ * `periscope doctor` command.
+ *
+ * Runs credential + access checks against the engines periscope talks
+ * to. Currently the Ads engine is the only one with a diagnostic
+ * module; other engines (gsc, ga4, bing) can plug in by adding
+ * src/diagnostics/<engine>.ts and registering here.
+ *
+ * Exits 0 when all checks pass, 1 when any fail, 2 when an unknown
+ * engine was requested.
+ */
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { diagnoseAds } from '../diagnostics/ads.js';
+import { bold, dim, green, red, yellow } from '../lib/colors.js';
+import type { CheckStatus, DiagnosticReport } from '../lib/diagnostics.js';
+
+export interface DoctorCommandOptions {
+  /** Optional engine filter. If unset, all available diagnostics run. */
+  engine?: string;
+  /** Project root override. Defaults to process.cwd(). */
+  repoRoot?: string;
+}
+
+const ENGINE_LABELS: Record<string, string> = {
+  keywords: 'Google Ads (keywords engine)',
+};
+
+const AVAILABLE_DIAGNOSTICS: Record<
+  string,
+  (repoRoot: string) => Promise<DiagnosticReport>
+> = {
+  // Alias `ads` to the keywords-engine diagnostic since users think
+  // "Ads" while periscope's engine name is `keywords`.
+  ads: diagnoseAds,
+  keywords: diagnoseAds,
+};
+
+function statusGlyph(s: CheckStatus): string {
+  if (s === 'ok') return green('✓');
+  if (s === 'warn') return yellow('!');
+  return red('✗');
+}
+
+function statusWord(s: CheckStatus): string {
+  if (s === 'ok') return green('ok');
+  if (s === 'warn') return yellow('warn');
+  return red('fail');
+}
+
+export function printReport(
+  report: DiagnosticReport,
+  out: NodeJS.WriteStream = process.stdout,
+): void {
+  const label = ENGINE_LABELS[report.engine] ?? report.engine;
+  out.write('\n');
+  out.write(`${bold(label)}  ${statusWord(report.status)}\n`);
+  for (const check of report.checks) {
+    out.write(`  ${statusGlyph(check.status)} ${check.name}\n`);
+    if (check.detail) {
+      out.write(`     ${dim(check.detail)}\n`);
+    }
+  }
+  if (report.notes?.length) {
+    out.write('\n');
+    for (const note of report.notes) {
+      out.write(`  ${dim('note:')} ${note}\n`);
+    }
+  }
+}
+
+function loadDotenv(repoRoot: string): void {
+  if (typeof process.loadEnvFile !== 'function') return;
+  for (const name of ['.env', '.env.local']) {
+    const f = path.join(repoRoot, name);
+    if (existsSync(f)) {
+      try {
+        process.loadEnvFile(f);
+      } catch {
+        // Tolerate malformed env files; engine checks surface missing values.
+      }
+    }
+  }
+}
+
+export async function runDoctor(options: DoctorCommandOptions = {}): Promise<void> {
+  const repoRoot = options.repoRoot ?? process.cwd();
+  loadDotenv(repoRoot);
+
+  const requested = options.engine?.toLowerCase();
+  const enginesToRun: string[] = requested
+    ? [requested]
+    : Object.keys(AVAILABLE_DIAGNOSTICS).filter(
+        (k) => !['ads'].includes(k), // dedupe the `ads` alias from default run
+      );
+
+  if (requested && !AVAILABLE_DIAGNOSTICS[requested]) {
+    process.stderr.write(
+      `[doctor] Unknown engine: ${requested}. Supported: ${Object.keys(AVAILABLE_DIAGNOSTICS).join(', ')}\n`,
+    );
+    process.exit(2);
+  }
+
+  const reports: DiagnosticReport[] = [];
+  for (const engine of enginesToRun) {
+    const diagnose = AVAILABLE_DIAGNOSTICS[engine];
+    if (!diagnose) continue;
+    const report = await diagnose(repoRoot);
+    reports.push(report);
+    printReport(report);
+  }
+
+  process.stdout.write('\n');
+  const failed = reports.filter((r) => r.status === 'fail');
+  const warned = reports.filter((r) => r.status === 'warn');
+  if (failed.length > 0) {
+    process.stdout.write(red(`Failed: ${failed.length}/${reports.length}\n`));
+    process.exit(1);
+  } else if (warned.length > 0) {
+    process.stdout.write(
+      yellow(`Warnings: ${warned.length}/${reports.length}\n`),
+    );
+  } else {
+    process.stdout.write(green(`All ${reports.length} check group(s) passed.\n`));
+  }
+}

--- a/tooling/periscope/src/diagnostics/ads.ts
+++ b/tooling/periscope/src/diagnostics/ads.ts
@@ -1,0 +1,235 @@
+/**
+ * Google Ads diagnostic.
+ *
+ * Mints the same JWT the keywords engine mints, then calls
+ * `listAccessibleCustomers` (the cheapest probe -- does not need
+ * `login-customer-id`) and reports which customer IDs the service
+ * account can see. Compares against `GOOGLE_ADS_CUSTOMER_ID` and
+ * `GOOGLE_ADS_LOGIN_CUSTOMER_ID` and names the gap.
+ *
+ * Never prints the developer token, access token, or private key.
+ * Prints `client_email` and customer IDs (not secret).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { google } from 'googleapis';
+
+import {
+  type Check,
+  type DiagnosticReport,
+  overallStatus,
+} from '../lib/diagnostics.js';
+
+const API_VERSION = 'v21';
+const ADS_SCOPE = 'https://www.googleapis.com/auth/adwords';
+
+interface ServiceAccountKey {
+  client_email: string;
+  project_id?: string;
+  private_key: string;
+}
+
+const stripDashes = (s: string | undefined): string =>
+  String(s ?? '').replace(/\D/g, '');
+
+function loadCredentials(repoRoot: string): {
+  source: string;
+  credentials: ServiceAccountKey;
+} {
+  const keyPath = process.env.GSC_SERVICE_ACCOUNT_KEY_PATH;
+  const inline = process.env.GSC_SERVICE_ACCOUNT_JSON;
+  if (keyPath) {
+    const resolved = path.isAbsolute(keyPath)
+      ? keyPath
+      : path.resolve(repoRoot, keyPath);
+    if (!existsSync(resolved)) {
+      throw new Error(
+        `GSC_SERVICE_ACCOUNT_KEY_PATH points to a missing file: ${resolved}`,
+      );
+    }
+    return {
+      source: `GSC_SERVICE_ACCOUNT_KEY_PATH=${keyPath}`,
+      credentials: JSON.parse(readFileSync(resolved, 'utf-8')) as ServiceAccountKey,
+    };
+  }
+  if (inline) {
+    return {
+      source: 'GSC_SERVICE_ACCOUNT_JSON (inline)',
+      credentials: JSON.parse(inline) as ServiceAccountKey,
+    };
+  }
+  throw new Error(
+    'Neither GSC_SERVICE_ACCOUNT_KEY_PATH nor GSC_SERVICE_ACCOUNT_JSON is set.',
+  );
+}
+
+export async function diagnoseAds(
+  repoRoot: string = process.cwd(),
+): Promise<DiagnosticReport> {
+  const checks: Check[] = [];
+
+  // ── 1. Load credentials ──────────────────────────────────────────────
+  let credentials: ServiceAccountKey;
+  let credSource: string;
+  try {
+    const loaded = loadCredentials(repoRoot);
+    credentials = loaded.credentials;
+    credSource = loaded.source;
+    checks.push({
+      name: 'Service account loaded',
+      status: 'ok',
+      detail: `${credentials.client_email} (project: ${credentials.project_id ?? 'unknown'}; via ${credSource})`,
+    });
+  } catch (err) {
+    checks.push({
+      name: 'Service account credentials',
+      status: 'fail',
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return { engine: 'keywords', status: 'fail', checks };
+  }
+
+  // ── 2. Required env vars ─────────────────────────────────────────────
+  const targetId = stripDashes(process.env.GOOGLE_ADS_CUSTOMER_ID);
+  const loginId = stripDashes(process.env.GOOGLE_ADS_LOGIN_CUSTOMER_ID);
+  const devToken = process.env.GOOGLE_ADS_DEVELOPER_TOKEN ?? '';
+
+  const missing: string[] = [];
+  if (!targetId) missing.push('GOOGLE_ADS_CUSTOMER_ID');
+  if (!loginId) missing.push('GOOGLE_ADS_LOGIN_CUSTOMER_ID');
+  if (!devToken) missing.push('GOOGLE_ADS_DEVELOPER_TOKEN');
+  if (missing.length > 0) {
+    checks.push({
+      name: 'Required Ads env vars',
+      status: 'fail',
+      detail: `Missing: ${missing.join(', ')}`,
+    });
+    return { engine: 'keywords', status: 'fail', checks };
+  }
+  checks.push({
+    name: 'Required Ads env vars',
+    status: 'ok',
+    detail: `CUSTOMER_ID=${targetId}, LOGIN_CUSTOMER_ID=${loginId}, DEVELOPER_TOKEN=(set, ${devToken.length} chars)`,
+  });
+
+  // ── 3. Mint an access token ──────────────────────────────────────────
+  let accessToken: string;
+  try {
+    const auth = new google.auth.GoogleAuth({
+      credentials,
+      scopes: [ADS_SCOPE],
+    });
+    const client = await auth.getClient();
+    const tokenResp = await client.getAccessToken();
+    if (!tokenResp.token) {
+      checks.push({
+        name: 'Access token mint',
+        status: 'fail',
+        detail: 'Service account JWT did not mint an access token.',
+      });
+      return { engine: 'keywords', status: 'fail', checks };
+    }
+    accessToken = tokenResp.token;
+    checks.push({
+      name: 'Access token mint',
+      status: 'ok',
+      detail: `Token length: ${accessToken.length} chars`,
+    });
+  } catch (err) {
+    checks.push({
+      name: 'Access token mint',
+      status: 'fail',
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return { engine: 'keywords', status: 'fail', checks };
+  }
+
+  // ── 4. listAccessibleCustomers ───────────────────────────────────────
+  let ids: string[] = [];
+  try {
+    const resp = await fetch(
+      `https://googleads.googleapis.com/${API_VERSION}/customers:listAccessibleCustomers`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'developer-token': devToken,
+        },
+      },
+    );
+    const text = await resp.text();
+    if (!resp.ok) {
+      checks.push({
+        name: 'listAccessibleCustomers',
+        status: 'fail',
+        detail: `HTTP ${resp.status} ${resp.statusText}: ${text.slice(0, 300)}`,
+      });
+      return {
+        engine: 'keywords',
+        status: 'fail',
+        checks,
+        notes: [
+          '401 - token rejected; service account key may have been rotated.',
+          '403 DEVELOPER_TOKEN_NOT_APPROVED - developer token not approved yet.',
+          '403 PERMISSION_DENIED - service account not added to ANY Ads account this token can see.',
+        ],
+      };
+    }
+    const data = JSON.parse(text) as { resourceNames?: string[] };
+    ids = (data.resourceNames ?? []).map((n) =>
+      String(n).replace(/^customers\//, ''),
+    );
+    if (ids.length === 0) {
+      checks.push({
+        name: 'listAccessibleCustomers',
+        status: 'warn',
+        detail: `Service account ${credentials.client_email} has access to ZERO Ads customers. Add it as a user in the Ads UI.`,
+      });
+    } else {
+      checks.push({
+        name: 'listAccessibleCustomers',
+        status: 'ok',
+        detail: `Accessible customers: ${ids.join(', ')}`,
+      });
+    }
+  } catch (err) {
+    checks.push({
+      name: 'listAccessibleCustomers',
+      status: 'fail',
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return { engine: 'keywords', status: 'fail', checks };
+  }
+
+  // ── 5. Cross-check the configured IDs ────────────────────────────────
+  const targetOk = ids.includes(targetId);
+  const loginOk = ids.includes(loginId);
+  checks.push({
+    name: `GOOGLE_ADS_CUSTOMER_ID=${targetId}`,
+    status: targetOk ? 'ok' : 'fail',
+    detail: targetOk ? 'in accessible list' : 'NOT in accessible list',
+  });
+  checks.push({
+    name: `GOOGLE_ADS_LOGIN_CUSTOMER_ID=${loginId}`,
+    status: loginOk ? 'ok' : 'fail',
+    detail: loginOk ? 'in accessible list' : 'NOT in accessible list',
+  });
+
+  const notes: string[] = [];
+  if (!targetOk || !loginOk) {
+    notes.push(
+      `Options: (1) update .env to use an accessible ID; (2) add ${credentials.client_email} as a user on the missing customer(s) in the Google Ads UI.`,
+    );
+  } else if (targetId !== loginId) {
+    notes.push(
+      'CUSTOMER_ID differs from LOGIN_CUSTOMER_ID. Correct only if LOGIN_CUSTOMER_ID is a Manager account and CUSTOMER_ID is a child it manages.',
+    );
+  }
+
+  return {
+    engine: 'keywords',
+    status: overallStatus(checks),
+    checks,
+    notes: notes.length > 0 ? notes : undefined,
+  };
+}

--- a/tooling/periscope/src/lib/diagnostics.ts
+++ b/tooling/periscope/src/lib/diagnostics.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types for periscope's doctor command.
+ *
+ * Each engine ships a `diagnose*()` function in src/diagnostics/ that
+ * returns a DiagnosticReport. The doctor command aggregates reports,
+ * prints them, and exits with the right code.
+ */
+
+import type { EngineName } from '../types/snapshot.js';
+
+export type CheckStatus = 'ok' | 'warn' | 'fail';
+
+export interface Check {
+  /** Short human-readable name, e.g. "listAccessibleCustomers". */
+  name: string;
+  status: CheckStatus;
+  /** Optional one-line detail printed under the check. */
+  detail?: string;
+}
+
+export interface DiagnosticReport {
+  engine: EngineName;
+  /** Overall status -- worst of any check's status. */
+  status: CheckStatus;
+  checks: Check[];
+  /** Optional advisory notes printed under the report. */
+  notes?: string[];
+}
+
+/** Reduce a list of check statuses to an overall status (worst wins). */
+export function overallStatus(checks: Check[]): CheckStatus {
+  if (checks.some((c) => c.status === 'fail')) return 'fail';
+  if (checks.some((c) => c.status === 'warn')) return 'warn';
+  return 'ok';
+}

--- a/tooling/periscope/tests/unit/diagnostics.test.ts
+++ b/tooling/periscope/tests/unit/diagnostics.test.ts
@@ -1,0 +1,104 @@
+import { Writable } from 'node:stream';
+
+import { describe, expect, it } from 'vitest';
+
+import { printReport } from '../../src/commands/doctor.js';
+import {
+  type Check,
+  type DiagnosticReport,
+  overallStatus,
+} from '../../src/lib/diagnostics.js';
+
+// ── overallStatus ──────────────────────────────────────────────────────
+
+describe('overallStatus', () => {
+  it('returns ok when every check is ok', () => {
+    const checks: Check[] = [
+      { name: 'a', status: 'ok' },
+      { name: 'b', status: 'ok' },
+    ];
+    expect(overallStatus(checks)).toBe('ok');
+  });
+
+  it('returns warn when any check is warn and none failed', () => {
+    const checks: Check[] = [
+      { name: 'a', status: 'ok' },
+      { name: 'b', status: 'warn' },
+    ];
+    expect(overallStatus(checks)).toBe('warn');
+  });
+
+  it('returns fail when any check failed (even with warns)', () => {
+    const checks: Check[] = [
+      { name: 'a', status: 'warn' },
+      { name: 'b', status: 'fail' },
+      { name: 'c', status: 'ok' },
+    ];
+    expect(overallStatus(checks)).toBe('fail');
+  });
+
+  it('returns ok for an empty check list', () => {
+    expect(overallStatus([])).toBe('ok');
+  });
+});
+
+// ── printReport ────────────────────────────────────────────────────────
+
+function captureWritable(): { sink: Writable & { value: () => string }; chunks: string[] } {
+  const chunks: string[] = [];
+  const sink = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  // Attach a helper for assertions.
+  (sink as Writable & { value: () => string }).value = () => chunks.join('');
+  return { sink: sink as Writable & { value: () => string }, chunks };
+}
+
+describe('printReport', () => {
+  it('emits the engine label, status word, and every check name', () => {
+    const report: DiagnosticReport = {
+      engine: 'keywords',
+      status: 'ok',
+      checks: [
+        { name: 'Service account loaded', status: 'ok', detail: 'svc@example' },
+        { name: 'Access token mint', status: 'ok' },
+      ],
+    };
+    const { sink } = captureWritable();
+    // printReport's signature takes a NodeJS.WriteStream; the Writable cast is safe here.
+    printReport(report, sink as unknown as NodeJS.WriteStream);
+    const out = sink.value();
+    expect(out).toContain('Google Ads');
+    expect(out).toContain('Service account loaded');
+    expect(out).toContain('svc@example');
+    expect(out).toContain('Access token mint');
+  });
+
+  it('prints notes section when notes are present', () => {
+    const report: DiagnosticReport = {
+      engine: 'keywords',
+      status: 'fail',
+      checks: [{ name: 'listAccessibleCustomers', status: 'fail', detail: 'HTTP 403' }],
+      notes: ['Token may be revoked.', 'Service account may need re-adding.'],
+    };
+    const { sink } = captureWritable();
+    printReport(report, sink as unknown as NodeJS.WriteStream);
+    const out = sink.value();
+    expect(out).toContain('Token may be revoked.');
+    expect(out).toContain('Service account may need re-adding.');
+  });
+
+  it('omits the notes section when there are no notes', () => {
+    const report: DiagnosticReport = {
+      engine: 'keywords',
+      status: 'ok',
+      checks: [{ name: 'ok', status: 'ok' }],
+    };
+    const { sink } = captureWritable();
+    printReport(report, sink as unknown as NodeJS.WriteStream);
+    expect(sink.value()).not.toContain('note:');
+  });
+});


### PR DESCRIPTION
## Summary

Promotes the one-off `scripts/diagnose-google-ads.mjs` script (from the unmerged `chore/ads-diagnostic` branch) into a first-class periscope subcommand: **`periscope doctor [engine]`**.

The Ads diagnostic just earned its keep — it pinpointed a real `USER_PERMISSION_DENIED` config issue in under a minute. Worth baking in permanently and extensible to the other engines as needs surface.

## What's new

**`periscope doctor [engine]`**
- Defaults: runs all available checks (currently just `ads`)
- `periscope doctor ads` (or `keywords` — alias): run just the Ads probe

The Ads diagnostic:
- Walks the same auth path the `keywords` engine uses (service-account JWT)
- Calls `listAccessibleCustomers` (cheapest probe — no `login-customer-id` needed)
- Compares returned IDs to `GOOGLE_ADS_CUSTOMER_ID` and `GOOGLE_ADS_LOGIN_CUSTOMER_ID`
- Names exactly which env id is misaligned
- **Never prints** the developer token, access token, or service-account private key

Exit codes: 0 ok, 1 fail, 2 unknown engine.

## Architecture for future engines

The plumbing is engine-agnostic:

| File | Purpose |
| --- | --- |
| `src/lib/diagnostics.ts` | Shared types: `Check`, `DiagnosticReport`, `overallStatus()` |
| `src/diagnostics/<engine>.ts` | Engine-specific `diagnose<Engine>()` function |
| `src/commands/doctor.ts` | `AVAILABLE_DIAGNOSTICS` registry + report formatter |

Adding a new engine diagnostic is a single new file + one line in the registry.

## Verification

- Periscope typecheck ✅
- Periscope build ✅ (`dist/cli.js` ~78 KB)
- Periscope tests: **36/36** (7 new diagnostics tests cover `overallStatus` + `printReport`)
- Root lint ✅
- Root typecheck ✅

## Docs

- `tooling/periscope/README.md` — `doctor` in the command table; Phase A marked complete
- `docs/documentation/guides/seo-tooling-inventory.md` — Diagnostics section
- `docs/documentation/guides/seo-snapshot-setup.md` — `USER_PERMISSION_DENIED` troubleshooting row pointing at `npm run seo:doctor -- ads`
- `CLAUDE.md` — `npm run seo:doctor` in the command reference

## After merge

```bash
git tag periscope-v0.2.0
git push origin periscope-v0.2.0
# workflow publishes @anthonycoffey/periscope@0.2.0
```

Then on coffey.codes:

```bash
npm update @anthonycoffey/periscope
npm run seo:doctor              # all available checks
npm run seo:doctor -- ads       # just Ads
```

## Cleanup

The `chore/ads-diagnostic` branch (with the standalone `scripts/diagnose-google-ads.mjs` script) is now redundant — its logic lives in `src/diagnostics/ads.ts`. Safe to delete after this PR merges:

```bash
git push origin --delete chore/ads-diagnostic
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)