### PR TITLE
feat: portfolio /[slug] route + periscope landing + 1.1.0 doc refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ SEO tooling (via `@anthonycoffey/periscope` from GitHub Packages, see Setup belo
 
 ```bash
 npm run seo:snapshot         # Pull multi-engine snapshot
-npm run seo:diff             # Diff two snapshot JSONs
+npm run seo:diff -- yesterday # Diff snapshots; accepts NL refs (yesterday/7d/"last month"/YYYY-MM-DD) or .json paths
 npm run seo:audit-articles   # Flag article keyword fit
 npm run seo:discover-topics  # Editorial backlog from Ads + GSC
 npm run seo:validate-lps     # Validate LP keyword targets

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ All SEO data work runs through **[`@anthonycoffey/periscope`](https://github.com
 | Command | What it does |
 | --- | --- |
 | `npm run seo:snapshot` | Pull all four engines into a dated JSON + Markdown pair in `docs/strategy/data/` |
-| `npm run seo:diff` | Diff two snapshots; per-engine deltas, movers, fallers (TTY-colored) |
+| `npm run seo:diff -- <ref>` | Diff snapshots with natural refs (`yesterday`, `7d`, `"last month"`, `YYYY-MM-DD`) or `.json` paths. `newer` defaults to latest. |
 | `npm run seo:audit-articles` | Flag articles ranking on long-tails where Ads suggests a higher-volume term |
 | `npm run seo:discover-topics` | Ranked editorial backlog of fresh keyword ideas (drops topics already covered) |
 | `npm run seo:validate-lps` | Verdict per `app/lp/*` page: `WELL_TARGETED` / `UNDER_INVESTED` / `OVER_AMBITIOUS` |
@@ -222,6 +222,16 @@ All SEO data work runs through **[`@anthonycoffey/periscope`](https://github.com
 | `npm run seo:doctor` | Diagnose engine credentials and access (currently Google Ads) |
 
 Common flags pass through after `--`, e.g. `npm run seo:snapshot -- --engines=gsc --window=180 --asof=2026-05-09`.
+
+A few diff examples:
+
+```bash
+npm run seo:diff -- yesterday                # latest vs yesterday
+npm run seo:diff -- 7d                       # latest vs 7 days ago
+npm run seo:diff -- "last month"             # latest vs ~30 days ago
+npm run seo:diff -- 2026-05-10               # latest vs explicit date
+npm run seo:diff -- 2026-05-10 2026-05-17    # both explicit
+```
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,49 @@ npm lint            # ESLint
 npm lint:fix        # ESLint auto-fix
 ```
 
+---
+
+## 🔭 Periscope — SEO Management
+
+All SEO data work runs through **[`@anthonycoffey/periscope`](https://github.com/anthonycoffey/periscope)**, a TypeScript CLI that unifies Google Search Console, GA4, Bing Webmaster Tools, and Google Ads Keyword Planner under a single command surface. Originally incubated in this repo at `tooling/periscope/` (driven by SPEC-018, 019, 020, 023), extracted to its own home in 2026-05.
+
+### Commands
+
+| Command | What it does |
+| --- | --- |
+| `npm run seo:snapshot` | Pull all four engines into a dated JSON + Markdown pair in `docs/strategy/data/` |
+| `npm run seo:diff` | Diff two snapshots; per-engine deltas, movers, fallers (TTY-colored) |
+| `npm run seo:audit-articles` | Flag articles ranking on long-tails where Ads suggests a higher-volume term |
+| `npm run seo:discover-topics` | Ranked editorial backlog of fresh keyword ideas (drops topics already covered) |
+| `npm run seo:validate-lps` | Verdict per `app/lp/*` page: `WELL_TARGETED` / `UNDER_INVESTED` / `OVER_AMBITIOUS` |
+| `npm run seo:probe -- <url>` | One-shot competitor URL probe — top 30 keyword ideas to stdout |
+| `npm run seo:doctor` | Diagnose engine credentials and access (currently Google Ads) |
+
+Common flags pass through after `--`, e.g. `npm run seo:snapshot -- --engines=gsc --window=180 --asof=2026-05-09`.
+
+### Configuration
+
+Project-specific values live in `periscope.config.mjs` at the repo root (siteUrl, GA4 property, article and LP dirs, categories, bot regions). Engine credentials come from `.env` / `.env.local`.
+
+### One-time setup
+
+1. Generate a GitHub PAT with **only** `read:packages` scope at https://github.com/settings/tokens.
+2. Set the env var: `setx GITHUB_PACKAGES_TOKEN "ghp_yourTokenHere"` (open a new terminal after).
+3. `.npmrc` is already committed (with env-var interpolation, no secrets). `npm install` will resolve `@anthonycoffey/periscope` from GitHub Packages.
+4. Verify: `npx periscope --version` and `npx periscope --help`.
+
+Engine setup (Google service account, Bing API key, Google Ads dev token) is documented in [docs/documentation/guides/seo-snapshot-setup.md](./docs/documentation/guides/seo-snapshot-setup.md). When something auth-related goes sideways, `npm run seo:doctor` pinpoints the exact misconfiguration.
+
+### Updating
+
+```bash
+npm update @anthonycoffey/periscope
+```
+
+Plain `npm update` works because periscope follows semver from 1.0.0.
+
+---
+
 ## 👨‍💻 Author
 
 **Anthony Coffey**

--- a/app/(site)/portfolio/[slug]/page.tsx
+++ b/app/(site)/portfolio/[slug]/page.tsx
@@ -1,0 +1,251 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import {
+  ArrowTopRightOnSquareIcon,
+  CodeBracketSquareIcon,
+  TagIcon,
+} from '@heroicons/react/24/outline';
+
+import Breadcrumbs from '@/components/Breadcrumbs';
+import GoBack from '@/components/GoBack';
+import { CustomMDX } from '@/components/mdx';
+import { baseUrl } from '@/app/sitemap';
+import { formatDate } from '@/utils/date';
+import {
+  getAllPortfolioItems,
+  getPortfolioItem,
+} from '@/app/(site)/portfolio/utils';
+
+// Avoid the "missing timezone" warning Google's Rich Results Test
+// emits for date-only schema.org datePublished/dateModified values.
+function toIsoDatetime(value: string): string {
+  return value.includes('T') ? value : `${value}T00:00:00.000Z`;
+}
+
+export async function generateStaticParams() {
+  return getAllPortfolioItems().map((item) => ({ slug: item.slug }));
+}
+
+interface PageParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: PageParams) {
+  const { slug } = await params;
+  const item = getPortfolioItem(slug);
+  if (!item) return;
+
+  const { title, summary, mainImage, tags } = item.metadata;
+  const ogImage = mainImage
+    ? `${baseUrl}${mainImage}`
+    : `${baseUrl}/og?title=${encodeURIComponent(title)}&category=${encodeURIComponent('Portfolio')}`;
+
+  return {
+    title,
+    description: summary,
+    keywords: tags?.join(', '),
+    alternates: { canonical: `/portfolio/${slug}` },
+    openGraph: {
+      title,
+      description: summary,
+      type: 'article',
+      url: `${baseUrl}/portfolio/${slug}`,
+      images: [{ url: ogImage }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description: summary,
+      images: [ogImage],
+    },
+  };
+}
+
+export default async function PortfolioItemPage({ params }: PageParams) {
+  const { slug } = await params;
+  const item = getPortfolioItem(slug);
+  if (!item) notFound();
+
+  const { metadata } = item;
+  const datePublishedIso = toIsoDatetime(metadata.publishedAt);
+  const dateModifiedIso = toIsoDatetime(
+    metadata.updated ?? item.mtime ?? metadata.publishedAt,
+  );
+
+  return (
+    <>
+      {/* schema.org structured data */}
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'CreativeWork',
+            name: metadata.title,
+            description: metadata.summary,
+            url: `${baseUrl}/portfolio/${slug}`,
+            datePublished: datePublishedIso,
+            dateModified: dateModifiedIso,
+            image: metadata.mainImage
+              ? `${baseUrl}${metadata.mainImage}`
+              : undefined,
+            author: {
+              '@type': 'Person',
+              name: 'Anthony Coffey',
+              url: baseUrl,
+            },
+            keywords: metadata.tags?.join(', '),
+            ...(metadata.repo && {
+              codeRepository: metadata.repo,
+            }),
+          }),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BreadcrumbList',
+            itemListElement: [
+              { '@type': 'ListItem', position: 1, name: 'Home', item: baseUrl },
+              {
+                '@type': 'ListItem',
+                position: 2,
+                name: 'Portfolio',
+                item: `${baseUrl}/portfolio`,
+              },
+              {
+                '@type': 'ListItem',
+                position: 3,
+                name: metadata.title,
+                item: `${baseUrl}/portfolio/${slug}`,
+              },
+            ],
+          }),
+        }}
+      />
+
+      <Breadcrumbs title={metadata.title} />
+
+      <section className="bg-surface border border-border rounded-lg shadow-sm px-6 sm:px-10 pt-6 sm:pt-8 pb-4 sm:pb-6">
+        {/* Header */}
+        <div className="flex items-start gap-3 mb-2">
+          <CodeBracketSquareIcon className="h-8 w-8 text-link flex-shrink-0 mt-1" />
+          <h1
+            className="title font-editorial font-bold text-3xl sm:text-4xl text-c-heading"
+            style={{ letterSpacing: '0.005em' }}
+          >
+            {metadata.title}
+          </h1>
+        </div>
+
+        <p className="text-lg text-c-muted mt-2 mb-4 leading-relaxed">
+          {metadata.summary}
+        </p>
+
+        {/* Tag chips + meta row */}
+        <div className="flex flex-wrap items-center gap-2 mb-4 text-sm text-c-muted">
+          {metadata.client && (
+            <span className="inline-flex items-center gap-1">
+              <span className="font-semibold text-c-text">Client:</span>
+              {metadata.client}
+            </span>
+          )}
+          {metadata.client && metadata.year && (
+            <span className="text-c-muted">·</span>
+          )}
+          {metadata.year && (
+            <span className="inline-flex items-center gap-1">
+              <span className="font-semibold text-c-text">Year:</span>
+              {metadata.year}
+            </span>
+          )}
+          <span className="text-c-muted">·</span>
+          <time dateTime={metadata.publishedAt} itemProp="datePublished">
+            Updated {formatDate(metadata.updated ?? metadata.publishedAt)}
+          </time>
+        </div>
+
+        {metadata.tags && metadata.tags.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-4">
+            {metadata.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center gap-1 bg-accent2 text-c-heading text-xs font-semibold px-2.5 py-1 rounded-full"
+              >
+                <TagIcon className="h-3 w-3" />
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Action buttons */}
+        {(metadata.link || metadata.repo) && (
+          <div className="flex flex-wrap gap-3 mb-6">
+            {metadata.link && (
+              <a
+                href={metadata.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 bg-accent1-dark text-white text-sm font-semibold px-4 py-2 rounded-lg hover:opacity-90 transition-opacity"
+              >
+                <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                View live
+              </a>
+            )}
+            {metadata.repo && (
+              <a
+                href={metadata.repo}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 bg-surface border border-border text-c-text text-sm font-semibold px-4 py-2 rounded-lg hover:bg-bg-alt transition-colors"
+              >
+                <CodeBracketSquareIcon className="h-4 w-4" />
+                Source repository
+              </a>
+            )}
+          </div>
+        )}
+
+        {/* Hero image */}
+        {metadata.mainImage && (
+          <div className="rounded-lg overflow-hidden border border-border mb-6 bg-bg-alt">
+            <Image
+              src={metadata.mainImage}
+              alt={metadata.title}
+              width={1600}
+              height={900}
+              sizes="(max-width: 1024px) 100vw, 80vw"
+              className="w-full h-auto object-cover"
+              priority
+            />
+          </div>
+        )}
+
+        <hr className="my-6 border-border" />
+
+        {/* MDX body */}
+        <article className="prose prose-lg xl:prose-xl max-w-none dark:prose-invert">
+          <CustomMDX source={item.content} />
+        </article>
+
+        {/* Footer: navigate back */}
+        <div className="mt-10">
+          <Link
+            href="/portfolio"
+            className="inline-flex items-center gap-2 text-link hover:underline text-sm"
+          >
+            ← Back to portfolio
+          </Link>
+        </div>
+
+        <GoBack />
+      </section>
+    </>
+  );
+}

