### PR TITLE
release(periscope): promote to 1.0.0

### DIFF
--- a/docs/documentation/guides/seo-tooling-inventory.md
+++ b/docs/documentation/guides/seo-tooling-inventory.md
@@ -187,7 +187,7 @@ Date in filename, not timestamp. Reruns on the same day overwrite; history lives
 | SPEC-019 | Google Ads Keyword Planner as the fourth engine | Archived |
 | SPEC-020 | The four keyword research scripts | Archived |
 | SPEC-022 | Ahrefs as a fifth snapshot engine | Active (proposed) |
-| SPEC-023 | Extract everything into the `@anthonycoffey/periscope` package | Active |
+| SPEC-023 | Extract everything into the `@anthonycoffey/periscope` package | Archived (shipped 1.0.0) |
 
 ## What is intentionally not here
 

--- a/docs/specs/archive/SPEC-023-periscope-tool-suite.md
+++ b/docs/specs/archive/SPEC-023-periscope-tool-suite.md
@@ -1,8 +1,9 @@
 ---
 id: SPEC-023
 title: 'Periscope: extract SEO tooling into a reusable TypeScript package'
-status: in-review
+status: complete
 created: 2026-05-15
+completed: 2026-05-17
 author: Anthony Coffey
 reviewers: []
 affected_repos: [coffey.codes]

--- a/tooling/periscope/README.md
+++ b/tooling/periscope/README.md
@@ -18,11 +18,17 @@ Look at the SERPs from a hidden vantage. Your repo is the vantage. The SERPs are
 
 ## Status
 
-Phase A is complete. The package ships every capability the legacy `scripts/seo-*.mjs` + `scripts/keyword-*.mjs` files provided, plus a config layer, types, tests, and the `doctor` diagnostic command. Driven by [SPEC-023](../../docs/specs/active/SPEC-023-periscope-tool-suite.md).
+**1.0.0 — stable.** Phase A is complete. The package ships every capability the legacy `scripts/seo-*.mjs` + `scripts/keyword-*.mjs` files provided, plus a config layer, types, tests, and the `doctor` diagnostic command. Originally driven by [SPEC-023](../../docs/specs/archive/SPEC-023-periscope-tool-suite.md).
 
-Phases B (extract to own repo) and C (further publish workflow polish) are future work tracked under their own specs.
+From 1.0.0 forward, the CLI surface, config schema, and exported library functions follow [semver](https://semver.org/):
 
-## Install (from source, during Phase A)
+- **patch** (`1.0.x`) — bug fixes, doc updates, internal refactors
+- **minor** (`1.x.0`) — new commands, new config fields, new engines (additive)
+- **major** (`2.0.0`) — breaking changes to CLI flags, config schema, snapshot JSON shape, or the lib surface
+
+Consumers can pin with `^1.0.0` and rely on `npm update` for non-breaking changes. Phase B (extract to own repo) is the next milestone, tracked separately.
+
+## Install (from source, for periscope development)
 
 ```bash
 cd tooling/periscope

--- a/tooling/periscope/package-lock.json
+++ b/tooling/periscope/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonycoffey/periscope",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@google-analytics/data": "^5.2.2",

--- a/tooling/periscope/package.json
+++ b/tooling/periscope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "SEO data tooling: pull GSC/GA4/Bing/Ads snapshots, diff them, run keyword research. A unified CLI over a set of project-configurable engines.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes `@anthonycoffey/periscope` from `0.2.0` to **`1.0.0`** — stable.

Phase A is complete, the doctor command is in, the package has real production usage. Time to commit to standard semver and stop the pre-1.0 minor-version-as-breaking dance.

## What changes for consumers

Exactly one thing, and it's a *nice* thing: from 1.0 forward,

```bash
npm update @anthonycoffey/periscope
```

with a `^1.0.0` constraint picks up every non-breaking version automatically. No more `npm install ...@latest --save-dev` on each release.

## Semver commitment from here

| Bump | Means |
| --- | --- |
| **patch** (`1.0.x`) | Bug fixes, doc updates, internal refactors |
| **minor** (`1.x.0`) | New commands, new config fields, new engines (additive) |
| **major** (`2.0.0`) | Breaking changes to CLI flags, config schema, snapshot JSON shape, or the lib exports |

Documented in `tooling/periscope/README.md` under Status.

## Included

- `tooling/periscope/package.json`: version bump `0.2.0` → `1.0.0`
- `tooling/periscope/README.md`: Status section updated, semver table added
- `docs/specs/active/SPEC-023-periscope-tool-suite.md` → `docs/specs/archive/SPEC-023-periscope-tool-suite.md`, status `in-review` → `complete`, `completed: 2026-05-17` added
- `docs/documentation/guides/seo-tooling-inventory.md`: SPEC-023 row updated to "Archived (shipped 1.0.0)"
- Lockfile synced

## Verification

- Periscope typecheck ✅
- Periscope tests: 36/36 ✅

## After merge

```bash
git tag periscope-v1.0.0
git push origin periscope-v1.0.0
# workflow publishes 1.0.0
```

Then on coffey.codes (one last `npm install ...@latest`):

```bash
npm install @anthonycoffey/periscope@latest --save-dev
npx periscope --version    # 1.0.0
```

After that one install, every future periscope release reaches coffey.codes via plain `npm update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)