### PR TITLE
docs: refresh periscope references for v1.4.x

### DIFF
--- a/app/(site)/portfolio/items/periscope.mdx
+++ b/app/(site)/portfolio/items/periscope.mdx
@@ -2,7 +2,7 @@
 title: Periscope — SEO Data Tooling
 summary: A TypeScript CLI that unifies Google Search Console, GA4, Bing Webmaster Tools, and Google Ads Keyword Planner into a single local snapshot for editorial and landing-page decisions.
 publishedAt: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-27
 tags:
   [TypeScript, CLI, Google Ads API, GSC, GA4, Bing Webmaster Tools, SEO, npm]
 mainImage: /periscope-logo.png
@@ -29,8 +29,9 @@ Executes seed-based keyword expansion. Returns an adjacent keyword universe sugg
 
 **Required Headers:**
 
-- `Authorization`: `Bearer <service-account-access-token>`
+- `Authorization`: `Bearer <oauth-access-token>` (or service-account access token in the legacy fallback path)
 - `developer-token`: `<google-ads-developer-token>`
+- `login-customer-id`: `<manager-customer-id>`
 - `Content-Type`: `application/json`
 
 **Request Body (JSON):**
@@ -61,8 +62,9 @@ Retrieves historical performance data—including average monthly search volume,
 
 **Headers**
 
-- `Authorization`: `Bearer <service-account-access-token>`
+- `Authorization`: `Bearer <oauth-access-token>` (or service-account access token in the legacy fallback path)
 - `developer-token`: `<google-ads-developer-token>`
+- `login-customer-id`: `<manager-customer-id>`
 - `Content-Type`: `application/json`
 
 **Path Parameters**
@@ -96,17 +98,24 @@ Retrieves historical performance data—including average monthly search volume,
 | `periscope validate lps`    | Validates `/lp/*` landing pages against Keyword Planner demand              |
 | `periscope probe <url>`     | One-shot URL-seeded keyword ideas for a competitor URL                      |
 | `periscope doctor ads`      | Diagnostic that verifies credentials and API reachability                   |
+| `periscope auth ads`        | One-time OAuth setup helper. Mints a refresh token via the standard Desktop-app loopback flow and prints credentials to stdout for the operator to place in their preferred env manager. |
 
 ## Authentication
 
-Periscope authenticates to the Google Ads API using a Google Cloud **service account** with a developer token. Credentials are read from environment variables on the developer's local machine:
+Periscope authenticates to the Google Ads API via **OAuth 2.0 user-flow** with a developer token. The operator runs `periscope auth ads` once on their local machine; the tool mints a refresh token via the standard Desktop-app loopback redirect flow and prints the three resulting env vars to stdout for the operator to place in their preferred env manager (a `.env` file, a shell profile, 1Password CLI, Doppler — the tool does not assume).
 
-- `GOOGLE_ADS_DEVELOPER_TOKEN`
-- `GOOGLE_ADS_LOGIN_CUSTOMER_ID` (Manager account)
-- `GOOGLE_ADS_CUSTOMER_ID`
-- `GSC_SERVICE_ACCOUNT_KEY_PATH` or `GSC_SERVICE_ACCOUNT_JSON` (reused for GSC, GA4, and Ads)
+The same operator-side credentials are then read from environment variables on every CLI invocation:
 
