### PR TITLE
fix(portfolio): mermaid edge label syntax (periscope diagram)

### DIFF
--- a/app/(site)/portfolio/items/periscope.mdx
+++ b/app/(site)/portfolio/items/periscope.mdx
@@ -154,7 +154,7 @@ flowchart LR
     Dev -->|invokes| Periscope
     Engines -->|HTTPS GET/POST| GSC
     Engines -->|HTTPS GET/POST| GA4
-    Engines -->|HTTPS POST<br/>OAuth user-flow<br/>(SA fallback)| ADS
+    Engines -->|HTTPS POST<br/>OAuth user-flow| ADS
     Engines -->|HTTPS GET/POST| BING
     Periscope -->|writes| Snap
 


### PR DESCRIPTION
## Summary

The periscope portfolio diagram broke after #214 with "Syntax error in text" (mermaid 11.14.0). The label I shipped — `|HTTPS POST<br/>OAuth user-flow<br/>(SA fallback)|` — hit two mermaid edge-label rules at once:

1. **Multiple `<br/>` tags in a single edge label** aren''t supported (node labels allow them fine — different rule).
2. **Parentheses `()` inside edge labels** confuse the parser; they look like a node-shape delimiter.

Fix: mirror the structure of the original working label — single `<br/>`, no parens. The SA-fallback nuance lives in the prose Authentication section below the diagram, so the diagram doesn''t need to encode it.

Before:  `Engines -->|HTTPS POST<br/>OAuth user-flow<br/>(SA fallback)| ADS`
After:   `Engines -->|HTTPS POST<br/>OAuth user-flow| ADS`

## Test plan

- [ ] Vercel preview renders the diagram without "Syntax error in text"
- [x] One-character-class fix; no functional change