### PR TITLE
feat: consume periscope 1.2.0 (GSC-first audit) [SPEC-024]

### DIFF
--- a/docs/documentation/guides/google-ads-basic-access.md
+++ b/docs/documentation/guides/google-ads-basic-access.md
@@ -1,0 +1,117 @@
+---
+service: coffey.codes
+updated: 2026-05-17
+description: Application checklist for upgrading a Google Ads developer token from Test → Basic access so periscope can query production customer accounts. Field-by-field walkthrough, RMF positioning, README requirements, and a privacy/ToS template.
+---
+
+# Google Ads Basic Access — application checklist
+
+A freshly minted Google Ads developer token is granted **Test access only**. That means the API works, but every call against a production customer ID returns HTTP 403 `DEVELOPER_TOKEN_NOT_APPROVED`. To run [`periscope audit articles`](../../strategy/data/snapshot-2026-05-17.md) (or any other `seo:*` command) against `coffey.codes`'s real Google Ads account, the token must be upgraded to **Basic access**.
+
+Basic is the right level for periscope — it caps at 15,000 ops/day per token (we use a handful per snapshot) and 1,000 ops/day per `login-customer-id`, which is far more than the tool needs. Standard access only matters for resellers managing many MCC accounts.
+
+Submit the form at <https://ads.google.com/aw/apicenter> → **Basic access** → **Apply for Basic Access**. The review window is 1–5 business days. The most common rejection reason is "use case is unclear or not RMF-compliant" — this doc exists to head off both.
+
+## Before you apply
+
+| Check | Why |
+| --- | --- |
+| You have a **valid `developer_token`** issued under your MCC (Manager) Ads account. | The token itself is created in API Center → "Token" tab. Apply only after the token exists. |
+| The MCC has at least one **linked customer account** with billing set up. | If `CUSTOMER_NOT_ENABLED`, your application will be denied. Run `periscope doctor ads` to confirm the link works in Test mode first. |
+| Your tool has a **public-facing description** (page or repo). | Reviewers paste your tool name into a Google search; if nothing turns up, reject is fast. |
+| The tool's **README is comprehensive** (see below). | Linked from the form; reviewers click it. |
+| You have a **privacy policy / ToS** at a stable URL. | Required by the RMF (Required Minimum Functionality). |
+
+## RMF compliance positioning (this is the section reviewers actually read)
+
+The Google Ads API's [Required Minimum Functionality (RMF)](https://developers.google.com/google-ads/api/docs/policies/required-minimum-functionality) policy says any third-party tool must implement at least one of: campaign management, reporting, account management, or — relevant to us — **research / planning** features. Periscope is squarely in the research/planning bucket. Frame the application that way:
+
+> Periscope is an SEO research tool that analyzes a property's own keyword landscape. It consumes Google Search Console (real ranking queries) as the primary data source and supplements with Google Ads' Keyword Planner (`KeywordPlanIdeaService`, `KeywordPlanService.generateKeywordHistoricalMetrics`) to enrich GSC queries with search-volume and competition data, and to surface adjacent keyword ideas for articles that lack GSC coverage yet. The operator authenticates as themselves against their own Google Ads account; the tool does not aggregate data across customers, does not modify campaigns, and does not pull data for accounts the operator isn't already authorized on.
+
+That paragraph touches all the boxes Google looks for: *what the tool is*, *which API surfaces it uses*, *which RMF category*, and the negative space (*what it doesn't do*).
+
+## Periscope repo / README requirements
+
+The reviewer will check the public repo to confirm the tool is real and that the use case matches the application. Periscope's README at <https://github.com/anthonycoffey/periscope> already satisfies the requirements; if it ever stops, fix it before re-applying:
+
+- [x] **What it does** — table of commands, plain language.
+- [x] **How to install** — concrete `npm install` instructions including the GitHub Packages PAT step.
+- [x] **Configuration** — sample `periscope.config.mjs` showing required + optional fields.
+- [x] **Auth model** — table of which env vars feed which engine.
+- [x] **Public source** — repository is browsable and the link from the API Center form lands on it (not a redirect, not a private mirror).
+- [x] **License** — MIT.
+
+## Privacy policy / ToS template
+
+Periscope is a CLI run locally against the operator's own credentials, so a single short page covers both. Either host it on `coffey.codes/legal/periscope/` or as `PRIVACY.md` in the periscope repo and link to it.
+
+```markdown
+# Periscope — Privacy and Terms
+
+## Data collected
+Periscope is a command-line tool run on your local machine against your own
+Google credentials. It does not have a backend, does not collect telemetry,
+does not transmit data to any third party other than the Google APIs you
+explicitly configure (Search Console, GA4, Bing Webmaster Tools, Google Ads).
+
+## Data storage
+All data the tool retrieves is written to local files in your project's
+configured `outputDir` (default `docs/strategy/data/`). Data never leaves
+your machine via Periscope itself; whether you commit the output to a git
+repository is your choice.
+
+## Credentials
+Periscope reads credentials from environment variables and JSON key files on
+your local filesystem. It never prints credentials in logs (developer token,
+access token, and service-account private key are scrubbed from all output).
+
+## Third-party services
+Periscope queries the following Google APIs on your behalf using credentials
+you configure:
+- Google Search Console (`webmasters.readonly`)
+- Google Analytics Data API
+- Google Ads API (`adwords` scope)
+Each service's own privacy policy and Terms of Service govern data retrieved
+from them.
+
+## Liability
+Periscope is MIT-licensed and provided "as is", without warranty of any kind.
+
+## Contact
+coffey.j.anthony@gmail.com
+```
+
+## Form: field-by-field guidance
+
+When you submit at <https://ads.google.com/aw/apicenter>, expect these fields. Recommended answers (adjust for your contact info):
+
+| Field | Answer |
+| --- | --- |
+| **Tool name** | Periscope |
+| **Tool URL** | https://github.com/anthonycoffey/periscope |
+| **Privacy policy URL** | URL of the policy you hosted from the template above |
+| **Tool description** | Use the RMF positioning paragraph from above. |
+| **Use case** | Research / planning. Specifically: enriching the operator's own Google Search Console query data with Google Ads search-volume and competition; surfacing adjacent keyword ideas for under-performing pages. |
+| **Which Ads API services do you use?** | `KeywordPlanIdeaService` (`generateKeywordIdeas`, `generateKeywordIdeasFromUrl`), `KeywordPlanService.generateKeywordHistoricalMetrics`, `CustomerService.listAccessibleCustomers`. |
+| **Will you store Google Ads data?** | Yes, locally on the operator's filesystem only, as part of the snapshot output. Not transmitted to any third party. |
+| **Are you charging users?** | No (open-source tool, MIT-licensed). |
+| **Approximate daily call volume per token** | <100 (per-property snapshots fire <10 calls; the cache absorbs the rest). |
+| **Multi-tenant?** | No. Each operator authenticates with their own Google credentials against their own account. |
+
+## After submission
+
+1. Watch the email associated with the MCC for the decision. The first response is usually a confirmation that the application is queued.
+2. If approved, the developer token's access level flips to Basic. **No code change needed.** Re-run `periscope doctor ads`; the previously 403'd calls should now succeed.
+3. If rejected, the email lists the specific RMF criterion that wasn't satisfied. Address it (usually a doc/site gap, not a code gap), then re-submit.
+
+## What to do while you wait
+
+The application can take several business days. In the meantime, `periscope audit articles` already operates **GSC-first** as of 1.2.0 — verdicts (`TITLE_QUERY_DRIFT`, `STRIKING_DISTANCE`, `CANNIBALIZATION`, `WELL_TARGETED`, `GHOST`) all derive from Search Console data and need no Ads access. Only the optional Ads enrichment for GHOST articles is blocked, and the keyword-ideas cache covers most of that gap on rerun.
+
+Read the categorized error message periscope prints on rejection; it tells you which fix path applies (apply for Basic, switch to a test account, enable billing, etc.). See [`src/lib/ads-error-classify.ts`](https://github.com/anthonycoffey/periscope/blob/main/src/lib/ads-error-classify.ts) for the full category map.
+
+## Related
+
+- [seo-snapshot-setup.md](./seo-snapshot-setup.md) — the canonical wiring guide for the snapshot script.
+- [Periscope README](https://github.com/anthonycoffey/periscope) — the public surface reviewers will click through to.
+- [SPEC-024](../../specs/active/SPEC-024-periscope-gsc-first-audit-ads-quota.md) — the spec behind the GSC-first audit and error classification that make Basic access optional rather than blocking.

--- a/docs/specs/active/SPEC-029-periscope-multi-property-config.md
+++ b/docs/specs/active/SPEC-029-periscope-multi-property-config.md
@@ -1,0 +1,152 @@
+---
+id: SPEC-029
+title: 'Periscope multi-property config (--property flag, properties[] map)'
+status: draft
+created: 2026-05-17
+author: Anthony Coffey
+reviewers: []
+affected_repos: [periscope, coffey.codes]
+---
+
+## Reviewer Notes
+
+<!-- Leave empty until code review. -->
+
+---
+
+# Feature: Multi-property config for periscope
+
+## Problem
+
+Periscope today supports exactly one property per config file. The schema in [src/lib/config.ts](https://github.com/anthonycoffey/periscope/blob/main/src/lib/config.ts) hardcodes `siteUrl`, `ga4PropertyId`, `outputDir`, `articles.dir`, `landingPages.dir`, `ads.*`, and `categories[]` as top-level keys. Every consuming repo that wants to monitor more than one property has to either fork the package or maintain N config files + invoke the CLI N times.
+
+This was carved out of [SPEC-024](./SPEC-024-periscope-gsc-first-audit-ads-quota.md) (must-have #9) because the author has no second property to exercise from this machine — landing multi-property without a real second property risked shipping untested code on the critical path of every Ads command. SPEC-024 closed all the OTHER must-haves; this spec is the dedicated follow-up.
+
+## Requirements
+
+### Must have
+
+1. WHEN `periscope.config.{ts,mjs}` contains a `properties: Record<string, PropertyConfig>` map plus a `defaultProperty: string`, the CLI SHALL accept `--property <name>` on every command to select which property to run against. Without `--property`, the default is used.
+2. WHEN `periscope.config.{ts,mjs}` uses the existing flat shape (no `properties` map), every command SHALL continue to work unchanged — the flat shape becomes the "single default property". No breaking changes for existing consumers.
+3. `PropertyConfig` per property SHALL include: `siteUrl`, `gscSiteUrl` (often same), `ga4PropertyId`, `ads.customerId`, `ads.loginCustomerId`, `ads.developerTokenEnv` (default `GOOGLE_ADS_DEVELOPER_TOKEN`), `outputDir`, `articles.dir`, `landingPages.dir`, `categories[]`.
+4. WHEN `--property foo` is passed but `foo` is not defined in the config, the CLI SHALL exit with code 2 and list the available property names.
+5. `periscope doctor` and `periscope --explain` (SPEC-024) SHALL print the selected property name as the first line of their output.
+6. `outputDir` per property SHALL isolate snapshot files and keyword-ideas caches per property (e.g., `data/coffey-codes/snapshot-*.json` vs `data/client-b/snapshot-*.json`).
+
+### Nice to have
+
+- `--all-properties` flag on `snapshot` to run every property in sequence (useful for daily cron).
+- `periscope properties list` subcommand to print the configured property names.
+
+### Non-goals
+
+- This spec does NOT add an interactive onboarding command — that's [SPEC-028](./SPEC-028-periscope-onboard-flow.md).
+- This spec does NOT add per-property credential isolation in a vault — credentials remain env-var-driven.
+- This spec does NOT introduce a property-aware diff format. `periscope diff` continues to compare snapshots within one property's `outputDir`.
+
+## Design (sketch)
+
+### Config shape — additive
+
+The zod schema gains a discriminated union: either the existing flat shape OR a `properties` map.
+
+```ts
+const SinglePropertySchema = z.object({
+  siteUrl: z.string(),
+  ga4PropertyId: z.string().optional(),
+  outputDir: z.string().default('docs/strategy/data'),
+  articles: ArticlesSchema,
+  landingPages: LandingPagesSchema,
+  ads: AdsSchema,
+  ga4: Ga4Schema,
+  categories: z.array(z.string()).default([]),
+});
+
+const PropertyConfigSchema = SinglePropertySchema.extend({
+  ads: AdsSchema.extend({
+    customerId: z.string().optional(),
+    loginCustomerId: z.string().optional(),
+    developerTokenEnv: z.string().default('GOOGLE_ADS_DEVELOPER_TOKEN'),
+  }),
+});
+
+const MultiPropertySchema = z.object({
+  defaultProperty: z.string(),
+  properties: z.record(z.string(), PropertyConfigSchema),
+});
+
+export const PeriscopeConfigSchema = z.union([
+  SinglePropertySchema,
+  MultiPropertySchema,
+]);
+```
+
+`loadConfig()` returns a `{ config, resolvedProperty: ResolvedProperty }` shape where `ResolvedProperty` is always the flat per-property view, regardless of source. Commands consume `resolvedProperty` and never branch on which shape the user wrote.
+
+### CLI surface
+
+```bash
+periscope --property client-b snapshot
+periscope --property client-b audit articles
+periscope --property client-b validate lps --cache-only
+```
+
+`--property` is a global option (registered on the root command). Each command's `--explain` prefixes its plan with `[--property=<name>]`.
+
+### Critical files
+
+- `src/lib/config.ts` — schema, resolution.
+- `src/lib/auth.ts` — Ads env var lookup honors per-property `ads.developerTokenEnv`.
+- `src/cli.ts` — register `--property` globally; pass through to every command.
+- All command modules — accept `propertyName` option, plumb to `loadConfig`.
+- `tests/fixtures/periscope.config.multi.mjs` — two properties for tests.
+- `tests/unit/config-multi-property.test.ts`, `tests/unit/cli-property-flag.test.ts`.
+
+## Edge cases
+
+- [ ] `--property` passed without a `properties` map in the config: error message that explains the user is on the flat shape, list how to convert.
+- [ ] Both `properties` and top-level `siteUrl` defined: zod refuses; clear error.
+- [ ] `defaultProperty` names a property that doesn't exist in `properties`: zod refuses.
+- [ ] Two properties with the same `outputDir`: warn (snapshot files will overwrite each other).
+- [ ] Per-property `developerTokenEnv` points to an unset env var: same `developer-token-not-approved` / `auth-error` flow as today.
+
+## Acceptance criteria
+
+1. Existing single-property consumers (including `coffey.codes`) need zero config changes after upgrading to the version that lands this spec.
+2. A `periscope.config.mjs` with two properties allows `periscope --property foo snapshot` and `periscope --property bar snapshot` to write to different `outputDir` paths with different `siteUrl`/`customerId` values, verified by a multi-property fixture under `tests/fixtures/`.
+3. `periscope --property does-not-exist audit articles` exits 2 and lists the available property names.
+4. `periscope --property foo audit articles --explain` prints `[--property=foo]` as the first line of the plan.
+
+## Constraints
+
+- Must remain backwards-compatible with the single-property flat config shape.
+- Snapshot file format additions only (no breaking removals).
+- The Ads developer-token env var name MUST be configurable per property — different client accounts use different MCCs with different tokens.
+
+## Tasks
+
+- [ ] Extend zod schema to a discriminated union (flat or multi-property).
+- [ ] `loadConfig` returns a `resolvedProperty` view.
+- [ ] CLI `--property` global flag wired into every command.
+- [ ] Per-property `outputDir` honored end-to-end.
+- [ ] Per-property `ads.developerTokenEnv` consulted by auth.
+- [ ] `--explain` and `doctor` prefix their output with the property name.
+- [ ] Multi-property fixture + tests.
+- [ ] README + migration note: "How to convert a single-property config to multi-property".
+
+## Notes
+
+### Why this didn't ride along in SPEC-024
+
+The author has no second property to exercise from this machine right now. Landing the multi-property abstraction without a real second property to test it against would put untested code on the critical path of every Ads command (every `loadConfig` call, every CLI invocation). SPEC-024 carved this out so the GSC-first pivot + error UX + caching could land first, then this spec can be planned and tested deliberately once a second property is real.
+
+### Open questions
+
+1. Should `--all-properties` be opt-in per command or only on `snapshot`?
+2. Should the cache file naming gain a property prefix (e.g., `keyword-ideas-<property>-<asof>.json`), or is per-property `outputDir` enough?
+3. Is there a use case for a "shared" / inheritable property block (DRY across properties that share categories or auth)?
+
+### Related specs
+
+- [SPEC-024](./SPEC-024-periscope-gsc-first-audit-ads-quota.md) — parent; this spec implements its must-have #9 in isolation.
+- [SPEC-028](./SPEC-028-periscope-onboard-flow.md) — onboarding flow will create new property entries in `properties:`; depends on this shape landing first.

--- a/docs/specs/archive/SPEC-024-periscope-gsc-first-audit-ads-quota.md
+++ b/docs/specs/archive/SPEC-024-periscope-gsc-first-audit-ads-quota.md
@@ -1,11 +1,17 @@
 ---
 id: SPEC-024
 title: 'Periscope GSC-first audit + Ads quota strategy + enterprise error handling'
-status: draft
+status: complete
 created: 2026-05-17
+completed: 2026-05-18
 author: Anthony Coffey
 reviewers: []
 affected_repos: [periscope, coffey.codes]
+shipped_as:
+  - 'periscope v1.2.0 (anthonycoffey/periscope#3)'
+  - 'coffey.codes @anthonycoffey/periscope devDep bump'
+carve_outs:
+  - 'Multi-property config (must-have #9) → SPEC-029 (draft)'
 ---
 
 ## Reviewer Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "yup": "^1.6.1"
       },
       "devDependencies": {
-        "@anthonycoffey/periscope": "^1.0.2",
+        "@anthonycoffey/periscope": "^1.2.0",
         "@axe-core/playwright": "^4.11.3",
         "@eslint/eslintrc": "^3.0.2",
         "@eslint/js": "^9.23.0",
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@anthonycoffey/periscope": {
-      "version": "1.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@anthonycoffey/periscope/1.1.0/632f0feef558d120e8493cf5a0235f3a0b198786",
-      "integrity": "sha512-ZQzm4hpczsYGtMyqEX7H/WXb1ZOtbgWxssgI5VPs01U061NfGOqmZEjdPTJAUOxvz4G1qc7LmmuzkK5RjS9cPg==",
+      "version": "1.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@anthonycoffey/periscope/1.2.0/efb8c106986da1b4fed9f631b8078944792f0a86",
+      "integrity": "sha512-clDUYjywMuddSdWBzdoNxAzI77c/LS31UPxaQ3/dPZXrZA1s4/Ue+WVWbr4+l6cbkaPbukHqYEacOGqQwpWmvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "yup": "^1.6.1"
   },
   "devDependencies": {
-    "@anthonycoffey/periscope": "^1.0.2",
+    "@anthonycoffey/periscope": "^1.2.0",
     "@axe-core/playwright": "^4.11.3",
     "@eslint/eslintrc": "^3.0.2",
     "@eslint/js": "^9.23.0",


### PR DESCRIPTION
## Summary

Consumer-side of [SPEC-024](https://github.com/anthonycoffey/coffey.codes/blob/main/docs/specs/archive/SPEC-024-periscope-gsc-first-audit-ads-quota.md). Lands four commits:

- **Bump `@anthonycoffey/periscope` to `^1.2.0`** ([anthonycoffey/periscope#3](https://github.com/anthonycoffey/periscope/pull/3), now released as v1.2.0). GSC-first article audit, batched + backed-off Ads calls, classified error UX with abort-after-3, snapshot-time keyword-ideas cache, `--explain` / `--no-cache` / `--cache-only` flags.
- **Add [docs/documentation/guides/google-ads-basic-access.md](docs/documentation/guides/google-ads-basic-access.md)** — application checklist the new `developer-token-not-approved` error message points operators to (RMF positioning, README requirements, privacy/ToS template, field-by-field form guidance). SPEC-024 must-have #12.
- **Draft [SPEC-029](docs/specs/active/SPEC-029-periscope-multi-property-config.md)** — multi-property config (`--property` flag, `properties:` map) carved out of SPEC-024 must-have #9. No implementation; status: draft. The author has no second property to exercise from this machine, so landing the abstraction without a real second property risked shipping untested code on the critical path of every Ads command.
- **Archive SPEC-024** → `docs/specs/archive/`, status → `complete`.

## Verification (run from this branch's checkout)

Smoke-tested live against the real `coffey.codes` config — all four spec acceptance criteria observed:

```
$ npx periscope --version
1.2.0

$ npx periscope snapshot
[snapshot] keywords: skipped (DEVELOPER_TOKEN_NOT_APPROVED — graceful)
Wrote docs/strategy/data/snapshot-2026-05-18.json  (engines: gsc, ga4, bing)

$ npx periscope audit articles --explain
[audit-articles] plan:
  - articles to evaluate: 23
  - GSC pass: 1 read from latest snapshot (no API call)
  - Cannibalization pass: 1 in-memory sweep (no API call)
  - Ghost-enrichment Ads calls: up to 12 (one per GHOST article, batched + backed off)
  - Note: --explain is set; nothing will execute.

$ npx periscope audit articles
[…3 consecutive DEVELOPER_TOKEN_NOT_APPROVED errors…]
[audit-articles] Google Ads developer token is approved for TEST ACCOUNTS ONLY (HTTP 403 DEVELOPER_TOKEN_NOT_APPROVED).
  Your current developer token cannot query production customer accounts. Two paths:
    1. Apply for Basic Access at https://ads.google.com/aw/apicenter ...
    2. Switch CUSTOMER_ID/LOGIN_CUSTOMER_ID to a Google Ads test account ...
[exits 1, one message — not 12 noise lines]

$ npx periscope audit articles --cache-only
Wrote docs/strategy/data/keyword-audit-articles-2026-05-18.md
  (cannibalization: 0, striking: 5, drift: 0)  — zero Ads calls
```

The resulting report (not committed; data drift) showed: 5 STRIKING_DISTANCE, 6 WELL_TARGETED, 12 GHOST, plus a real cannibalization cluster for "anthony coffey" between `/` and `/contact`.

## Test plan

- [x] `npm install` resolves periscope 1.2.0 from GitHub Packages
- [x] `npx periscope --version` → 1.2.0
- [x] `npx periscope snapshot` writes new `keyword-ideas-<asof>.json` cache + populates `gsc.pageQueries`
- [x] `npx periscope audit articles --explain` plan correct, no API calls
- [x] `npx periscope audit articles` collapses 12 unapproved-token failures to one classified message
- [x] `npx periscope audit articles --cache-only` produces report with zero Ads calls

## Notes

The Google Ads developer-token is currently TEST-only. The new error UX makes the upgrade path obvious — the message links directly to the new `google-ads-basic-access.md` guide. Until then, `--cache-only` and the GSC-first verdicts cover the bulk of the audit's value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)