-**No OAuth user consent flow is involved.** No end-user credentials are collected, stored, or proxied.
+- `GOOGLE_ADS_DEVELOPER_TOKEN` — the Basic-access developer token issued under the operator's MCC
+- `GOOGLE_ADS_CLIENT_ID` — OAuth 2.0 client ID (Desktop application type)
+- `GOOGLE_ADS_CLIENT_SECRET` — OAuth 2.0 client secret
+- `GOOGLE_ADS_REFRESH_TOKEN` — refresh token, minted once by `periscope auth ads`
+- `GOOGLE_ADS_LOGIN_CUSTOMER_ID` — the operator's manager (MCC) customer ID
+- `GOOGLE_ADS_CUSTOMER_ID` — the operating customer (typically a child of the MCC)
+
+A **legacy service-account fallback** is preserved for environments without a domain-policy constraint (Workspace MCCs, test accounts): when `GSC_SERVICE_ACCOUNT_KEY_PATH` or `GSC_SERVICE_ACCOUNT_JSON` is set instead of the three OAuth vars above, periscope authenticates as the service account. Personal-Gmail MCCs reject service-account emails at the Ads API layer (an "allowed domains" policy that the UI tolerates but the API enforces), which is why OAuth user-flow is the primary path in v1.3+.
+
+The OAuth user flow authenticates **the operator as themselves** against their own Google Ads account. The tool has no backend, no third-party identity broker, no end-user consent surface — it is local CLI tooling for a single operator at a time. No credentials are transmitted anywhere other than Google's own OAuth + Ads API endpoints.
 
 ## Data handling
 
@@ -145,7 +154,7 @@ flowchart LR
     Dev -->|invokes| Periscope
     Engines -->|HTTPS GET/POST| GSC
     Engines -->|HTTPS GET/POST| GA4
-    Engines -->|HTTPS POST<br/>service-account auth| ADS
+    Engines -->|HTTPS POST<br/>OAuth user-flow<br/>(SA fallback)| ADS
     Engines -->|HTTPS GET/POST| BING
     Periscope -->|writes| Snap
 