--- a/app/(site)/portfolio/items/periscope.mdx
+++ b/app/(site)/portfolio/items/periscope.mdx
@@ -1,0 +1,116 @@
+---
+title: Periscope — SEO Data Tooling
+summary: A TypeScript CLI that unifies Google Search Console, GA4, Bing Webmaster Tools, and Google Ads Keyword Planner into a single local snapshot for editorial and landing-page decisions.
+publishedAt: 2026-05-17
+updated: 2026-05-17
+tags: [TypeScript, CLI, Google Ads API, GSC, GA4, Bing Webmaster Tools, SEO, npm]
+mainImage: /portfolio/periscope/hero.png
+link: https://github.com/anthonycoffey/coffey.codes/tree/main#-periscope--seo-management
+repo: https://github.com/anthonycoffey/periscope
+client: Personal / Internal Tool
+year: 2026
+featured: true
+category: Open Source / SEO Tooling
+---
+
+## What it is
+
+**Periscope** is an internal command-line tool I built for SEO research across my own websites and a small number of client sites. It unifies data from Google Search Console, Google Analytics 4, Bing Webmaster Tools, and the **Google Ads API (Keyword Planner)** into a single local snapshot, so I can make editorial and landing-page decisions from one source.
+
+The project is distributed as a **private npm package** on GitHub Packages (`@anthonycoffey/periscope`). It is not a SaaS product, has no end users beyond the developer, and does not resell, share, or expose Google data to third parties.
+
+## How Periscope uses the Google Ads API
+
+Periscope calls the Google Ads API solely to retrieve **keyword ideas and historical search-volume metrics** from the Keyword Planner. Specifically, it uses the `KeywordPlanIdeaService` and invokes exactly two methods, both read-only:
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `generateKeywordIdeas` | `POST /v21/customers/{customerId}:generateKeywordIdeas` | Seed-based keyword expansion (keywords, URL, or both) |
+| `generateKeywordHistoricalMetrics` | `POST /v21/customers/{customerId}:generateKeywordHistoricalMetrics` | Average monthly volume, competition, and CPC bid range for a keyword set |
+
+Periscope does **not** call any other Google Ads API service. It does not create, read, update, or delete campaigns, ad groups, ads, budgets, conversions, audiences, or billing data. It performs zero mutations of any kind on the Google Ads account.
+
+## CLI commands that consume the Ads API
+
+| Command | Use of Ads API |
+| --- | --- |
+| `periscope snapshot` | Pulls Keyword Planner volume + competition for the configured keyword set |
+| `periscope discover topics` | Seeds Keyword Planner with category names + top GSC queries to surface gaps |
+| `periscope audit articles` | Compares MDX article keywords against Keyword Planner metrics |
+| `periscope validate lps` | Validates `/lp/*` landing pages against Keyword Planner demand |
+| `periscope probe <url>` | One-shot URL-seeded keyword ideas for a competitor URL |
+| `periscope doctor ads` | Diagnostic that verifies credentials and API reachability |
+
+## Authentication
+
+Periscope authenticates to the Google Ads API using a Google Cloud **service account** with a developer token. Credentials are read from environment variables on the developer's local machine:
+
+- `GOOGLE_ADS_DEVELOPER_TOKEN`
+- `GOOGLE_ADS_LOGIN_CUSTOMER_ID` (Manager account)
+- `GOOGLE_ADS_CUSTOMER_ID`
+- `GSC_SERVICE_ACCOUNT_KEY_PATH` or `GSC_SERVICE_ACCOUNT_JSON` (reused for GSC, GA4, and Ads)
+
+**No OAuth user consent flow is involved.** No end-user credentials are collected, stored, or proxied.
+
+## Data handling
+
+- **Scope:** Read-only access to Keyword Planner data for the developer's own Manager-account-linked accounts.
+- **Storage:** Responses are written to a local `outputDir` on the developer's machine as JSON and Markdown snapshots. Nothing is uploaded to any third-party service.
+- **Sharing:** Data is not shared with, sold to, or exposed to any third party. There are no end users.
+- **Retention:** Snapshots are retained locally at the developer's discretion and can be deleted at any time.
+- **Compliance:** Use complies with the Google Ads API Terms of Service, including the Required Minimum Functionality requirements for tools that surface Keyword Planner data.
+
+## Call volume
+
+Call volume is **low** — on the order of dozens to low hundreds of requests per day, invoked manually from the CLI during editorial reviews. There is no automated continuous polling.
+
+## Architecture
+
+| Layer | Tech | Notes |
+| --- | --- | --- |
+| Language | TypeScript (strict) | Compiled to ESM via `tsup`; typed snapshot JSON contracts |
+| CLI parser | `commander` | Nested subcommands, `--help` per command with examples |
+| Engine modules | `src/engines/{gsc,ga4,bing,ads}.ts` | One file per upstream API |
+| Lib | `src/lib/*.ts` | Auth, bucket math, markdown renderer, zod config loader, ANSI colors, snapshot store, NL date resolver |
+| Tests | `vitest` | 56 unit tests covering bucket math, config schema, frontmatter parser, color helpers, diagnostics, snapshot ref resolution |
+| Distribution | GitHub Packages | Private npm package `@anthonycoffey/periscope`, published via tag-triggered workflow |
+
+The engine code is project-agnostic: each engine takes its config explicitly (`siteUrl`, `propertyId`, `apiKey`, `botRegions`) rather than reading env vars itself. The orchestrator command reads env vars and a `periscope.config.mjs` from the consumer repo and threads them through. That means the same package serves any number of consumer projects, each with its own config.
+
+## Command surface
+
+```bash
+# Pull a multi-engine snapshot
+periscope snapshot
+periscope snapshot --engines=gsc,ga4 --window=180 --asof=2026-05-09
+
+# Diff two snapshots with natural-language refs (new in 1.1)
+periscope diff yesterday                      # latest vs yesterday
+periscope diff 7d                             # latest vs 7 days ago
+periscope diff "last month"                   # latest vs ~30 days ago
+periscope diff 2026-05-10 2026-05-17          # explicit both sides
+
+# Keyword research (all use the Ads Keyword Planner)
+periscope discover topics
+periscope audit articles
+periscope validate lps
+periscope probe <url>
+
+# Diagnostic
+periscope doctor ads
+```
+
+## What's next
+
+- **Ahrefs engine** as a fifth data source ([SPEC-022](https://github.com/anthonycoffey/coffey.codes/blob/main/docs/specs/active/SPEC-022-ahrefs-snapshot-engine.md))
+- A `periscope-lite` open-source build for community contributions
+- Additional `doctor` modules for GSC and GA4 access checks
+
+## Project history
+
+Periscope incubated inside the `coffey.codes` monorepo at `tooling/periscope/` (driven by [SPEC-018](https://github.com/anthonycoffey/coffey.codes/blob/main/docs/specs/archive/SPEC-018-multi-engine-snapshot.md), [SPEC-019](https://github.com/anthonycoffey/coffey.codes/blob/main/docs/specs/archive/SPEC-019-keyword-volume-in-snapshot.md), [SPEC-020](https://github.com/anthonycoffey/coffey.codes/blob/main/docs/specs/archive/SPEC-020-keyword-research-tools.md), and [SPEC-023](https://github.com/anthonycoffey/coffey.codes/blob/main/docs/specs/archive/SPEC-023-periscope-tool-suite.md)). It was extracted to its own repo in May 2026 and published as `@anthonycoffey/periscope@1.0.0`. The current release is `1.1.0`, which adds natural-language refs to the `diff` command.
+
+## Contact
+
+- Developer contact: `ads-api@coffey.codes`
+- Source: [github.com/anthonycoffey/periscope](https://github.com/anthonycoffey/periscope) (private GitHub Packages scope: `@anthonycoffey`)

--- a/app/(site)/portfolio/page.tsx
+++ b/app/(site)/portfolio/page.tsx
@@ -12,6 +12,7 @@ import {
   CodeBracketSquareIcon,
   XMarkIcon,
 } from '@heroicons/react/24/solid';
+import Link from 'next/link';
 import RetroWindow from '@/components/ui/RetroWindow';
 import Button from '@/components/ui/Button';
 import PageHeader from '@/components/PageHeader';
@@ -33,10 +34,47 @@ interface Project {
   results: string[];
   year: string;
   featured: boolean;
+  /**
+   * When set, the card is a Next.js Link to /portfolio/<slug> instead of
+   * a modal-opener. Projects with their own MDX item file should set this.
+   * Modal-based projects continue to work as before for back-compat.
+   */
+  slug?: string;
 }
 
 const PortfolioSection: React.FC = () => {
   const portfolioProjects: Project[] = [
+    {
+      id: 0,
+      title: 'Periscope — SEO Data Tooling',
+      description:
+        'TypeScript CLI that unifies GSC, GA4, Bing Webmaster Tools, and Google Ads Keyword Planner into a single local snapshot.',
+      tags: [
+        'TypeScript',
+        'CLI',
+        'Google Ads API',
+        'GSC',
+        'GA4',
+        'Bing Webmaster',
+      ],
+      mainImage: '/portfolio/periscope/hero.png',
+      gallery: [],
+      link: 'https://github.com/anthonycoffey/periscope',
+      client: 'Personal / Internal Tool',
+      challenge:
+        'Pulling SEO data from four different APIs into a coherent editorial workflow without committing to any single vendor dashboard.',
+      solution:
+        'A typed, config-driven TypeScript CLI distributed as a private npm package. One snapshot file per pull, paired JSON + Markdown.',
+      results: [
+        'Single CLI surface across four upstream APIs',
+        'Diff command with natural-language refs (yesterday, 7d, last month)',
+        'Diagnostic command for credentials and access checks',
+        '56 unit tests',
+      ],
+      year: '2026',
+      featured: true,
+      slug: 'periscope',
+    },
     {
       id: 1,
       title: 'Personal Blog & Portfolio',
@@ -175,55 +213,81 @@ const PortfolioSection: React.FC = () => {
 
       {/* Polaroid grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-10 mb-12">
-        {displayedProjects.map((project, i) => (
-          <div
-            key={project.id}
-            className="polaroid-card vhs-card cursor-pointer"
-            style={
-              {
-                '--card-tilt': `${tiltAngles[i % tiltAngles.length]}deg`,
-              } as React.CSSProperties
-            }
-            onClick={() => openProject(project)}
-          >
-            <div className="h-56 overflow-hidden">
-              <Image
-                width={1200}
-                height={1200}
-                src={project.mainImage}
-                alt={project.title}
-                sizes="(max-width: 768px) 100vw, 50vw"
-                className="w-full h-full object-cover"
-              />
-            </div>
-            <div className="pt-3 px-1">
-              <h3 className="font-outfit text-lg font-bold text-c-heading mb-1">
-                {project.title}
-              </h3>
-              <p className="text-c-muted text-sm mb-3">{project.description}</p>
-              <div className="flex flex-wrap gap-1 mb-3">
-                {project.tags.map((tag, idx) => (
-                  <span
-                    key={idx}
-                    className="bg-accent2 text-c-heading text-xs font-semibold px-2 py-0.5 rounded-full"
-                  >
-                    {tag}
+        {displayedProjects.map((project, i) => {
+          const cardStyle = {
+            '--card-tilt': `${tiltAngles[i % tiltAngles.length]}deg`,
+          } as React.CSSProperties;
+
+          const cardInner = (
+            <>
+              <div className="h-56 overflow-hidden">
+                <Image
+                  width={1200}
+                  height={1200}
+                  src={project.mainImage}
+                  alt={project.title}
+                  sizes="(max-width: 768px) 100vw, 50vw"
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <div className="pt-3 px-1">
+                <h3 className="font-outfit text-lg font-bold text-c-heading mb-1">
+                  {project.title}
+                </h3>
+                <p className="text-c-muted text-sm mb-3">
+                  {project.description}
+                </p>
+                <div className="flex flex-wrap gap-1 mb-3">
+                  {project.tags.map((tag, idx) => (
+                    <span
+                      key={idx}
+                      className="bg-accent2 text-c-heading text-xs font-semibold px-2 py-0.5 rounded-full"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <div className="flex justify-between text-xs text-c-muted">
+                  <span className="flex items-center gap-1">
+                    <UserIcon className="h-3 w-3" />
+                    {project.client}
                   </span>
-                ))}
+                  <span className="flex items-center gap-1">
+                    <ClockIcon className="h-3 w-3" />
+                    {project.year}
+                  </span>
+                </div>
               </div>
-              <div className="flex justify-between text-xs text-c-muted">
-                <span className="flex items-center gap-1">
-                  <UserIcon className="h-3 w-3" />
-                  {project.client}
-                </span>
-                <span className="flex items-center gap-1">
-                  <ClockIcon className="h-3 w-3" />
-                  {project.year}
-                </span>
-              </div>
+            </>
+          );
+
+          // Projects with a `slug` navigate to a dedicated page. Others
+          // still open the modal -- the older portfolio entries haven't
+          // been migrated to MDX yet.
+          if (project.slug) {
+            return (
+              <Link
+                key={project.id}
+                href={`/portfolio/${project.slug}`}
+                className="polaroid-card vhs-card cursor-pointer block"
+                style={cardStyle}
+              >
+                {cardInner}
+              </Link>
+            );
+          }
+
+          return (
+            <div
+              key={project.id}
+              className="polaroid-card vhs-card cursor-pointer"
+              style={cardStyle}
+              onClick={() => openProject(project)}
+            >
+              {cardInner}
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Modal */}

--- a/app/(site)/portfolio/utils.ts
+++ b/app/(site)/portfolio/utils.ts
@@ -1,0 +1,161 @@
+/**
+ * Portfolio item loader.
+ *
+ * Mirrors the pattern in app/(site)/articles/utils.ts: each portfolio
+ * item is an MDX file under app/(site)/portfolio/items/<slug>.mdx with
+ * frontmatter for metadata and an MDX body.
+ *
+ * Used by the dynamic route at app/(site)/portfolio/[slug]/page.tsx
+ * and (for hard-coded fallbacks) by the listing at app/(site)/portfolio/page.tsx.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface PortfolioMetadata {
+  /** Display title, used in <h1> and metadata. */
+  title: string;
+  /** One-sentence summary. Used in card descriptions, OG, meta description. */
+  summary: string;
+  /** ISO date when the item was published / last updated. */
+  publishedAt: string;
+  /** Optional explicit update date. */
+  updated?: string;
+  /** Tech stack chips. */
+  tags?: string[];
+  /** Main hero / card image, path under /public. */
+  mainImage?: string;
+  /** Additional screenshots. */
+  gallery?: string[];
+  /** Primary external link (live demo, repo). */
+  link?: string;
+  /** Source code repo (optional second link distinct from `link`). */
+  repo?: string;
+  /** Client or "Personal Project". */
+  client?: string;
+  /** Year (for the card grid). */
+  year?: string;
+  /** Whether to feature on listing pages. */
+  featured?: boolean;
+  /** Optional category, e.g. "Open Source", "Client Work". */
+  category?: string;
+}
+
+export interface PortfolioItem {
+  slug: string;
+  metadata: PortfolioMetadata;
+  content: string;
+  mtime?: string;
+}
+
+const ITEMS_DIR = path.join(
+  process.cwd(),
+  'app',
+  '(site)',
+  'portfolio',
+  'items',
+);
+
+function parseFrontmatter(raw: string): {
+  metadata: PortfolioMetadata;
+  content: string;
+} {
+  const fmRegex = /---\s*([\s\S]*?)\s*---/;
+  const match = fmRegex.exec(raw);
+  if (!match) {
+    throw new Error('Portfolio item: no frontmatter block found');
+  }
+  const fmBlock = match[1] ?? '';
+  const content = raw.replace(fmRegex, '').trim();
+
+  const metadata: Partial<PortfolioMetadata> = {};
+
+  // Simple parser: key: value per line. Tags + gallery are comma-separated.
+  // featured is boolean.
+  for (const line of fmBlock.trim().split('\n')) {
+    const sep = line.indexOf(':');
+    if (sep === -1) continue;
+    const key = line.slice(0, sep).trim();
+    let value = line.slice(sep + 1).trim();
+    // Strip surrounding single/double quotes
+    value = value.replace(/^['"](.*)['"]$/, '$1');
+
+    switch (key) {
+      case 'tags':
+        metadata.tags = value
+          .replace(/^\[|\]$/g, '')
+          .split(',')
+          .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+          .filter(Boolean);
+        break;
+      case 'gallery':
+        metadata.gallery = value
+          .replace(/^\[|\]$/g, '')
+          .split(',')
+          .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+          .filter(Boolean);
+        break;
+      case 'featured':
+        metadata.featured = value === 'true';
+        break;
+      case 'title':
+      case 'summary':
+      case 'publishedAt':
+      case 'updated':
+      case 'mainImage':
+      case 'link':
+      case 'repo':
+      case 'client':
+      case 'year':
+      case 'category':
+        (metadata as Record<string, string>)[key] = value;
+        break;
+      default:
+        // Ignore unknown keys
+        break;
+    }
+  }
+
+  if (!metadata.title || !metadata.summary || !metadata.publishedAt) {
+    throw new Error(
+      'Portfolio item: missing required frontmatter (title, summary, publishedAt)',
+    );
+  }
+
+  return { metadata: metadata as PortfolioMetadata, content };
+}
+
+function getMdxFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir).filter((f) => path.extname(f) === '.mdx');
+}
+
+function readItem(filePath: string): {
+  metadata: PortfolioMetadata;
+  content: string;
+  mtime: string;
+} {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const mtime = fs.statSync(filePath).mtime.toISOString();
+  return { ...parseFrontmatter(raw), mtime };
+}
+
+/** All portfolio items, sorted by publishedAt descending. */
+export function getAllPortfolioItems(): PortfolioItem[] {
+  return getMdxFiles(ITEMS_DIR)
+    .map((file): PortfolioItem => {
+      const { metadata, content, mtime } = readItem(path.join(ITEMS_DIR, file));
+      const slug = path.basename(file, '.mdx');
+      return { slug, metadata, content, mtime };
+    })
+    .sort((a, b) => {
+      const ad = new Date(a.metadata.publishedAt).getTime();
+      const bd = new Date(b.metadata.publishedAt).getTime();
+      return bd - ad;
+    });
+}
+
+/** Single item by slug; null when not found. */
+export function getPortfolioItem(slug: string): PortfolioItem | null {
+  return getAllPortfolioItems().find((p) => p.slug === slug) ?? null;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,6 +4,7 @@ import {
   getAllTags,
 } from '@/app/(site)/articles/utils';
 import { caseStudies } from '@/app/(site)/case-studies/case-studies';
+import { getAllPortfolioItems } from '@/app/(site)/portfolio/utils';
 
 export const baseUrl = 'https://coffey.codes';
 
@@ -50,6 +51,13 @@ export default async function sitemap(): Promise<SitemapEntry[]> {
     lastModified: today,
     changeFrequency: 'monthly',
     priority: 0.8,
+  }));
+
+  const portfolioItems: SitemapEntry[] = getAllPortfolioItems().map((item) => ({
+    url: `${baseUrl}/portfolio/${item.slug}`,
+    lastModified: item.metadata.updated ?? item.metadata.publishedAt,
+    changeFrequency: 'monthly',
+    priority: 0.85,
   }));
 
   const staticRoutes: SitemapEntry[] = [
@@ -127,5 +135,6 @@ export default async function sitemap(): Promise<SitemapEntry[]> {
     ...categories,
     ...tags,
     ...caseStudyEntries,
+    ...portfolioItems,
   ];
 }

--- a/docs/documentation/deep-dives/ctr-by-position-baseline.md
+++ b/docs/documentation/deep-dives/ctr-by-position-baseline.md
@@ -115,7 +115,7 @@ mcp__search-console__analytics_query
 
 Then bucket rows by `round(position)` and sum `clicks` / `impressions` per bucket.
 
-The `scripts/seo-snapshot.mjs` script (also from SPEC-016) writes the raw CSV to `docs/strategy/data/` so this analysis can be re-done from a frozen snapshot rather than a live pull.
+The `periscope snapshot` command (originally SPEC-016, now part of [@anthonycoffey/periscope](https://github.com/anthonycoffey/periscope)) writes the raw CSV to `docs/strategy/data/` so this analysis can be re-done from a frozen snapshot rather than a live pull.
 
 ## Limitations
 

--- a/docs/documentation/deep-dives/onpage-seo-strategy.md
+++ b/docs/documentation/deep-dives/onpage-seo-strategy.md
@@ -117,7 +117,7 @@ Two tools, both safe to run repeatedly:
 - **Google Rich Results Test**: https://search.google.com/test/rich-results
 - **schema.org validator**: https://validator.schema.org/
 
-The SEO snapshot script (`scripts/seo-snapshot.mjs`) also invokes `mcp__search-console__schema_validate` for top-clicked pages as part of the quarterly audit (see SPEC-015 plan).
+The `periscope snapshot` command (in [@anthonycoffey/periscope](https://github.com/anthonycoffey/periscope), originally part of SPEC-015) also invokes `mcp__search-console__schema_validate` for top-clicked pages as part of the quarterly audit.
 
 ## Related docs
 

--- a/docs/documentation/guides/seo-snapshot-setup.md
+++ b/docs/documentation/guides/seo-snapshot-setup.md
@@ -184,9 +184,18 @@ The reports use the bucket order `<100 < 100-1K < 1K-10K < 10K-100K < 100K+` and
 
 ## Diffing snapshots
 
+Periscope's `diff` command accepts natural-language refs (`yesterday`, `7d`, `"last month"`, `YYYY-MM-DD`) on either side, plus `.json` paths for the legacy form. The `newer` arg is optional and defaults to the latest snapshot in `outputDir`.
+
 ```powershell
-npm run seo:diff -- <older.json> <newer.json>
+npm run seo:diff -- yesterday                       # latest vs yesterday
+npm run seo:diff -- 7d                              # latest vs 7 days ago
+npm run seo:diff -- "last month"                    # latest vs ~30 days ago
+npm run seo:diff -- 2026-05-10                      # latest vs explicit date
+npm run seo:diff -- 2026-05-10 2026-05-17           # both explicit
+npm run seo:diff -- <older.json> <newer.json>       # legacy path form
 ```
+
+If the requested date has no exact snapshot, periscope falls back to the nearest available snapshot whose date is ≤ the target and prints a `note:` line explaining the substitution. A summary panel at the end lists every snapshot available in `outputDir` so you can see what dates exist without `ls`-ing the directory.
 
 Prints per-engine totals delta, top-page click delta, new entrants (queries with >=5 impressions absent from older), and fallers (>30% impression drop). When stdout is a TTY, output is colored and box-bordered; piped output strips back to plain text.
 

--- a/docs/documentation/guides/seo-tooling-inventory.md
+++ b/docs/documentation/guides/seo-tooling-inventory.md
@@ -49,14 +49,16 @@ Two files per run, same date stem:
 
 ### `periscope diff`
 
-Diffs two snapshot JSONs. Surfaces:
+Diffs two snapshots. Accepts natural-language refs (`yesterday`, `7d`, `"last month"`, `YYYY-MM-DD`) or `.json` paths on either side; `newer` defaults to the latest snapshot in `outputDir`. Falls back to nearest snapshot ≤ target when an exact date isn't present, with a `note:` line surfacing the substitution. Closes with a summary panel showing what got resolved, every snapshot date available in `outputDir`, and example commands.
+
+Surfaces per engine:
 
 - Per-engine totals delta
 - Top-page click delta
 - New entrants (queries with >=5 impressions absent from older snapshot)
 - Fallers (>30% impression drop)
 
-TTY-colored when stdout is a terminal, plain text when piped. Reuses `src/lib/colors.ts` for the ANSI helpers shared with `probe`.
+TTY-colored when stdout is a terminal, plain text when piped. Reuses `src/lib/colors.ts` for the ANSI helpers shared with `probe`. NLP ref resolution lives in `src/lib/snapshot-refs.ts` (introduced in periscope 1.1.0).
 
 ## Keyword research
 

--- a/docs/documentation/repos/coffey-codes.md
+++ b/docs/documentation/repos/coffey-codes.md
@@ -170,18 +170,22 @@ JSON-LD is emitted across the site to give Google's Knowledge Graph and other cr
 
 ## SEO data pipeline
 
-`scripts/seo-snapshot.mjs` (SPEC-018 + SPEC-019) pulls Google Search Console, GA4, Bing Webmaster Tools, and Google Ads Keyword Planner into a single dated JSON snapshot in `docs/strategy/data/`, with a frontmatter-tagged Markdown summary (`scripts/lib/snapshot-markdown.mjs`) written alongside the JSON for AI/RAG consumption. `scripts/seo-snapshot-diff.mjs` compares two snapshots and renders a colored, box-bordered terminal report.
+All SEO data work runs through **[@anthonycoffey/periscope](https://github.com/anthonycoffey/periscope)**, a TypeScript package on GitHub Packages. coffey.codes consumes it as a devDependency; project-specific paths and ids come from `periscope.config.mjs` at the repo root. The package source originally lived here at `tooling/periscope/` (driven by SPEC-018, SPEC-019, SPEC-020, SPEC-023); it was extracted to its own repo in 2026-05.
 
-Snapshots are committed to git because GSC's data window is only 16 months and historical data is otherwise lost. Each snapshot is roughly 80-120 KB.
+Six commands cover the workflow:
 
-Four follow-on tools (SPEC-020) consume the snapshot + Google Ads API to produce editorial reports:
+- `periscope snapshot` — pull GSC, GA4, Bing, and Google Ads Keyword Planner into a paired dated JSON + Markdown file in `outputDir` (default `docs/strategy/data/`). The Markdown companion is frontmatter-tagged for AI/RAG consumption.
+- `periscope diff <older> <newer>` — compare two snapshots; colored, box-bordered terminal output.
+- `periscope audit articles` — flag articles ranking on long-tails where Ads suggests a higher-volume term they could target.
+- `periscope discover topics` — ranked editorial backlog of fresh keyword ideas (filters out topics already covered by existing article slugs).
+- `periscope validate lps` — verdict (`WELL_TARGETED` / `UNDER_INVESTED` / `OVER_AMBITIOUS`) per `app/lp/*/page.tsx`.
+- `periscope probe <url>` — one-shot competitor URL probe; stdout-only.
 
-- `scripts/keyword-audit-articles.mjs` — flags articles ranking on long-tails where Ads suggests a higher-volume term they could target
-- `scripts/keyword-discover-topics.mjs` — ranked editorial backlog of fresh keyword ideas (filters out topics already covered by existing slugs)
-- `scripts/keyword-validate-lps.mjs` — verdict (`WELL_TARGETED` / `UNDER_INVESTED` / `OVER_AMBITIOUS`) per `app/lp/*/page.tsx`
-- `scripts/keyword-probe-url.mjs` — one-shot competitor URL probe; stdout-only
+Plus a diagnostic:
 
-All four reuse `scripts/lib/google-ads.mjs` (shared service-account JWT auth, direct REST against `googleads.googleapis.com/v21/`, no `google-ads-api` dep). Customer-ID dashes are stripped automatically. Full setup in [SEO snapshot setup](../guides/seo-snapshot-setup.md).
+- `periscope doctor [engine]` — engine credential + access checks (currently the Ads engine; calls `listAccessibleCustomers` and reports which customer IDs the service account can see). Used to debug 401/403 from the Ads API without leaking the developer token.
+
+All commands invoked via the root `npm run seo:*` scripts. Snapshots are committed to git because GSC's data window is only 16 months and historical data is otherwise lost. Each snapshot is roughly 80-120 KB. Full setup in [SEO snapshot setup](../guides/seo-snapshot-setup.md).
 
 ## Known Issues / Pending Work
 

--- a/docs/specs/active/SPEC-022-ahrefs-snapshot-engine.md
+++ b/docs/specs/active/SPEC-022-ahrefs-snapshot-engine.md
@@ -3,9 +3,10 @@ id: SPEC-022
 title: 'Ahrefs as a fifth snapshot engine (link graph + organic position data)'
 status: draft
 created: 2026-05-14
+updated: 2026-05-17
 author: Anthony Coffey
 reviewers: []
-affected_repos: [coffey.codes]
+affected_repos: [anthonycoffey/periscope, coffey.codes]
 ---
 
 ## Reviewer Notes
@@ -14,7 +15,13 @@ affected_repos: [coffey.codes]
 
 ---
 
-# Feature: Ahrefs engine in `seo-snapshot.mjs`
+# Feature: Ahrefs engine in periscope
+
+## Implementation location
+
+This spec was originally written when periscope (`@anthonycoffey/periscope`) lived inside this repo at `tooling/periscope/`. Periscope has since been extracted to its own repo: **[github.com/anthonycoffey/periscope](https://github.com/anthonycoffey/periscope)**. All engine, lib, and command implementation work happens there. Paths like `src/engines/ads.ts` below refer to the periscope repo, not coffey.codes.
+
+The downstream docs updates — [seo-snapshot-setup.md](../../documentation/guides/seo-snapshot-setup.md), [seo-tooling-inventory.md](../../documentation/guides/seo-tooling-inventory.md), and the [coffey-codes agent brief](../../documentation/agents/coffey-codes.md) — stay in coffey.codes.
 
 ## Problem
 
@@ -31,12 +38,12 @@ Ahrefs has all of this. The Ahrefs MCP is available, but it requires the $129/mo
 
 ### Must have
 
-1. WHEN `scripts/seo-snapshot.mjs` runs with the `ahrefs` engine enabled, it SHALL pull a defined set of fields from Ahrefs and write them to the snapshot JSON under a top-level `ahrefs` key.
+1. WHEN `src/commands/snapshot.ts` runs with the `ahrefs` engine enabled, it SHALL pull a defined set of fields from Ahrefs and write them to the snapshot JSON under a top-level `ahrefs` key.
 2. WHEN the `AHREFS_API_KEY` env var is missing, the engine SHALL skip with a one-line stderr warning, matching the existing engine-skip pattern (no half-broken state).
 3. The Ahrefs engine SHALL be included in the default engine set when its env var is present, and SHALL be selectable via `--engines=ahrefs` for targeted runs.
-4. The snapshot's Markdown companion (`scripts/lib/snapshot-markdown.mjs`) SHALL render an "Ahrefs" section containing headline numbers: domain rating, total referring domains, new/lost refdomains in the window, top 10 organic keywords by traffic, top 10 backlinks by URL rating of source page.
-5. WHEN `scripts/seo-snapshot-diff.mjs` compares two snapshots that both contain Ahrefs data, it SHALL surface: domain rating delta, refdomain delta (new/lost since older snapshot), and any keyword whose position changed by more than 5 ranks.
-6. All Ahrefs API calls SHALL go through a shared client in `scripts/lib/ahrefs.mjs` that handles auth, rate limiting, and response normalization, mirroring the structure of `scripts/lib/google-ads.mjs`.
+4. The snapshot's Markdown companion (`src/lib/markdown.ts`) SHALL render an "Ahrefs" section containing headline numbers: domain rating, total referring domains, new/lost refdomains in the window, top 10 organic keywords by traffic, top 10 backlinks by URL rating of source page.
+5. WHEN `src/commands/diff.ts` compares two snapshots that both contain Ahrefs data, it SHALL surface: domain rating delta, refdomain delta (new/lost since older snapshot), and any keyword whose position changed by more than 5 ranks.
+6. All Ahrefs API calls SHALL go through a shared client in `src/engines/ahrefs.ts` that handles auth, rate limiting, and response normalization, mirroring the structure of `src/engines/ads.ts`.
 7. The Ahrefs engine SHALL respect the existing `--window=<days>` flag for time-bounded queries (refdomains gained/lost, keyword position history).
 
 ### Nice to have
@@ -57,7 +64,7 @@ Ahrefs has all of this. The Ahrefs MCP is available, but it requires the $129/mo
 
 ### Shared library
 
-`scripts/lib/ahrefs.mjs` exports:
+`src/engines/ahrefs.ts` exports:
 
 ```js
 export async function getAhrefsClient()                // returns a configured client from AHREFS_API_KEY
@@ -71,11 +78,11 @@ export async function getAnchors(target, limit)        // for nice-to-have #2
 export async function getLostBacklinks(target, window) // for nice-to-have #3
 ```
 
-Same patterns as `scripts/lib/google-ads.mjs`: thin wrapper over the HTTP API, retry with exponential backoff on 429s, raise on any other non-2xx, normalize the response shape.
+Same patterns as `src/engines/ads.ts`: thin wrapper over the HTTP API, retry with exponential backoff on 429s, raise on any other non-2xx, normalize the response shape.
 
 ### Snapshot integration
 
-`scripts/seo-snapshot.mjs` gains a `pullAhrefs(target, window)` function next to the existing `pullGsc`, `pullGa4`, `pullBing`, `pullKeywords`. The dispatch table in `main()` adds `ahrefs` as a known engine. Order in the JSON output is alphabetical (`ahrefs` first), so existing consumers reading `gsc`/`ga4`/`bing`/`keywords` are unaffected.
+`src/commands/snapshot.ts` gains a `pullAhrefs(target, window)` function next to the existing `pullGsc`, `pullGa4`, `pullBing`, `pullKeywords`. The dispatch table in `main()` adds `ahrefs` as a known engine. Order in the JSON output is alphabetical (`ahrefs` first), so existing consumers reading `gsc`/`ga4`/`bing`/`keywords` are unaffected.
 
 Snapshot shape adds:
 
@@ -97,7 +104,7 @@ Snapshot shape adds:
 
 ### Markdown renderer
 
-`scripts/lib/snapshot-markdown.mjs` gains an `ahrefsSection(data)` function. Output:
+`src/lib/markdown.ts` gains an `ahrefsSection(data)` function. Output:
 
 ```markdown
 ## Ahrefs
@@ -119,7 +126,7 @@ Snapshot shape adds:
 
 ### Diff integration
 
-`scripts/seo-snapshot-diff.mjs` gains an `ahrefsDiff(older, newer)` block alongside the existing per-engine diff blocks. Surfaces:
+`src/commands/diff.ts` gains an `ahrefsDiff(older, newer)` block alongside the existing per-engine diff blocks. Surfaces:
 
 - DR delta with arrow
 - Refdomain net change, plus the actual new and lost domain lists
@@ -143,13 +150,13 @@ Pulls data for the property the snapshot is targeting (currently `coffey.codes`,
 - [ ] **Ahrefs plan is downgraded mid-cycle.** API returns an "insufficient plan" 403; engine logs the exact error and skips, matching the existing skip pattern.
 - [ ] **Snapshot has Ahrefs data but the prior snapshot does not.** Diff script reports "Ahrefs baseline established" rather than crashing on a missing comparison.
 - [ ] **Credit usage spikes.** The `_meta.creditsUsed` field lets us track per-snapshot cost. If a run consumes >100 credits, log a warning so we notice before the monthly cap.
-- [ ] **API version sunsets.** Ahrefs has historically been more stable than Google's APIs here, but if v3 sunsets, the version constant in `scripts/lib/ahrefs.mjs` is the only thing to change. Document this in the troubleshooting table.
+- [ ] **API version sunsets.** Ahrefs has historically been more stable than Google's APIs here, but if v3 sunsets, the version constant in `src/engines/ahrefs.ts` is the only thing to change. Document this in the troubleshooting table.
 
 ## Acceptance criteria
 
-1. A run of `node scripts/seo-snapshot.mjs --engines=ahrefs` against a real Ahrefs account produces a snapshot JSON with the documented `ahrefs` block populated and the Markdown companion's "Ahrefs" section rendered.
-2. A full run (`node scripts/seo-snapshot.mjs` with all engines enabled) includes Ahrefs alongside the other four engines without affecting their output structure.
-3. `node scripts/seo-snapshot-diff.mjs <older> <newer>` between two snapshots containing Ahrefs data prints the new Ahrefs diff block.
+1. A run of `periscope snapshot --engines=ahrefs` against a real Ahrefs account produces a snapshot JSON with the documented `ahrefs` block populated and the Markdown companion's "Ahrefs" section rendered.
+2. A full run (`periscope snapshot` with all engines enabled) includes Ahrefs alongside the other four engines without affecting their output structure.
+3. `periscope diff <older> <newer>` between two snapshots containing Ahrefs data prints the new Ahrefs diff block.
 4. With `AHREFS_API_KEY` unset, the engine skips with the expected one-line stderr warning and the rest of the snapshot completes.
 5. [seo-snapshot-setup.md](../../documentation/guides/seo-snapshot-setup.md) is updated with: env var documentation, the one-time setup subsection, an entry in the troubleshooting table, and a note in the "engines and auth model" table.
 6. [seo-tooling-inventory.md](../../documentation/guides/seo-tooling-inventory.md) is updated to list Ahrefs as a fifth engine and to remove the "intentionally not here" bullet about Ahrefs.
@@ -166,10 +173,10 @@ Pulls data for the property the snapshot is targeting (currently `coffey.codes`,
 
 ## Tasks
 
-- [ ] Implement `scripts/lib/ahrefs.mjs` with the documented exports.
-- [ ] Implement `pullAhrefs` in `scripts/seo-snapshot.mjs` and wire it into the engine dispatch table.
-- [ ] Update `scripts/lib/snapshot-markdown.mjs` with the `ahrefsSection` renderer.
-- [ ] Update `scripts/seo-snapshot-diff.mjs` with the `ahrefsDiff` renderer.
+- [ ] Implement `src/engines/ahrefs.ts` with the documented exports.
+- [ ] Implement `pullAhrefs` in `src/commands/snapshot.ts` and wire it into the engine dispatch table.
+- [ ] Update `src/lib/markdown.ts` with the `ahrefsSection` renderer.
+- [ ] Update `src/commands/diff.ts` with the `ahrefsDiff` renderer.
 - [ ] Update `docs/documentation/guides/seo-snapshot-setup.md` (engines table, one-time setup, troubleshooting, env vars).
 - [ ] Update `docs/documentation/guides/seo-tooling-inventory.md` (add Ahrefs to engines, remove the "not here yet" bullet).
 - [ ] Update `docs/documentation/agents/coffey-codes.md` if it lists engines explicitly.

--- a/docs/strategy/seo-audit-2026-Q3.md
+++ b/docs/strategy/seo-audit-2026-Q3.md
@@ -141,7 +141,7 @@ This also explains the apparent contradiction with GA4's 114 Bing organic sessio
 
 **Status:** Bing diagnostic loop closed. No code or config fix needed.
 
-**Next quarterly audit (target 2026-08-10):** re-run the snapshot. By that point Bing Webmaster Tools should have ~90 days of recorded performance data. `scripts/seo-snapshot-diff.mjs` against this baseline will show the full delta from zero to whatever's accumulated. This will also be the first real test of `scripts/seo-snapshot.mjs`'s Bing path against non-empty data.
+**Next quarterly audit (target 2026-08-10):** re-run `periscope snapshot`. By that point Bing Webmaster Tools should have ~90 days of recorded performance data. `periscope diff` against this baseline will show the full delta from zero to whatever's accumulated. This will also be the first real test of periscope's Bing engine against non-empty data.
 
 ## 9.5 GA4 cross-reference (180 days, post-config-change)
 


### PR DESCRIPTION
## Summary

Three threads in one PR (kept together because they all hang off the same theme — the periscope tool's public-facing surface). Originally the post-phase-B doc refresh; expanded to cover the new portfolio template + the AdWords-compliance landing page.

### 1. New portfolio template

**`/portfolio/[slug]` dynamic route** mirroring the `articles/[slug]` pattern. Each item is an MDX file under `app/(site)/portfolio/items/<slug>.mdx` with typed frontmatter; the route renders breadcrumbs, schema.org `CreativeWork` + `BreadcrumbList` JSON-LD, a header with hero image and CTAs (live link + repo link), the MDX body in `prose` typography, and a back-to-portfolio link.

The existing modal-based portfolio listing still works — projects without a `slug` open the modal; projects with one navigate to the dedicated page. Lets you migrate one project at a time.

### 2. First portfolio item: Periscope

**`/portfolio/periscope`** doubles as the [Google Ads API compliance documentation page](https://github.com/anthonycoffey/coffey.codes/blob/d013916/app/(site)/portfolio/items/periscope.mdx). Covers exactly which API services are called (`KeywordPlanIdeaService` only, two read-only methods), the auth model (service account, no OAuth), the data-handling story (local-only, no third-party sharing), and the call volume.

Pages it satisfies for Google's reviewer:
- Tool description matches what `src/engines/ads.ts` actually does
- Reachable in one click from the homepage via the Portfolio nav entry
- No login required, indexable, served over `https://`

### 3. Periscope 1.1.0 doc refresh

Periscope 1.1.0 (just published from `anthonycoffey/periscope`) adds natural-language refs to the `diff` command:

```bash
periscope diff yesterday                # latest vs yesterday
periscope diff 7d                       # latest vs 7 days ago
periscope diff "last month"             # latest vs ~30 days ago
periscope diff 2026-05-10               # latest vs explicit date
periscope diff 2026-05-10 2026-05-17    # both explicit
```

Plus a summary panel showing what got resolved + every snapshot available in `outputDir`. Docs updated in `README.md`, `CLAUDE.md`, `seo-snapshot-setup.md`, `seo-tooling-inventory.md`.

The package.json dep stays at `^1.0.2` (caret accepts 1.1.0). `npm update @anthonycoffey/periscope` after merge picks up 1.1.0 without a lockfile churn.

## Files

| File | Change |
| --- | --- |
| `app/(site)/portfolio/[slug]/page.tsx` | New — dynamic route |
| `app/(site)/portfolio/utils.ts` | New — MDX item loader + typed metadata |
| `app/(site)/portfolio/items/periscope.mdx` | New — first item, Ads API compliance content |
| `app/(site)/portfolio/page.tsx` | Listing: periscope card at top, slug-conditional Link navigation |
| `app/sitemap.ts` | Includes `/portfolio/<slug>` entries |
| `README.md` | NLP diff examples in the Periscope section |
| `CLAUDE.md` | Periscope command reference updated |
| `docs/documentation/guides/seo-snapshot-setup.md` | NLP refs section under Diffing |
| `docs/documentation/guides/seo-tooling-inventory.md` | `periscope diff` description updated |
| `docs/documentation/repos/coffey-codes.md` | Already updated in earlier commit on this branch |
| `docs/documentation/deep-dives/{ctr-by-position-baseline,onpage-seo-strategy}.md` | Already updated |
| `docs/strategy/seo-audit-2026-Q3.md` | Already updated |
| `docs/specs/active/SPEC-022-ahrefs-snapshot-engine.md` | Already updated to reference periscope-repo paths |

## After merge

### You

1. **Drop the hero screenshot** at `public/portfolio/periscope/hero.png` (or update the path in `periscope.mdx`'s frontmatter). The page degrades cleanly if missing — you can add it any time, including after merge.
2. **Set up `ads-api@coffey.codes`** as a forwarding alias to your real inbox.
3. **Resubmit the Google Ads API form** using:
   - Website URL: `https://coffey.codes/portfolio/periscope`
   - Developer contact: `ads-api@coffey.codes`
   - Services used: `KeywordPlanIdeaService` (`generateKeywordIdeas`, `generateKeywordHistoricalMetrics`)
4. **Update GH Packages source repo link** (optional cosmetic): see https://github.com/users/anthonycoffey/packages/npm/periscope/settings — link the package to `anthonycoffey/periscope` now instead of `anthonycoffey/coffey.codes`.

### Periscope side

Already shipped as `@anthonycoffey/periscope@1.1.0`. To pick it up locally / on Vercel:

```bash
npm update @anthonycoffey/periscope
npx periscope diff yesterday
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)