### PR TITLE
perf(home): defer WebGL mount, fix loader, add mobile quality tier

### DIFF
--- a/__tests__/components/Loader.test.tsx
+++ b/__tests__/components/Loader.test.tsx
@@ -59,19 +59,37 @@ describe('Loader', () => {
     expect(cursor).toHaveClass('animate-blink');
   });
 
-  it('slides out completely after 2000ms', () => {
+  it('slides out via the safety cap when no ready signal arrives', () => {
     const { container } = render(<Loader />);
     const overlay = container.firstChild as HTMLElement;
 
-    // Before timeout (e.g. 1500ms)
+    // Before the safety cap (1500ms)
     act(() => {
-      vi.advanceTimersByTime(1500);
+      vi.advanceTimersByTime(1400);
     });
     expect(overlay).toHaveClass('loading');
 
-    // After timeout (2000ms total)
+    // After the safety cap fires
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(200);
+    });
+    expect(overlay).toHaveClass('-translate-y-full');
+    expect(overlay).toHaveClass('pointer-events-none');
+  });
+
+  it('slides out immediately when the scene reports ready', () => {
+    const { container, rerender } = render(<Loader loaded={false} />);
+    const overlay = container.firstChild as HTMLElement;
+
+    // Still loading well before the safety cap
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(overlay).toHaveClass('loading');
+
+    // Scene signals first frame — loader dismisses without waiting for the cap
+    act(() => {
+      rerender(<Loader loaded={true} />);
     });
     expect(overlay).toHaveClass('-translate-y-full');
     expect(overlay).toHaveClass('pointer-events-none');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,6 +31,11 @@ export default function Page() {
     <>
       <Navbar />
       <main>
+        {/* Server-rendered page heading. Present in the initial HTML so there is
+            a fast, crawlable LCP/SEO target independent of the WebGL canvas
+            (which is client-only and deferred). Visually hidden so the cinematic
+            scroll experience stays unchanged. */}
+        <h1 className="sr-only">{HOME_TITLE}</h1>
         <ScrollContainer />
       </main>
     </>

--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useState } from 'react';
 
-export default function Loader() {
+// Hard safety cap — the loader always dismisses by this point even if the
+// scene never signals ready (e.g. WebGL fails to init). Kept short so it never
+// gates LCP: the overlay text behind it can paint as soon as it's gone.
+const SAFETY_CAP_MS = 1500;
+
+interface LoaderProps {
+  /** Flips true once the WebGL scene has rendered its first frame. */
+  loaded?: boolean;
+}
+
+export default function Loader({ loaded = false }: LoaderProps) {
   const [loading, setLoading] = useState(true);
   const [progress, setProgress] = useState(0);
   const [text, setText] = useState('');
@@ -16,6 +26,11 @@ export default function Loader() {
       document.body.style.overflow = '';
     };
   }, [loading]);
+
+  // Dismiss as soon as the scene reports its first frame.
+  useEffect(() => {
+    if (loaded) setLoading(false);
+  }, [loaded]);
 
   useEffect(() => {
     const fullText = 'LOADING...';
@@ -33,9 +48,10 @@ export default function Loader() {
       setTimeout(() => setProgress(100), 100);
     });
 
+    // Safety net so the overlay can never hang past the cap.
     const timeout = setTimeout(() => {
       setLoading(false);
-    }, 2000);
+    }, SAFETY_CAP_MS);
 
     return () => {
       clearInterval(typeInterval);

--- a/components/ScrollContainer.tsx
+++ b/components/ScrollContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLayoutEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import dynamic from 'next/dynamic';
@@ -22,6 +22,58 @@ const SCROLL_MULTIPLIER = 6;
 export default function ScrollContainer() {
   const spacerRef = useRef<HTMLDivElement>(null);
   const scrollProgress = useRef(0);
+
+  // Defer the WebGL canvas until the browser is idle *after* first paint, so
+  // the heavy three.js chunk download + scene init fall outside the critical
+  // render path (FCP/LCP) and the Lighthouse main-thread (TBT) window.
+  const [canvasReady, setCanvasReady] = useState(false);
+  // Flipped by WorldCanvas once its first frame has rendered — used to dismiss
+  // the Loader on a real signal instead of a blind timeout.
+  const [sceneReady, setSceneReady] = useState(false);
+
+  useEffect(() => {
+    let idleId: number | undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const schedule = () => {
+      const ric = (
+        window as Window &
+          typeof globalThis & {
+            requestIdleCallback?: (
+              cb: () => void,
+              opts?: { timeout: number },
+            ) => number;
+          }
+      ).requestIdleCallback;
+      if (typeof ric === 'function') {
+        idleId = ric(() => setCanvasReady(true), { timeout: 2000 });
+      } else {
+        // Safari has no requestIdleCallback — fall back to a short timeout.
+        timeoutId = setTimeout(() => setCanvasReady(true), 200);
+      }
+    };
+
+    // Wait for the load event so the canvas mounts after the initial paint and
+    // existing resources have settled. If the page is already loaded, schedule
+    // immediately.
+    if (document.readyState === 'complete') {
+      schedule();
+    } else {
+      window.addEventListener('load', schedule, { once: true });
+    }
+
+    return () => {
+      window.removeEventListener('load', schedule);
+      if (timeoutId) clearTimeout(timeoutId);
+      const cic = (
+        window as Window &
+          typeof globalThis & {
+            cancelIdleCallback?: (id: number) => void;
+          }
+      ).cancelIdleCallback;
+      if (idleId !== undefined && typeof cic === 'function') cic(idleId);
+    };
+  }, []);
 
   useLayoutEffect(() => {
     const spacer = spacerRef.current;
@@ -62,9 +114,14 @@ export default function ScrollContainer() {
           height: '100dvh',
         }}
       >
-        <WorldCanvas scrollProgress={scrollProgress} />
+        {canvasReady && (
+          <WorldCanvas
+            scrollProgress={scrollProgress}
+            onReady={() => setSceneReady(true)}
+          />
+        )}
         <HUDOverlay scrollProgress={scrollProgress} />
-        <Loader />
+        <Loader loaded={sceneReady} />
       </div>
     </div>
   );

--- a/components/canvas/WorldCanvas.tsx
+++ b/components/canvas/WorldCanvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { sampleMerkaba } from '@/utils/merkaba';
@@ -23,19 +23,21 @@ const MERKABA_RADIUS = 2;
 const DISPERSE_DISTANCE = 10;
 
 // Background star field — static, always visible (the ONLY source of stars).
-const BG_STAR_COUNT = 1500;
+// Mobile gets a sparser field to cut per-frame draw cost and init work.
+const BG_STAR_COUNT_DESKTOP = 1500;
+const BG_STAR_COUNT_MOBILE = 700;
 const BG_STAR_Z_MIN = -65;
 const BG_STAR_Z_MAX = -180;
-const BG_STAR_POSITIONS = (() => {
-  const arr = new Float32Array(BG_STAR_COUNT * 3);
-  for (let i = 0; i < BG_STAR_COUNT; i++) {
+function buildBgStars(count: number): Float32Array {
+  const arr = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
     arr[i * 3] = (Math.random() - 0.5) * 160;
     arr[i * 3 + 1] = (Math.random() - 0.5) * 160;
     arr[i * 3 + 2] =
       BG_STAR_Z_MIN + Math.random() * (BG_STAR_Z_MAX - BG_STAR_Z_MIN);
   }
   return arr;
-})();
+}
 
 // ── Pre-computed geometry data (computed once at module load) ──────────
 const MERKABA_POSITIONS = sampleMerkaba(MERKABA_RADIUS, PARTICLE_COUNT);
@@ -151,12 +153,38 @@ function ParticleSystem({ scrollProgress }: ParticleSystemProps) {
 // ── WorldCanvas — full-viewport canvas, IS the visual experience ──────────
 interface WorldCanvasProps {
   scrollProgress: React.RefObject<number>;
+  /** Called once the canvas has created its WebGL context / first frame. */
+  onReady?: () => void;
 }
 
-export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
+export default function WorldCanvas({
+  scrollProgress,
+  onReady,
+}: WorldCanvasProps) {
   // Spaceship (with thrust particles, lasers, and per-frame work) is desktop-only.
   // Below 1024px the scene reads cleaner and avoids the GPU/CPU cost on mobile.
   const showSpaceship = useMediaQuery('(min-width: 1024px)');
+  // Single quality gate for the whole scene: < 1024px runs the low tier
+  // (fewer particles, lower dpr, lighter post-processing, simpler shaders).
+  const isMobile = !showSpaceship;
+
+  // Static background star field — fewer points on mobile.
+  const bgStars = useMemo(
+    () => buildBgStars(isMobile ? BG_STAR_COUNT_MOBILE : BG_STAR_COUNT_DESKTOP),
+    [isMobile],
+  );
+
+  // Pause the render loop while the tab is backgrounded — the scene animates
+  // continuously, so 'demand' isn't viable, but there's no reason to keep
+  // rendering when the page isn't visible.
+  const [frameloop, setFrameloop] = useState<'always' | 'never'>('always');
+  useEffect(() => {
+    const onVisibility = () =>
+      setFrameloop(document.hidden ? 'never' : 'always');
+    document.addEventListener('visibilitychange', onVisibility);
+    onVisibility();
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, []);
 
   return (
     <div
@@ -169,7 +197,7 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
     >
       <Canvas
         camera={{ position: [0, 0, 4], fov: 70 }}
-        dpr={[1, 1.5]}
+        dpr={[1, isMobile ? 1 : 1.5]}
         gl={{
           antialias: false,
           alpha: true,
@@ -177,7 +205,8 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
           toneMappingExposure: 1,
         }}
         style={{ background: 'transparent' }}
-        frameloop="always"
+        frameloop={frameloop}
+        onCreated={() => onReady?.()}
       >
         {/* Lighting — ambient base + directional sun from upper-left */}
         <ambientLight intensity={0.4} />
@@ -192,10 +221,7 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
         {/* Static background star field — always visible, never animated */}
         <points>
           <bufferGeometry>
-            <bufferAttribute
-              attach="attributes-position"
-              args={[BG_STAR_POSITIONS, 3]}
-            />
+            <bufferAttribute attach="attributes-position" args={[bgStars, 3]} />
           </bufferGeometry>
           <pointsMaterial
             size={0.007}
@@ -208,19 +234,21 @@ export default function WorldCanvas({ scrollProgress }: WorldCanvasProps) {
 
         <ParticleSystem scrollProgress={scrollProgress} />
         <UFO scrollProgress={scrollProgress} />
-        <Planet scrollProgress={scrollProgress} />
+        <Planet scrollProgress={scrollProgress} isMobile={isMobile} />
         <Satellite scrollProgress={scrollProgress} />
-        <Galaxy scrollProgress={scrollProgress} />
+        <Galaxy scrollProgress={scrollProgress} isMobile={isMobile} />
         {showSpaceship && <Spaceship scrollProgress={scrollProgress} />}
 
         <EffectComposer multisampling={0}>
+          {/* Bloom is the heaviest post pass; mobile uses fewer mip levels and
+              a lower intensity to cut fragment cost while keeping the glow. */}
           <Bloom
             luminanceThreshold={0.9}
             luminanceSmoothing={0.3}
-            intensity={1.5}
+            intensity={isMobile ? 1.0 : 1.5}
             mipmapBlur
-            radius={0.85}
-            levels={5}
+            radius={isMobile ? 0.7 : 0.85}
+            levels={isMobile ? 3 : 5}
           />
           <Vignette eskil={false} offset={0.3} darkness={0.55} />
         </EffectComposer>

--- a/components/canvas/objects/Galaxy.tsx
+++ b/components/canvas/objects/Galaxy.tsx
@@ -4,6 +4,12 @@ import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 
+// Quality-tier particle counts (low tier = mobile).
+const GALAXY_COUNT_DESKTOP = 1000;
+const GALAXY_COUNT_MOBILE = 500;
+const RING_COUNT_DESKTOP = 250;
+const RING_COUNT_MOBILE = 120;
+
 function smoothstep(t: number): number {
   const c = Math.max(0, Math.min(1, t));
   return c * c * (3 - 2 * c);
@@ -13,7 +19,6 @@ function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t;
 }
 
-const GALAXY_COUNT = 1000;
 // Minimum spiral-particle radius — creates a visible gap around the core ("eye"
 // of the galaxy) so stars don't overlap the glowing sun sphere.
 const CORE_GAP = 6;
@@ -117,6 +122,8 @@ const STAR_MAX_R = 24;
 
 interface GalaxyProps {
   scrollProgress: React.RefObject<number>;
+  /** Low-quality tier: fewer disc + ring particles. */
+  isMobile?: boolean;
 }
 
 /**
@@ -151,14 +158,18 @@ interface GalaxyProps {
  *   - Moons orbit their parent planets on independent, inclined timers
  */
 
-// Pre-compute spiral galaxy particle positions AND per-star color gradient
-// (module level — computed once). Inner stars inherit warm sun-light tint;
-// outer stars fade to cool near-white.
-const { positions: GALAXY_POSITIONS, colors: GALAXY_COLORS } = (() => {
-  const positions = new Float32Array(GALAXY_COUNT * 3);
-  const colors = new Float32Array(GALAXY_COUNT * 3);
+// Build spiral galaxy particle positions AND per-star color gradient for a
+// given star count. Inner stars inherit warm sun-light tint; outer stars fade
+// to cool near-white. Called from a useMemo so the count tracks the quality
+// tier (desktop vs mobile).
+function buildGalaxy(count: number): {
+  positions: Float32Array;
+  colors: Float32Array;
+} {
+  const positions = new Float32Array(count * 3);
+  const colors = new Float32Array(count * 3);
   const tmp = new THREE.Color();
-  for (let i = 0; i < GALAXY_COUNT; i++) {
+  for (let i = 0; i < count; i++) {
     const arm = i % 2; // two arms, 180° apart
     // Exponential radius distribution — dense core, long sparse arms.
     // CORE_GAP pushes the inner edge outward to create the central deadzone.
@@ -199,7 +210,7 @@ const { positions: GALAXY_POSITIONS, colors: GALAXY_COLORS } = (() => {
     colors[i * 3 + 2] = tmp.b;
   }
   return { positions, colors };
-})();
+}
 
 /**
  * Small helper — a moon that orbits a parent point.
@@ -254,21 +265,20 @@ function OrbitingMoon({
  * Tuned for low density, a thin radial band, small particle size, and a
  * cool icy color so the ring reads distinctly from the warm galaxy stars.
  */
-const RING_COUNT = 250;
 const RING_INNER = 1.1;
 const RING_OUTER = 1.6;
 
-function RingParticles() {
+function RingParticles({ count }: { count: number }) {
   const pointsRef = useRef<THREE.Points>(null);
 
   // Stable per-particle state (angle, radius, angular speed, y-scatter).
   const { positions, angles, radii, speeds, ys } = useMemo(() => {
-    const positions = new Float32Array(RING_COUNT * 3);
-    const angles = new Float32Array(RING_COUNT);
-    const radii = new Float32Array(RING_COUNT);
-    const speeds = new Float32Array(RING_COUNT);
-    const ys = new Float32Array(RING_COUNT);
-    for (let i = 0; i < RING_COUNT; i++) {
+    const positions = new Float32Array(count * 3);
+    const angles = new Float32Array(count);
+    const radii = new Float32Array(count);
+    const speeds = new Float32Array(count);
+    const ys = new Float32Array(count);
+    for (let i = 0; i < count; i++) {
       // Bias radius so the ring has a faint gap-and-band texture
       const u = Math.random();
       const r = RING_INNER + u * (RING_OUTER - RING_INNER);
@@ -283,14 +293,14 @@ function RingParticles() {
       positions[i * 3 + 2] = r * Math.sin(theta);
     }
     return { positions, angles, radii, speeds, ys };
-  }, []);
+  }, [count]);
 
   useFrame(({ clock }) => {
     const pts = pointsRef.current;
     if (!pts) return;
     const t = clock.getElapsedTime();
     const arr = pts.geometry.attributes.position.array as Float32Array;
-    for (let i = 0; i < RING_COUNT; i++) {
+    for (let i = 0; i < count; i++) {
       const a = angles[i] + t * speeds[i];
       const r = radii[i];
       arr[i * 3] = r * Math.cos(a);
@@ -317,9 +327,19 @@ function RingParticles() {
   );
 }
 
-export default function Galaxy({ scrollProgress }: GalaxyProps) {
+export default function Galaxy({
+  scrollProgress,
+  isMobile = false,
+}: GalaxyProps) {
   const groupRef = useRef<THREE.Group>(null);
   const pointsRef = useRef<THREE.Points>(null);
+
+  // Quality-tier particle buffers — rebuilt only when the tier changes.
+  const { positions: galaxyPositions, colors: galaxyColors } = useMemo(
+    () => buildGalaxy(isMobile ? GALAXY_COUNT_MOBILE : GALAXY_COUNT_DESKTOP),
+    [isMobile],
+  );
+  const ringCount = isMobile ? RING_COUNT_MOBILE : RING_COUNT_DESKTOP;
   // Refs for per-planet axial spin. Each planet rotates about its local Y-axis
   // independent of the galaxy's overall rotation.
   const planet1MeshRef = useRef<THREE.Mesh>(null);
@@ -436,11 +456,11 @@ export default function Galaxy({ scrollProgress }: GalaxyProps) {
         <bufferGeometry>
           <bufferAttribute
             attach="attributes-position"
-            args={[GALAXY_POSITIONS, 3]}
+            args={[galaxyPositions, 3]}
           />
           <bufferAttribute
             attach="attributes-color"
-            args={[GALAXY_COLORS, 3]}
+            args={[galaxyColors, 3]}
           />
         </bufferGeometry>
         <pointsMaterial
@@ -508,7 +528,7 @@ export default function Galaxy({ scrollProgress }: GalaxyProps) {
             />
           </mesh>
           {/* Particle rings — swirling dust annulus, Keplerian rotation. */}
-          <RingParticles />
+          <RingParticles count={ringCount} />
           {/* Moon — orbital plane sits between parallel and perpendicular to
               the rings (~57° inclination). Inside the tilt group so the
               inclination is preserved as the planet wobbles. */}

--- a/components/canvas/objects/Planet.tsx
+++ b/components/canvas/objects/Planet.tsx
@@ -6,11 +6,13 @@ import * as THREE from 'three';
 
 interface PlanetProps {
   scrollProgress: React.RefObject<number>;
+  /** Low-quality tier: fewer ring particles, lower sphere tessellation, fewer
+   * fbm octaves. */
+  isMobile?: boolean;
 }
 
 // ── Flat, Saturn-like Orbital Rings ───────────────────────────────────────
-function OrbitalParticles() {
-  const count = 5000; // More particles for a dense ring
+function OrbitalParticles({ count }: { count: number }) {
   const particlesRef = useRef<THREE.Points>(null);
 
   const positions = useMemo(() => {
@@ -123,12 +125,13 @@ const NOISE_GLSL = `
     return 42.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1), dot(p2,x2), dot(p3,x3) ) );
   }
 
-  // Fractional Brownian Motion for cloud layers
+  // Fractional Brownian Motion for cloud layers. Octave count is injected via
+  // FBM_OCTAVES (#define) so mobile can run fewer, cheaper iterations.
   float fbm(vec3 x) {
     float v = 0.0;
     float a = 0.5;
     vec3 shift = vec3(100.0);
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < FBM_OCTAVES; ++i) {
       v += a * snoise(x);
       x = x * 2.0 + shift;
       a *= 0.5;
@@ -140,9 +143,17 @@ const NOISE_GLSL = `
 // Layer 1 is dedicated specifically to the Planet and its exclusive lighting
 const PLANET_LIGHTING_LAYER = 1;
 
-export default function Planet({ scrollProgress }: PlanetProps) {
+export default function Planet({
+  scrollProgress,
+  isMobile = false,
+}: PlanetProps) {
   const groupRef = useRef<THREE.Group>(null);
   const meshRef = useRef<THREE.Mesh>(null);
+
+  // Quality-tier knobs.
+  const ringCount = isMobile ? 1500 : 5000;
+  const sphereSegments = isMobile ? 32 : 64;
+  const fbmOctaves = isMobile ? 3 : 4;
 
   const eclipseLightRef = useRef<THREE.PointLight>(null);
   const frontLightRef = useRef<THREE.DirectionalLight>(null);
@@ -222,6 +233,7 @@ export default function Planet({ scrollProgress }: PlanetProps) {
 
     shader.fragmentShader =
       `
+      #define FBM_OCTAVES ${fbmOctaves}
       uniform float uTime;
       varying vec3 vLocalPos;
       ${NOISE_GLSL}
@@ -279,7 +291,7 @@ export default function Planet({ scrollProgress }: PlanetProps) {
         Zero vertex displacement. Beautiful, mathematically generated swirling cloud bands.
       */}
       <mesh ref={meshRef}>
-        <sphereGeometry args={[20, 64, 64]} />
+        <sphereGeometry args={[20, sphereSegments, sphereSegments]} />
         <meshStandardMaterial
           ref={planetMatRef}
           roughness={0.6} // Gas giants are relatively smooth/matte
@@ -288,7 +300,7 @@ export default function Planet({ scrollProgress }: PlanetProps) {
         />
       </mesh>
 
-      <OrbitalParticles />
+      <OrbitalParticles count={ringCount} />
 
       {/* Lighting tailored for a smooth, massive body */}
       <pointLight

--- a/components/overlay/IntroOverlay.tsx
+++ b/components/overlay/IntroOverlay.tsx
@@ -10,11 +10,11 @@ interface IntroOverlayProps {
 export default function IntroOverlay({ visible }: IntroOverlayProps) {
   return (
     <div className={`${styles.introPanel} ${visible ? styles.visible : ''}`}>
-      <h1 className={styles.leadLine}>
+      <h2 className={styles.leadLine}>
         👨‍🚀
         <br />
         Who Am I?
-      </h1>
+      </h2>
       <p className={styles.byline}>Anthony Coffey - Austin, Texas</p>
 
       <div className={styles.socialLinks}>


### PR DESCRIPTION
## Why

The homepage is a full-screen three.js scene, and its **mobile PageSpeed score is low**. Exploration found three compounding causes:

1. **No fast LCP candidate + an artificial 2s hold.** The canvas is `dynamic(..., { ssr: false })` (renders nothing server-side) and the only thing painted for the first ~2s is `Loader`, a black overlay that unconditionally dismissed on `setTimeout(…, 2000)` and locked body scroll. LCP ≈ the HUD text revealed *after* that timeout.
2. **Heavy main-thread work during the Lighthouse trace (TBT).** The WebGL chunk parse + scene init (5000-particle ring, 2000-particle merkaba, 1000-particle galaxy, 64×64 sphere, shader compiles, Bloom) all ran the instant `ScrollContainer` mounted.
3. **Continuous per-frame work** under `frameloop="always"`, with `useFrame` loops rewriting large buffers every frame.

**Decision:** keep the live WebGL scene on both mobile and desktop — optimize loading instead of replacing it with a static poster.

> Note: `frameloop="demand"` is **not** viable — the scene animates continuously even with no scroll input (planet/galaxy spin, orbits, moons, ring particles), so the loop must keep running. The render-loop win comes from reducing per-frame work and pausing when the tab is hidden.

## What changed

- **Defer the WebGL mount** (`ScrollContainer.tsx`) until the `load` event + `requestIdleCallback` (Safari falls back to a short timeout), so the three.js chunk download and scene init fall *outside* the FCP/LCP/TBT window. The HUD overlay and the new `<h1>` still render immediately as early LCP candidates.
- **Fix the loader** (`Loader.tsx`): event-driven dismiss the moment the scene reports its first frame (`onCreated` → `onReady` → `sceneReady`), with a **1.5s safety cap** so it can never hang. Body-scroll lock releases on dismiss.
- **Mobile quality tier** (`WorldCanvas.tsx`, `Planet.tsx`, `Galaxy.tsx`): a single `isMobile` flag (< 1024px) lowers `dpr` to 1, cuts background stars 1500→700, lightens Bloom (levels 5→3), reduces planet ring particles 5000→1500 / sphere 64→32 segments / fbm octaves 4→3, and galaxy stars 1000→500 / ring particles 250→120. Module-level buffer builders are now tier-aware `useMemo`s.
- **Pause the render loop on a backgrounded tab** via `visibilitychange`.
- **SSR `<h1>`** (`app/page.tsx`): the homepage had no top-level heading. Added a server-rendered `sr-only` `<h1>` (fast, crawlable LCP/SEO target) and downgraded the in-scene overlay heading to `<h2>` so there's a single page heading.

## Verification

- ✅ `npm run typecheck`, `npm run lint`, `npm test` (307 tests) — all clean (Loader test updated for the new dismiss behavior)
- ✅ `npm run build` succeeds; `/` is statically prerendered
- ✅ Confirmed the SSR `<h1>` is in the prerendered HTML and the live prod server response

### Still to verify manually (needs a real browser)

- Run Lighthouse mobile locally (`npm run build && npm run start` → DevTools Lighthouse): compare TBT / LCP / Speed Index, and confirm the WebGL chunk is fetched **after** the load event.
- Scroll the full storyboard on desktop and an emulated mobile viewport: confirm the merkaba→stars→UFO→planet→satellite→galaxy beats still read and the loader transitions cleanly.
- Re-run PageSpeed Insights on the deployed URL after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