@@ -193,7 +202,9 @@ Each engine takes its config explicitly (site URL, property id, API key, bot reg
 
 `src/lib/*` holds the cross-cutting pieces:
 
-- Service-account JWT auth (shared across the Google engines)
+- Auth resolver: OAuth user-flow (primary) and service-account JWT (fallback) for Google Ads; service-account JWT for GSC + GA4
+- Ads error classifier (collapses ~20 raw error codes into 8 actionable categories)
+- Seed-phrase composition and topical filtering for keyword ideas
 - Bucket math for keyword volume tiers
 - Snapshot markdown renderer
 - Config loader (zod-validated)
@@ -203,7 +214,7 @@ Each engine takes its config explicitly (site URL, property id, API key, bot reg
 
 ### Tests
 
-56 unit tests on vitest covering bucket math, config schema, frontmatter parser, color helpers, diagnostics, and snapshot ref resolution. No live API in tests — engines are mocked at the HTTP boundary.
+159 unit tests on vitest covering bucket math, config schema, frontmatter parser, color helpers, diagnostics, snapshot ref resolution, Ads auth resolution, error classification, retry backoff, error-budget tripping, keyword-ideas cache, GSC-first verdict scoring, and the OAuth + seed-phrase work added in v1.3 – v1.4. No live API in tests — engines are mocked at the HTTP boundary.
 
 ### Distribution
 
@@ -226,8 +237,10 @@ Private npm package `@anthonycoffey/periscope` on GitHub Packages, published via
 
 ## What's next
 
-- An optional Ahrefs engine as a fifth data source
-- Additional `doctor` modules for GSC and GA4 access checks
+- An optional Ahrefs engine as a fifth data source (SPEC-022)
+- Topic-gap clustering across articles (SPEC-025)
+- Week-over-week movement diff (SPEC-026)
+- Guided multi-property onboarding flow (SPEC-028)
 
 ## Source Code
 

--- a/docs/documentation/guides/google-ads-basic-access.md
+++ b/docs/documentation/guides/google-ads-basic-access.md
@@ -1,12 +1,14 @@
 ---
 service: coffey.codes
-updated: 2026-05-17
+updated: 2026-05-27
 description: Application checklist for upgrading a Google Ads developer token from Test → Basic access so periscope can query production customer accounts. Field-by-field walkthrough, RMF positioning, README requirements, and a privacy/ToS template.
 ---
 
 # Google Ads Basic Access — application checklist
 
 A freshly minted Google Ads developer token is granted **Test access only**. That means the API works, but every call against a production customer ID returns HTTP 403 `DEVELOPER_TOKEN_NOT_APPROVED`. To run [`periscope audit articles`](../../strategy/data/snapshot-2026-05-17.md) (or any other `seo:*` command) against `coffey.codes`'s real Google Ads account, the token must be upgraded to **Basic access**.
+
+> **Auth model note (periscope v1.3+):** periscope authenticates to the Google Ads API via **OAuth 2.0 user-flow** (Desktop application type, loopback redirect), with a service-account fallback for Workspace MCCs and test accounts. The Basic-access developer-token requirement is identical in either path — the token is what unlocks production customer access at the API level, regardless of how the operator authenticates. Run `periscope auth ads` once to mint the OAuth refresh token; see the periscope README's "Google Ads setup" section for the full setup walk-through.
 
 Basic is the right level for periscope — it caps at 15,000 ops/day per token (we use a handful per snapshot) and 1,000 ops/day per `login-customer-id`, which is far more than the tool needs. Standard access only matters for resellers managing many MCC accounts.
 

--- a/docs/specs/active/SPEC-031-periscope-ads-onboarding-polish-and-scoped-seeds.md
+++ b/docs/specs/active/SPEC-031-periscope-ads-onboarding-polish-and-scoped-seeds.md
@@ -1,12 +1,16 @@
 ---
 id: SPEC-031
 title: 'Periscope Ads onboarding polish + scoped seed phrases for keyword ideas'
-status: draft
+status: complete
 created: 2026-05-26
+completed: 2026-05-27
 author: Anthony Coffey
 reviewers: []
 affected_repos: [periscope]
 priority: medium
+shipped_as:
+  - 'periscope v1.4.0 (anthonycoffey/periscope#9) — print-only auth flow + scoped seed phrases'
+  - 'periscope v1.4.1 (anthonycoffey/periscope#10) — fix MISSING_HOST on urlSeed + extend stopword list'
 ---
 
 ## Reviewer Notes


### PR DESCRIPTION
## Summary

Three stale spots refreshed to match periscope v1.4.1 (shipped 2026-05-27):

1. **SPEC-031** flipped `draft` → `complete` with `shipped_as` listing periscope#9 (v1.4.0) and #10 (v1.4.1). Stays in `active/` for now — move to `archive/` after end-to-end verification against the live corpus per the spec''s verification plan.

2. **Portfolio entry** (`app/(site)/portfolio/items/periscope.mdx`)
   - **Authentication section rewritten.** OAuth user-flow is now the primary path; service-account stays as a fallback for Workspace MCCs and test accounts. Lists the new env vars (CLIENT_ID / SECRET / REFRESH_TOKEN) and explains the Ads "allowed domains" policy that drove the migration in v1.3.
   - Request example headers now show `login-customer-id` and OAuth bearer token (were claiming service-account-only).
   - Adds `periscope auth ads` to the command surface table.
   - Mermaid diagram edge label corrected.
   - Lib section refreshed (Ads error classifier, seed-phrase composition).
   - Tests count: 56 → 159.
   - "What''s next" pruned — `doctor` for GSC/GA4/Bing landed in v1.3, so it''s no longer pending. Re-pointed at currently-active SPECs (022/025/026/028).

3. **`docs/documentation/guides/google-ads-basic-access.md`** gets a short callout noting the v1.3+ OAuth-primary auth model. The dev-token application process itself is unchanged — the token requirement is identical in either auth path.

## What''s _not_ in this PR

- The `.gitignore` / `package.json` / `package-lock.json` modifications visible in `git status` are unrelated WIP and intentionally left out of this branch.
- The two new `docs/strategy/data/keyword-*-2026-05-26.md` files from earlier periscope runs are untracked — decision on whether to track those is yours.
- No edits to SPEC-022/025/026/027/028/029 — the inventory pass confirmed they''re unaffected by the v1.3/v1.4 changes.

## Test plan

- [x] Visual diff on GitHub for the MDX rendering
- [x] Spot-check the portfolio page in a Vercel preview to confirm the mermaid diagram renders cleanly with the new edge label