### PR TITLE
fix(periscope): read --version from package.json at runtime [1.0.1]

### DIFF
--- a/tooling/periscope/package-lock.json
+++ b/tooling/periscope/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonycoffey/periscope",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@google-analytics/data": "^5.2.2",

--- a/tooling/periscope/package.json
+++ b/tooling/periscope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonycoffey/periscope",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SEO data tooling: pull GSC/GA4/Bing/Ads snapshots, diff them, run keyword research. A unified CLI over a set of project-configurable engines.",
   "type": "module",
   "license": "MIT",

--- a/tooling/periscope/src/cli.ts
+++ b/tooling/periscope/src/cli.ts
@@ -6,6 +6,9 @@
  * `node tooling/periscope/dist/cli.js <command>` during local development.
  */
 
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 
 import { runAuditArticles } from './commands/audit-articles.js';
@@ -16,12 +19,28 @@ import { runProbe } from './commands/probe.js';
 import { runSnapshot } from './commands/snapshot.js';
 import { runValidateLps } from './commands/validate-lps.js';
 
+/**
+ * Read the package version from package.json at runtime. dist/cli.js sits
+ * one level below the package root, so `../package.json` works whether
+ * installed in node_modules or run from the source repo's dist/.
+ */
+function readPackageVersion(): string {
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const pkgPath = path.resolve(here, '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version?: string };
+    return pkg.version ?? '0.0.0-unknown';
+  } catch {
+    return '0.0.0-unknown';
+  }
+}
+
 const program = new Command();
 
 program
   .name('periscope')
   .description('SEO data tooling: pull snapshots, diff them, run keyword research.')
-  .version('0.1.0');
+  .version(readPackageVersion());
 
 // ---------------------------------------------------------------------------
 // snapshot


### PR DESCRIPTION
## Summary

`periscope --version` was hardcoded to `0.1.0` in `src/cli.ts` and I forgot to bump it alongside the 0.2.0 and 1.0.0 releases. Reading from package.json at runtime fixes this once.

## What was wrong

```ts
program.version('0.1.0');  // hardcoded, drifted from package.json
```

Even after `npm install @anthonycoffey/periscope@1.0.0`, `periscope --version` reported `0.1.0`. The package itself was correctly at 1.0.0 — only the cosmetic `--version` output was wrong.

## Fix

```ts
function readPackageVersion(): string {
  try {
    const here = path.dirname(fileURLToPath(import.meta.url));
    const pkgPath = path.resolve(here, '..', 'package.json');
    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version?: string };
    return pkg.version ?? '0.0.0-unknown';
  } catch {
    return '0.0.0-unknown';
  }
}

program.version(readPackageVersion());
```

`dist/cli.js` sits one level below the package root (`dist/cli.js` → `../package.json`), so the relative resolve works whether running from `node_modules/@anthonycoffey/periscope/` or from `tooling/periscope/dist/` during development.

The try/catch fails safe to `0.0.0-unknown` rather than crashing — relevant if some odd consumer setup unlinks the package.json.

## Verification

```
$ node dist/cli.js --version
1.0.1
```

- typecheck ✅
- 36/36 tests passing ✅

## After merge

```bash
git tag periscope-v1.0.1
git push origin periscope-v1.0.1
```

Then on coffey.codes (now plain `npm update` works, since you're already on `^1.0.0`):

```bash
npm update @anthonycoffey/periscope
npx periscope --version    # 1.0.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)